### PR TITLE
Fix enum join

### DIFF
--- a/flux-errors/locales/en-US/refineck.ftl
+++ b/flux-errors/locales/en-US/refineck.ftl
@@ -24,3 +24,6 @@ refineck-param-inference-error =
 
 refineck-fold-error =
     fold error
+
+refineck-unknown-error =
+    unknown error

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -317,6 +317,10 @@ impl AdtDef {
     pub fn is_box(&self) -> bool {
         self.flags().contains(AdtFlags::IS_BOX)
     }
+
+    pub fn is_struct(&self) -> bool {
+        self.flags().contains(AdtFlags::IS_STRUCT)
+    }
 }
 
 impl VariantDef {

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -318,8 +318,8 @@ impl AdtDef {
         self.flags().contains(AdtFlags::IS_BOX)
     }
 
-    pub fn is_struct(&self) -> bool {
-        self.flags().contains(AdtFlags::IS_STRUCT)
+    pub fn is_enum(&self) -> bool {
+        self.flags().contains(AdtFlags::IS_ENUM)
     }
 }
 

--- a/flux-tests/tests/neg/structs/enum-join.rs
+++ b/flux-tests/tests/neg/structs/enum-join.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub enum Enum<T> {
+    A(T),
+    B(i64),
+}
+
+#[flux::sig(fn(Enum<i32{v : v >= 0}>) -> i32{v : v > 0})]
+pub fn test(x: Enum<i32>) -> i32 {
+    let y = match x {
+        Enum::A(n) => n,
+        Enum::B(_) => 0,
+    };
+    // test we correctly join branches with different variants
+    y //~ ERROR postcondition
+}

--- a/flux-tests/tests/neg/structs/enum-join.rs
+++ b/flux-tests/tests/neg/structs/enum-join.rs
@@ -3,14 +3,14 @@
 
 pub enum Enum<T> {
     A(T),
-    B(i64),
+    B(bool, T),
 }
 
 #[flux::sig(fn(Enum<i32{v : v >= 0}>) -> i32{v : v > 0})]
 pub fn test(x: Enum<i32>) -> i32 {
     let y = match x {
         Enum::A(n) => n,
-        Enum::B(_) => 0,
+        Enum::B(_, n) => n,
     };
     // test we correctly join branches with different variants
     y //~ ERROR postcondition

--- a/flux-tests/tests/neg/structs/struct-join.rs
+++ b/flux-tests/tests/neg/structs/struct-join.rs
@@ -1,0 +1,30 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int)]
+pub struct S {
+    #[flux::field({i32[@a] : a >= 0})]
+    f: i32,
+}
+
+#[flux::sig(fn(bool, S) -> i32{v : v >= 0})]
+pub fn test1(b: bool, mut s: S) -> i32 {
+    if b {
+        // we break the invariant
+        s.f -= 1;
+    }
+    // test that the struct is not unnecessarily folded
+    s.f //~ ERROR postcondition
+}
+
+#[flux::sig(fn(bool, S) -> i32{v : v > 0})]
+pub fn test2(b: bool, s: S) -> i32 {
+    let x = if b {
+        drop(s);
+        0
+    } else {
+        s.f
+    };
+    // test we correctly join the uninitialized branch
+    x //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/structs/enum-join.rs
+++ b/flux-tests/tests/pos/structs/enum-join.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub enum Enum<T> {
+    A(T),
+    B(i64),
+}
+
+#[flux::sig(fn(Enum<i32{v : v >= 0}>) -> i32{v : v > 0})]
+pub fn test(x: Enum<i32>) -> i32 {
+    let y = match x {
+        Enum::A(n) => n,
+        Enum::B(_) => 0,
+    };
+    // test we correctly join branches with different variants
+    y + 1
+}

--- a/flux-tests/tests/pos/structs/enum-join.rs
+++ b/flux-tests/tests/pos/structs/enum-join.rs
@@ -3,14 +3,14 @@
 
 pub enum Enum<T> {
     A(T),
-    B(i64),
+    B(bool, T),
 }
 
 #[flux::sig(fn(Enum<i32{v : v >= 0}>) -> i32{v : v > 0})]
 pub fn test(x: Enum<i32>) -> i32 {
     let y = match x {
         Enum::A(n) => n,
-        Enum::B(_) => 0,
+        Enum::B(_, n) => n,
     };
     // test we correctly join branches with different variants
     y + 1

--- a/flux-tests/tests/pos/structs/struct-join.rs
+++ b/flux-tests/tests/pos/structs/struct-join.rs
@@ -1,0 +1,30 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int)]
+pub struct S {
+    #[flux::field({i32[@a] : a >= 0})]
+    f: i32,
+}
+
+#[flux::sig(fn(bool, S) -> i32{v : v >= 0})]
+pub fn test1(b: bool, mut s: S) -> i32 {
+    if b {
+        // we break the invariant
+        s.f -= 1;
+    }
+    // test that the struct is not unnecessarily folded
+    s.f + 1
+}
+
+#[flux::sig(fn(bool, S) -> i32{v : v > 0})]
+pub fn test2(b: bool, s: S) -> i32 {
+    let x = if b {
+        drop(s);
+        0
+    } else {
+        s.f
+    };
+    // test we correctly join the uninitialized branch
+    x + 1
+}

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -915,7 +915,7 @@ impl Phase for Inference<'_> {
         dbg::infer_goto_enter!(target, env, ck.phase.bb_envs.get(&target));
         let modified = match ck.phase.bb_envs.entry(target) {
             Entry::Occupied(mut entry) => {
-                let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Other);
+                let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Unknown);
                 entry.get_mut().join(&mut rcx, &mut gen, env)
             }
             Entry::Vacant(entry) => {

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -915,7 +915,7 @@ impl Phase for Inference<'_> {
         dbg::infer_goto_enter!(target, env, ck.phase.bb_envs.get(&target));
         let modified = match ck.phase.bb_envs.entry(target) {
             Entry::Occupied(mut entry) => {
-                let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Unknown);
+                let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Other);
                 entry.get_mut().join(&mut rcx, &mut gen, env)
             }
             Entry::Vacant(entry) => {

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -914,7 +914,10 @@ impl Phase for Inference<'_> {
 
         dbg::infer_goto_enter!(target, env, ck.phase.bb_envs.get(&target));
         let modified = match ck.phase.bb_envs.entry(target) {
-            Entry::Occupied(mut entry) => entry.get_mut().join(ck.genv, &mut rcx, env),
+            Entry::Occupied(mut entry) => {
+                let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Other);
+                entry.get_mut().join(&mut rcx, &mut gen, env)
+            }
             Entry::Vacant(entry) => {
                 entry.insert(env.into_infer(ck.genv, scope));
                 true

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -42,7 +42,7 @@ pub enum Tag {
     Div(Span),
     Rem(Span),
     Goto(Option<Span>, BasicBlock),
-    Unknown,
+    Other,
 }
 
 impl Tag {
@@ -309,7 +309,7 @@ mod pretty {
                 }
                 Tag::Assert(msg, span) => w!("Assert(\"{}\", {:?})", ^msg, span),
                 Tag::Fold(span) => w!("Fold({:?})", span),
-                Tag::Unknown => w!("Other"),
+                Tag::Other => w!("Other"),
             }
         }
     }

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -42,6 +42,7 @@ pub enum Tag {
     Div(Span),
     Rem(Span),
     Goto(Option<Span>, BasicBlock),
+    Other,
 }
 
 impl Tag {
@@ -308,6 +309,7 @@ mod pretty {
                 }
                 Tag::Assert(msg, span) => w!("Assert(\"{}\", {:?})", ^msg, span),
                 Tag::Fold(span) => w!("Fold({:?})", span),
+                Tag::Other => w!("Other"),
             }
         }
     }

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -42,7 +42,7 @@ pub enum Tag {
     Div(Span),
     Rem(Span),
     Goto(Option<Span>, BasicBlock),
-    Other,
+    Unknown,
 }
 
 impl Tag {
@@ -309,7 +309,7 @@ mod pretty {
                 }
                 Tag::Assert(msg, span) => w!("Assert(\"{}\", {:?})", ^msg, span),
                 Tag::Fold(span) => w!("Fold({:?})", span),
-                Tag::Other => w!("Other"),
+                Tag::Unknown => w!("Other"),
             }
         }
     }

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -72,6 +72,7 @@ fn report_errors(
             Tag::Goto(span, _) => genv.sess.emit_err(errors::GotoError { span }),
             Tag::Assert(msg, span) => genv.sess.emit_err(errors::AssertError { msg, span }),
             Tag::Fold(span) => genv.sess.emit_err(errors::FoldError { span }),
+            Tag::Other => genv.sess.emit_err(errors::UnknownError { span: body_span }),
         });
     }
 
@@ -152,6 +153,13 @@ mod errors {
     #[derive(SessionDiagnostic)]
     #[error(refineck::fold_error, code = "FLUX")]
     pub struct FoldError {
+        #[primary_span]
+        pub span: Span,
+    }
+
+    #[derive(SessionDiagnostic)]
+    #[error(refineck::unknown_error, code = "FLUX")]
+    pub struct UnknownError {
         #[primary_span]
         pub span: Span,
     }

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -72,7 +72,7 @@ fn report_errors(
             Tag::Goto(span, _) => genv.sess.emit_err(errors::GotoError { span }),
             Tag::Assert(msg, span) => genv.sess.emit_err(errors::AssertError { msg, span }),
             Tag::Fold(span) => genv.sess.emit_err(errors::FoldError { span }),
-            Tag::Other => genv.sess.emit_err(errors::UnknownError { span: body_span }),
+            Tag::Unknown => genv.sess.emit_err(errors::UnknownError { span: body_span }),
         });
     }
 

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -72,7 +72,7 @@ fn report_errors(
             Tag::Goto(span, _) => genv.sess.emit_err(errors::GotoError { span }),
             Tag::Assert(msg, span) => genv.sess.emit_err(errors::AssertError { msg, span }),
             Tag::Fold(span) => genv.sess.emit_err(errors::FoldError { span }),
-            Tag::Unknown => genv.sess.emit_err(errors::UnknownError { span: body_span }),
+            Tag::Other => genv.sess.emit_err(errors::UnknownError { span: body_span }),
         });
     }
 

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -364,7 +364,7 @@ impl TypeEnvInfer {
         other.close_boxes(gen.genv, &self.scope);
 
         // Unfold
-        self.bindings.unfold_with(rcx, gen, &mut other.bindings);
+        self.bindings.join_with(rcx, gen, &mut other.bindings);
 
         let paths = self.bindings.paths().collect_vec();
 

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -360,11 +360,11 @@ impl TypeEnvInfer {
     /// join(self, genv, other) consumes the bindings in other, to "update"
     /// `self` in place, and returns `true` if there was an actual change
     /// or `false` indicating no change (i.e., a fixpoint was reached).
-    pub fn join(&mut self, genv: &GlobalEnv, rcx: &mut RefineCtxt, mut other: TypeEnv) -> bool {
-        other.close_boxes(genv, &self.scope);
+    pub fn join(&mut self, rcx: &mut RefineCtxt, gen: &mut ConstrGen, mut other: TypeEnv) -> bool {
+        other.close_boxes(gen.genv, &self.scope);
 
         // Unfold
-        self.bindings.unfold_with(genv, rcx, &mut other.bindings);
+        self.bindings.unfold_with(rcx, gen, &mut other.bindings);
 
         let paths = self.bindings.paths().collect_vec();
 
@@ -412,16 +412,16 @@ impl TypeEnvInfer {
             let binding2 = other.bindings.get(path);
             let binding = match (&binding1, &binding2) {
                 (Binding::Owned(ty1), Binding::Owned(ty2)) => {
-                    Binding::Owned(self.join_ty(genv, ty1, ty2))
+                    Binding::Owned(self.join_ty(gen.genv, ty1, ty2))
                 }
                 (Binding::Owned(ty1), Binding::Blocked(ty2)) => {
-                    Binding::Blocked(self.join_ty(genv, ty1, ty2))
+                    Binding::Blocked(self.join_ty(gen.genv, ty1, ty2))
                 }
                 (Binding::Blocked(ty1), Binding::Owned(ty2)) => {
-                    Binding::Blocked(self.join_ty(genv, ty1, ty2))
+                    Binding::Blocked(self.join_ty(gen.genv, ty1, ty2))
                 }
                 (Binding::Blocked(ty1), Binding::Blocked(ty2)) => {
-                    Binding::Blocked(self.join_ty(genv, ty1, ty2))
+                    Binding::Blocked(self.join_ty(gen.genv, ty1, ty2))
                 }
             };
             modified |= binding1 != binding;
@@ -618,7 +618,7 @@ mod pretty {
     impl Pretty for TypeEnvInfer {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("[{:?}] {:?}", &self.scope, &self.bindings)
+            w!("{:?} {:?}", &self.scope, &self.bindings)
         }
 
         fn default_cx(tcx: TyCtxt) -> PPrintCx {

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -392,10 +392,6 @@ impl Node {
         }
     }
 
-    // fn uninit(&mut self) {
-    //     *self = Node::owned(Ty::uninit());
-    // }
-
     // NOTE(nilehmann) The extra `unblock` parameter is there on purpose to force future clients of
     // this function to think harder about whether it should simply unblock bindings. Right now it's
     // being used in a single place with `unblock = true`.

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -125,15 +125,10 @@ impl PathsTree {
         self.iter().map(|(path, _)| path)
     }
 
-    pub fn unfold_with(
-        &mut self,
-        rcx: &mut RefineCtxt,
-        gen: &mut ConstrGen,
-        other: &mut PathsTree,
-    ) {
+    pub fn join_with(&mut self, rcx: &mut RefineCtxt, gen: &mut ConstrGen, other: &mut PathsTree) {
         for (loc, node1) in &mut self.map {
             if let Some(node2) = other.map.get_mut(loc) {
-                node1.unfold_with(gen, rcx, node2);
+                node1.join_with(gen, rcx, node2);
             }
         }
     }
@@ -299,10 +294,10 @@ impl Node {
         }
     }
 
-    fn unfold_with(&mut self, gen: &mut ConstrGen, rcx: &mut RefineCtxt, other: &mut Node) {
+    fn join_with(&mut self, gen: &mut ConstrGen, rcx: &mut RefineCtxt, other: &mut Node) {
         match (&mut *self, &mut *other) {
             (Node::Internal(..), Node::Leaf(_)) => {
-                other.unfold_with(gen, rcx, self);
+                other.join_with(gen, rcx, self);
             }
             (Node::Leaf(_), Node::Leaf(_)) => {}
             (Node::Leaf(_), Node::Internal(NodeKind::Adt(def, ..), _)) if def.is_enum() => {
@@ -310,7 +305,7 @@ impl Node {
             }
             (Node::Leaf(_), Node::Internal(..)) => {
                 self.split(gen.genv, rcx);
-                self.unfold_with(gen, rcx, other);
+                self.join_with(gen, rcx, other);
             }
             (
                 Node::Internal(NodeKind::Adt(_, variant1, _), children1),
@@ -318,7 +313,7 @@ impl Node {
             ) => {
                 if variant1 == variant2 {
                     for (node1, node2) in iter::zip(children1, children2) {
-                        node1.unfold_with(gen, rcx, node2);
+                        node1.join_with(gen, rcx, node2);
                     }
                 } else {
                     self.fold(rcx, gen, false);
@@ -335,7 +330,7 @@ impl Node {
                 }
 
                 for (node1, node2) in iter::zip(children1, children2) {
-                    node1.unfold_with(gen, rcx, node2);
+                    node1.join_with(gen, rcx, node2);
                 }
             }
         };


### PR DESCRIPTION
The join code for adts was written mainly with structs in mind, this PR fixes it to also work with enums