### PR TITLE
Add support for opaque string slices

### DIFF
--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -250,6 +250,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Bool => ty::BaseTy::Bool,
             rustc::ty::TyKind::Int(int_ty) => ty::BaseTy::Int(*int_ty),
             rustc::ty::TyKind::Uint(uint_ty) => ty::BaseTy::Uint(*uint_ty),
+            rustc::ty::TyKind::Str => ty::BaseTy::Str,
         };
         let sorts = bty.sorts();
         if sorts.is_empty() {

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -173,6 +173,8 @@ pub enum Constant {
     Uint(u128, UintTy),
     Float(u128, FloatTy),
     Bool(bool),
+    /// We only support opaque string slices, so no data stored here for now.
+    Str,
     Unit,
 }
 
@@ -432,6 +434,7 @@ impl fmt::Debug for Constant {
             Constant::Float(bits, float_ty) => write!(f, "{}{}", bits, float_ty.name_str()),
             Constant::Bool(b) => write!(f, "{}", b),
             Constant::Unit => write!(f, "()"),
+            Constant::Str => write!(f, "\"<opaque str>\""),
         }
     }
 }

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -53,6 +53,7 @@ struct TyS {
 pub enum TyKind {
     Adt(DefId, List<GenericArg>),
     Bool,
+    Str,
     Float(FloatTy),
     Int(IntTy),
     Never,
@@ -120,6 +121,10 @@ impl Ty {
         TyKind::Uint(uint_ty).intern()
     }
 
+    pub fn mk_str() -> Ty {
+        TyKind::Str.intern()
+    }
+
     pub fn kind(&self) -> &TyKind {
         &self.0.kind
     }
@@ -156,6 +161,7 @@ impl std::fmt::Debug for Ty {
                 Ok(())
             }
             TyKind::Bool => write!(f, "bool"),
+            TyKind::Str => write!(f, "str"),
             TyKind::Float(float_ty) => write!(f, "{}", float_ty.name_str()),
             TyKind::Int(int_ty) => write!(f, "{}", int_ty.name_str()),
             TyKind::Uint(uint_ty) => write!(f, "{}", uint_ty.name_str()),

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -312,14 +312,14 @@ impl TypeFoldable for BaseTy {
             BaseTy::Adt(adt_def, substs) => {
                 BaseTy::adt(adt_def.clone(), substs.iter().map(|ty| ty.fold_with(folder)))
             }
-            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool => self.clone(),
+            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => self.clone(),
         }
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             BaseTy::Adt(_, substs) => substs.iter().for_each(|ty| ty.visit_with(visitor)),
-            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool => {}
+            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => {}
         }
     }
 }

--- a/flux-tests/tests/neg/surface/str01.rs
+++ b/flux-tests/tests/neg/surface/str01.rs
@@ -1,0 +1,10 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// TODO(nilehmann) think how to refine string slices and
+// move this test to pos
+#[flux::sig(fn() -> usize[3])]
+pub fn str01() -> usize {
+    let x = "str";
+    x.len() //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/str01.rs
+++ b/flux-tests/tests/pos/surface/str01.rs
@@ -1,0 +1,11 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub fn str01() -> usize {
+    let x = "str";
+    x.len()
+}
+
+pub fn panic() {
+    panic!("a panic")
+}

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -866,6 +866,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             }
             Constant::Float(_, float_ty) => Ty::float(*float_ty),
             Constant::Unit => Ty::unit(),
+            Constant::Str => Ty::mk_ref(RefKind::Shr, Ty::str()),
         }
     }
 

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -264,7 +264,6 @@ fn bty_subtyping(
         (BaseTy::Uint(uint_ty1), BaseTy::Uint(uint_ty2)) => {
             debug_assert_eq!(uint_ty1, uint_ty2);
         }
-        (BaseTy::Bool, BaseTy::Bool) => {}
         (BaseTy::Adt(def1, substs1), BaseTy::Adt(def2, substs2)) => {
             debug_assert_eq!(def1.def_id(), def2.def_id());
             debug_assert_eq!(substs1.len(), substs2.len());
@@ -273,6 +272,7 @@ fn bty_subtyping(
                 variance_subtyping(genv, constr, *variance, ty1, ty2, tag);
             }
         }
+        (BaseTy::Bool, BaseTy::Bool) | (BaseTy::Str, BaseTy::Str) => {}
         _ => {
             unreachable!("unexpected base types: `{:?}` and `{:?}` at {:?}", bty1, bty2, tag.span())
         }

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -371,7 +371,7 @@ impl TypeEnvInfer {
                 let substs = substs.iter().map(|ty| Self::pack_ty(scope, ty));
                 BaseTy::adt(adt_def.clone(), substs)
             }
-            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool => bty.clone(),
+            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => bty.clone(),
         }
     }
 


### PR DESCRIPTION
Support for string slices with no refinement (refined by unit). This allows us to call some macros like `panic!` and `unreachable!`