### PR TITLE
Refactor kvars

### DIFF
--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -10,7 +10,7 @@ use flux_common::format::PadAdapter;
 pub enum Constraint<Tag> {
     Pred(Pred, Option<Tag>),
     Conj(Vec<Self>),
-    Guard(Expr, Box<Self>),
+    Guard(Pred, Box<Self>),
     ForAll(Name, Sort, Pred, Box<Self>),
 }
 

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -120,7 +120,11 @@ newtype_index! {
 }
 
 impl<Tag> Constraint<Tag> {
-    pub const TRUE: Self = Self::Pred(Pred::Expr(Expr::Constant(Constant::Bool(true))), None);
+    pub const TRUE: Self = Self::Pred(Pred::TRUE, None);
+}
+
+impl Pred {
+    pub const TRUE: Self = Pred::Expr(Expr::Constant(Constant::Bool(true)));
 }
 
 impl BinOp {

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -164,7 +164,7 @@ where
                 }
             }
             Constraint::Guard(body, head) => {
-                write!(f, "(forall ((_ Unit) ({body}))")?;
+                write!(f, "(forall ((_ Unit) {body})")?;
                 write!(PadAdapter::wrap_fmt(f, 2), "\n{head}")?;
                 write!(f, "\n)")
             }

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -310,14 +310,7 @@ impl TypeFoldable for BaseTy {
 impl TypeFoldable for Pred {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self {
-            Pred::Kvars(kvars) => {
-                Pred::kvars(
-                    kvars
-                        .iter()
-                        .map(|kvar| kvar.fold_with(folder))
-                        .collect_vec(),
-                )
-            }
+            Pred::Kvar(kvar) => Pred::Kvar(kvar.fold_with(folder)),
             Pred::Expr(e) => Pred::Expr(e.fold_with(folder)),
             Pred::Hole => Pred::Hole,
         }
@@ -326,7 +319,7 @@ impl TypeFoldable for Pred {
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             Pred::Expr(e) => e.visit_with(visitor),
-            Pred::Kvars(kvars) => kvars.iter().for_each(|kvar| kvar.visit_with(visitor)),
+            Pred::Kvar(kvar) => kvar.visit_with(visitor),
             Pred::Hole => {}
         }
     }

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -334,12 +334,12 @@ impl TypeFoldable for Pred {
 
 impl TypeFoldable for KVar {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
-        let KVar(kvid, args) = self;
+        let KVar { kvid, args } = self;
         KVar::new(*kvid, args.iter().map(|e| e.fold_with(folder)).collect_vec())
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
-        self.1.iter().for_each(|e| e.visit_with(visitor));
+        self.args.iter().for_each(|e| e.visit_with(visitor));
     }
 }
 

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -334,8 +334,10 @@ impl TypeFoldable for Pred {
 
 impl TypeFoldable for KVar {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
-        let KVar { kvid, args } = self;
-        KVar::new(*kvid, args.iter().map(|e| e.fold_with(folder)).collect_vec())
+        let KVar { kvid, args, scope } = self;
+        let args = args.iter().map(|e| e.fold_with(folder)).collect();
+        let scope = scope.iter().map(|e| e.fold_with(folder)).collect();
+        KVar::new(*kvid, args, scope)
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -663,8 +663,8 @@ impl ExprS {
         )
     }
 
-    /// Simplify expression applying some rules like removing double negation. This is only used
-    /// for pretty printing.
+    /// Simplify expression applying some simple rules like removing double negation. This is
+    /// only used for pretty printing.
     pub fn simplify(&self) -> Expr {
         match self.kind() {
             ExprKind::FreeVar(name) => Expr::fvar(*name),
@@ -758,6 +758,15 @@ impl Pred {
 
     pub fn is_atom(&self) -> bool {
         matches!(self, Pred::Kvars(..)) || matches!(self, Pred::Expr(e) if e.is_atom())
+    }
+
+    /// Simplify expression applying some simple rules like removing double negation. This is
+    /// only used for pretty printing.
+    pub fn simplify(&self) -> Pred {
+        match self {
+            Pred::Expr(e) => Pred::Expr(e.simplify()),
+            _ => self.clone(),
+        }
     }
 }
 

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -772,7 +772,7 @@ impl KVar {
         KVar { kvid, args: List::from_vec(args), scope: List::from_vec(scope) }
     }
 
-    pub fn all_args(&self) -> impl Iterator<Item = &Expr> {
+    fn all_args(&self) -> impl Iterator<Item = &Expr> {
         self.args.iter().chain(&self.scope)
     }
 }

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -144,7 +144,10 @@ pub enum Pred {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct KVar(pub KVid, pub List<Expr>);
+pub struct KVar {
+    pub kvid: KVid,
+    pub args: List<Expr>,
+}
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Sort {
@@ -762,11 +765,7 @@ impl KVar {
     where
         List<Expr>: From<T>,
     {
-        KVar(kvid, Interned::from(args))
-    }
-
-    pub fn dummy() -> KVar {
-        KVar::new(KVid::from(0usize), vec![])
+        KVar { kvid, args: Interned::from(args) }
     }
 }
 
@@ -1104,7 +1103,7 @@ mod pretty {
     impl Pretty for KVar {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            let KVar(kvid, args) = self;
+            let KVar { kvid, args } = self;
 
             w!("{:?}", ^kvid)?;
             match cx.kvar_args {

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, fmt, iter, sync::OnceLock};
 use flux_common::index::IndexGen;
 use itertools::Itertools;
 
-pub use flux_fixpoint::{BinOp, Constant, KVid, UnOp};
+pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use rustc_hir::def_id::DefId;
 use rustc_index::newtype_index;
 use rustc_middle::mir::{Field, Local};
@@ -185,6 +185,12 @@ pub enum ExprKind {
 pub struct BoundVar {
     pub debruijn: DebruijnIndex,
     pub index: usize,
+}
+
+newtype_index! {
+    pub struct KVid {
+        DEBUG_FORMAT = "$k{}"
+    }
 }
 
 newtype_index! {

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -142,6 +142,12 @@ pub enum Pred {
     Expr(Expr),
 }
 
+/// In theory a kvar is just an unknown predicate that can use some variables in scope. In practice,
+/// fixpoint makes a diference between the first and the rest of the variables, the first one being
+/// the kvar's *self argument*. Fixpoint will only instantiate qualifiers using this first argument.
+/// Flux generalizes the self argument to be a list in order to deal with multiple indices. When
+/// generating the fixpoint constraint, the kvar will be split into multiple kvars, one for each
+/// argument in the list.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KVar {
     pub kvid: KVid,

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -894,7 +894,7 @@ impl Phase for Inference<'_> {
         _rcx: &RefineCtxt,
         tag: Tag,
     ) -> ConstrGen<'a, 'tcx> {
-        ConstrGen::new(genv, |_| Pred::Hole, tag)
+        ConstrGen::new(genv, |sorts| Binders::new(Pred::Hole, sorts), tag)
     }
 
     fn enter_basic_block(&mut self, _rcx: &mut RefineCtxt, bb: BasicBlock) -> TypeEnv {
@@ -912,7 +912,7 @@ impl Phase for Inference<'_> {
         let scope = ck.snapshot_at_dominator(target).scope().unwrap();
 
         dbg::infer_goto_enter!(target, env, ck.phase.bb_envs.get(&target));
-        let mut gen = ConstrGen::new(ck.genv, |_| Pred::Hole, Tag::Other);
+        let mut gen = ConstrGen::new(ck.genv, |sorts| Binders::new(Pred::Hole, sorts), Tag::Other);
         let modified = match ck.phase.bb_envs.entry(target) {
             Entry::Occupied(mut entry) => entry.get_mut().join(&mut rcx, &mut gen, env),
             Entry::Vacant(entry) => {

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -8,8 +8,8 @@ use flux_middle::{
     global_env::{GlobalEnv, Variance},
     rustc::mir::BasicBlock,
     ty::{
-        fold::TypeFoldable, BaseTy, BinOp, Constraint, Constraints, Expr, Index, PolySig, Pred,
-        RefKind, Sort, Ty, TyKind,
+        fold::TypeFoldable, BaseTy, BinOp, Binders, Constraint, Constraints, Expr, Index, PolySig,
+        Pred, RefKind, Sort, Ty, TyKind,
     },
 };
 
@@ -22,7 +22,7 @@ use crate::{
 #[allow(clippy::type_complexity)]
 pub struct ConstrGen<'a, 'tcx> {
     pub genv: &'a GlobalEnv<'a, 'tcx>,
-    fresh_kvar: Box<dyn FnMut(&[Sort]) -> Pred + 'a>,
+    fresh_kvar: Box<dyn FnMut(&[Sort]) -> Binders<Pred> + 'a>,
     tag: Tag,
 }
 
@@ -63,7 +63,7 @@ impl Tag {
 impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
     pub fn new<F>(genv: &'a GlobalEnv<'a, 'tcx>, fresh_kvar: F, tag: Tag) -> Self
     where
-        F: FnMut(&[Sort]) -> Pred + 'a,
+        F: FnMut(&[Sort]) -> Binders<Pred> + 'a,
     {
         ConstrGen { genv, fresh_kvar: Box::new(fresh_kvar), tag }
     }

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -172,9 +172,9 @@ fn subtyping(genv: &GlobalEnv, constr: &mut ConstrBuilder, ty1: &Ty, ty2: &Ty, t
         }
         (TyKind::Exists(bty, pred), _) => {
             let indices = constr
-                .push_binders(pred)
+                .push_bound_guard(pred)
                 .into_iter()
-                .map(|name| Index::from(Expr::fvar(name)))
+                .map(Index::from)
                 .collect_vec();
             let ty1 = Ty::indexed(bty.clone(), indices);
             subtyping(genv, constr, &ty1, ty2, tag);

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -113,7 +113,8 @@ where
         let name = const_info.name;
         let e1 = fixpoint::Expr::from(name);
         let e2 = fixpoint::Expr::from(const_info.val);
-        fixpoint::Constraint::Guard(e1.eq(e2), Box::new(cstr))
+        let pred = fixpoint::Pred::Expr(e1.eq(e2));
+        fixpoint::Constraint::Guard(pred, Box::new(cstr))
     }
 
     pub fn check(
@@ -169,10 +170,6 @@ where
             .tags_inv
             .entry(tag)
             .or_insert_with(|| self.tags.push(tag))
-    }
-
-    pub fn expr_to_fixpoint(&self, expr: &ty::Expr) -> fixpoint::Expr {
-        expr_to_fixpoint(expr, &self.name_map, &self.const_map)
     }
 
     pub fn pred_to_fixpoint(

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -310,20 +310,15 @@ impl KVarStore {
             }
         }
 
-        let mut kvars = vec![];
-        for (idx, sort) in sorts.iter().enumerate() {
-            let arg = ty::Expr::bvar(BoundVar::innermost(idx));
+        let args = (0..sorts.len())
+            .map(|idx| ty::Expr::bvar(BoundVar::innermost(idx)))
+            .collect_vec();
 
-            let kvid = self
-                .kvars
-                .push(KVarSorts { args: vec![sort.clone()], scope: scope_sorts.clone() });
+        let kvid = self
+            .kvars
+            .push(KVarSorts { args: sorts.to_vec(), scope: scope_sorts.clone() });
 
-            kvars.push(ty::KVar::new(kvid, vec![arg.clone()], scope_exprs.clone()));
-
-            scope_sorts.push(sort.clone());
-            scope_exprs.push(arg)
-        }
-        ty::Pred::kvars(kvars)
+        ty::Pred::kvars(vec![ty::KVar::new(kvid, args, scope_exprs.clone())])
     }
 }
 

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -181,13 +181,7 @@ where
             ty::Pred::Expr(expr) => {
                 fixpoint::Pred::Expr(expr_to_fixpoint(expr, &self.name_map, &self.const_map))
             }
-            ty::Pred::Kvars(kvars) => {
-                let kvars = kvars
-                    .iter()
-                    .map(|kvar| self.kvar_to_fixpoint(kvar, &mut bindings))
-                    .collect();
-                fixpoint::Pred::And(kvars)
-            }
+            ty::Pred::Kvar(kvar) => self.kvar_to_fixpoint(kvar, &mut bindings),
             ty::Pred::Hole => panic!("unexpected hole"),
         };
         (bindings, pred)
@@ -318,7 +312,7 @@ impl KVarStore {
             .kvars
             .push(KVarSorts { args: sorts.to_vec(), scope: scope_sorts.clone() });
 
-        ty::Pred::kvars(vec![ty::KVar::new(kvid, args, scope_exprs.clone())])
+        ty::Pred::Kvar(ty::KVar::new(kvid, args, scope_exprs.clone()))
     }
 }
 

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -344,8 +344,7 @@ impl Node {
             NodeKind::ForAll(name, sort, pred) => {
                 let fresh = cx.fresh_name();
                 cx.with_name_map(*name, fresh, |cx| {
-                    let mut bindings = vec![];
-                    let pred = cx.pred_to_fixpoint(&mut bindings, pred);
+                    let (bindings, pred) = cx.pred_to_fixpoint(pred);
                     Some(stitch(
                         bindings,
                         fixpoint::Constraint::ForAll(
@@ -364,8 +363,7 @@ impl Node {
                 ))
             }
             NodeKind::Head(pred, tag) => {
-                let mut bindings = vec![];
-                let pred = cx.pred_to_fixpoint(&mut bindings, pred);
+                let (bindings, pred) = cx.pred_to_fixpoint(pred);
                 Some(stitch(bindings, fixpoint::Constraint::Pred(pred, Some(cx.tag_idx(*tag)))))
             }
         }


### PR DESCRIPTION
To handle existential types over a base type with multiple indices we were generating a kvar for each one of the indices. This made the api for opening a `Binders<Pred>` and pushing it into the context cumbersome. This PR fixes that by always working with a single kvar during type checking and only splitting it when generating the fixpoint constraint.