### PR TITLE
Basic support for arrays

### DIFF
--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_private)]
 #![feature(min_specialization)]
-#![feature(box_patterns, once_cell)]
+#![feature(box_patterns, once_cell, let_else)]
 
 extern crate rustc_errors;
 extern crate rustc_hash;

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -197,6 +197,10 @@ impl<'genv> Resolver<'genv> {
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Constr(pred, Box::new(ty))
             }
+            surface::TyKind::Array(ty, len) => {
+                let ty = self.resolve_ty(*ty)?;
+                surface::TyKind::Array(Box::new(ty), len)
+            }
         };
         Ok(surface::Ty { kind, span: ty.span })
     }
@@ -379,15 +383,17 @@ impl<'a> NameResTable<'a> {
             self.res.insert(sym, res);
         }
         match &ty.kind() {
-            rustc_middle::ty::TyKind::Adt(_, args) => {
+            rustc_middle::ty::Adt(_, args) => {
                 for arg in args.iter() {
                     if let rustc_middle::ty::GenericArgKind::Type(ty) = arg.unpack() {
                         self.collect_from_rustc_ty(&ty)?
                     }
                 }
             }
-            rustc_middle::ty::TyKind::Ref(_, ty, _) => self.collect_from_rustc_ty(ty)?,
-            rustc_middle::ty::TyKind::Tuple(tys) => {
+            rustc_middle::ty::Ref(_, ty, _) | rustc_middle::ty::Array(ty, _) => {
+                self.collect_from_rustc_ty(ty)?
+            }
+            rustc_middle::ty::Tuple(tys) => {
                 for ty in tys.iter() {
                     self.collect_from_rustc_ty(&ty)?
                 }

--- a/flux-desugar/src/zip_resolver.rs
+++ b/flux-desugar/src/zip_resolver.rs
@@ -188,6 +188,9 @@ impl<'genv, 'tcx> ZipResolver<'genv, 'tcx> {
                 )
             }
             (TyKind::Unit, rustc_ty::TyKind::Tuple(tys)) if tys.is_empty() => TyKind::Unit,
+            (TyKind::Array(ty, len), rustc_ty::TyKind::Array(rust_ty, _)) => {
+                TyKind::Array(Box::new(self.zip_ty(*ty, rust_ty)?), len)
+            }
 
             _ => panic!("incompatible types: `{rust_ty:?}`"),
         };

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -23,3 +23,6 @@ desugar-refined-type-param =
 desugar-refined-float =
     floats cannot be refined
     .label = this float has a refinement
+
+desugar-invalid-array-len =
+    unsupported or invalid array length

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -95,6 +95,7 @@ pub enum Ty {
     Ref(RefKind, Box<Ty>),
     Param(ParamTy),
     Tuple(Vec<Ty>),
+    Array(Box<Ty>, usize),
     Never,
 }
 
@@ -277,6 +278,7 @@ impl fmt::Debug for Ty {
             Ty::Tuple(tys) => write!(f, "({:?})", tys.iter().format(", ")),
             Ty::Never => write!(f, "!"),
             Ty::Constr(pred, ty) => write!(f, "{{{ty:?} : {pred:?}}}"),
+            Ty::Array(ty, len) => write!(f, "[{ty:?}; {len:?}]"),
         }
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -251,6 +251,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Int(int_ty) => ty::BaseTy::Int(*int_ty),
             rustc::ty::TyKind::Uint(uint_ty) => ty::BaseTy::Uint(*uint_ty),
             rustc::ty::TyKind::Str => ty::BaseTy::Str,
+            rustc::ty::TyKind::Array(_, _) => todo!(),
         };
         let sorts = bty.sorts();
         if sorts.is_empty() {

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -167,13 +167,15 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
     pub fn default_fn_sig(&self, def_id: DefId) -> ty::PolySig {
         match rustc::lowering::lower_fn_sig(self.tcx, self.tcx.fn_sig(def_id)) {
-            Ok(fn_sig) => self.refine_fn_sig(&fn_sig, &mut |_| ty::Pred::tt()),
+            Ok(fn_sig) => {
+                self.refine_fn_sig(&fn_sig, &mut |sorts| Binders::new(ty::Pred::tt(), sorts))
+            }
             Err(_) => FatalError.raise(),
         }
     }
 
     fn refine_ty_true(&self, rustc_ty: &rustc::ty::Ty) -> ty::Ty {
-        self.refine_ty(rustc_ty, &mut |_| ty::Pred::tt())
+        self.refine_ty(rustc_ty, &mut |sorts| Binders::new(ty::Pred::tt(), sorts))
     }
 
     pub fn default_type_of(&self, def_id: DefId) -> ty::Ty {
@@ -206,7 +208,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     pub fn refine_fn_sig(
         &self,
         fn_sig: &rustc::ty::FnSig,
-        mk_pred: &mut impl FnMut(&[ty::Sort]) -> ty::Pred,
+        mk_pred: &mut impl FnMut(&[ty::Sort]) -> Binders<ty::Pred>,
     ) -> ty::PolySig {
         let args = fn_sig
             .inputs()
@@ -220,7 +222,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     pub fn refine_ty(
         &self,
         ty: &rustc::ty::Ty,
-        mk_pred: &mut impl FnMut(&[ty::Sort]) -> ty::Pred,
+        mk_pred: &mut impl FnMut(&[ty::Sort]) -> Binders<ty::Pred>,
     ) -> ty::Ty {
         let bty = match ty.kind() {
             rustc::ty::TyKind::Never => return ty::Ty::never(),
@@ -251,13 +253,15 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Int(int_ty) => ty::BaseTy::Int(*int_ty),
             rustc::ty::TyKind::Uint(uint_ty) => ty::BaseTy::Uint(*uint_ty),
             rustc::ty::TyKind::Str => ty::BaseTy::Str,
-            rustc::ty::TyKind::Array(_, _) => todo!(),
+            rustc::ty::TyKind::Array(ty, len) => {
+                ty::BaseTy::Array(self.refine_ty(ty, mk_pred), len.clone())
+            }
         };
         let sorts = bty.sorts();
         if sorts.is_empty() {
             ty::Ty::indexed(bty, vec![])
         } else {
-            let pred = ty::Binders::new(mk_pred(sorts), sorts);
+            let pred = mk_pred(sorts);
             ty::Ty::exists(bty, pred)
         }
     }
@@ -265,7 +269,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     pub fn refine_generic_arg(
         &self,
         ty: &rustc::ty::GenericArg,
-        mk_pred: &mut impl FnMut(&[ty::Sort]) -> ty::Pred,
+        mk_pred: &mut impl FnMut(&[ty::Sort]) -> Binders<ty::Pred>,
     ) -> ty::Ty {
         match ty {
             rustc::ty::GenericArg::Ty(ty) => self.refine_ty(ty, mk_pred),

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -313,8 +313,10 @@ impl<'tcx> LoweringCtxt<'tcx> {
             rustc_mir::AggregateKind::Adt(def_id, variant_idx, substs, None, None) => {
                 Ok(AggregateKind::Adt(*def_id, *variant_idx, lower_substs(self.tcx, substs)?))
             }
+            rustc_mir::AggregateKind::Array(ty) => {
+                Ok(AggregateKind::Array(lower_ty(self.tcx, *ty)?))
+            }
             rustc_mir::AggregateKind::Adt(..)
-            | rustc_mir::AggregateKind::Array(_)
             | rustc_mir::AggregateKind::Tuple
             | rustc_mir::AggregateKind::Closure(_, _)
             | rustc_mir::AggregateKind::Generator(_, _, _) => {
@@ -510,15 +512,15 @@ pub fn lower_fn_sig<'tcx>(
 
 pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, ErrorGuaranteed> {
     match ty.kind() {
-        rustc_middle::ty::TyKind::Ref(_region, ty, mutability) => {
+        rustc_middle::ty::Ref(_region, ty, mutability) => {
             Ok(Ty::mk_ref(lower_ty(tcx, *ty)?, *mutability))
         }
-        rustc_middle::ty::TyKind::Bool => Ok(Ty::mk_bool()),
-        rustc_middle::ty::TyKind::Int(int_ty) => Ok(Ty::mk_int(*int_ty)),
-        rustc_middle::ty::TyKind::Uint(uint_ty) => Ok(Ty::mk_uint(*uint_ty)),
-        rustc_middle::ty::TyKind::Float(float_ty) => Ok(Ty::mk_float(*float_ty)),
-        rustc_middle::ty::TyKind::Param(param_ty) => Ok(Ty::mk_param(*param_ty)),
-        rustc_middle::ty::TyKind::Adt(adt_def, substs) => {
+        rustc_middle::ty::Bool => Ok(Ty::mk_bool()),
+        rustc_middle::ty::Int(int_ty) => Ok(Ty::mk_int(*int_ty)),
+        rustc_middle::ty::Uint(uint_ty) => Ok(Ty::mk_uint(*uint_ty)),
+        rustc_middle::ty::Float(float_ty) => Ok(Ty::mk_float(*float_ty)),
+        rustc_middle::ty::Param(param_ty) => Ok(Ty::mk_param(*param_ty)),
+        rustc_middle::ty::Adt(adt_def, substs) => {
             let substs = List::from_vec(
                 substs
                     .iter()
@@ -529,7 +531,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, E
         }
         rustc_middle::ty::Never => Ok(Ty::mk_never()),
         rustc_middle::ty::Str => Ok(Ty::mk_str()),
-        rustc_middle::ty::TyKind::Tuple(tys) if tys.is_empty() => Ok(Ty::mk_tuple(vec![])),
+        rustc_middle::ty::Tuple(tys) if tys.is_empty() => Ok(Ty::mk_tuple(vec![])),
         _ => emit_err(tcx, None, format!("unsupported type `{ty:?}`, kind: `{:?}`", ty.kind())),
     }
 }

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -21,7 +21,8 @@ use super::{
         StatementKind, Terminator, TerminatorKind,
     },
     ty::{
-        EnumDef, FnSig, GenericArg, GenericParamDef, GenericParamDefKind, Generics, Ty, VariantDef,
+        Const, ConstKind, EnumDef, FnSig, GenericArg, GenericParamDef, GenericParamDefKind,
+        Generics, Ty, ValTree, VariantDef,
     },
 };
 use crate::intern::List;
@@ -512,15 +513,13 @@ pub fn lower_fn_sig<'tcx>(
 
 pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, ErrorGuaranteed> {
     match ty.kind() {
-        rustc_middle::ty::Ref(_region, ty, mutability) => {
-            Ok(Ty::mk_ref(lower_ty(tcx, *ty)?, *mutability))
-        }
-        rustc_middle::ty::Bool => Ok(Ty::mk_bool()),
-        rustc_middle::ty::Int(int_ty) => Ok(Ty::mk_int(*int_ty)),
-        rustc_middle::ty::Uint(uint_ty) => Ok(Ty::mk_uint(*uint_ty)),
-        rustc_middle::ty::Float(float_ty) => Ok(Ty::mk_float(*float_ty)),
-        rustc_middle::ty::Param(param_ty) => Ok(Ty::mk_param(*param_ty)),
-        rustc_middle::ty::Adt(adt_def, substs) => {
+        rustc_ty::Ref(_region, ty, mutability) => Ok(Ty::mk_ref(lower_ty(tcx, *ty)?, *mutability)),
+        rustc_ty::Bool => Ok(Ty::mk_bool()),
+        rustc_ty::Int(int_ty) => Ok(Ty::mk_int(*int_ty)),
+        rustc_ty::Uint(uint_ty) => Ok(Ty::mk_uint(*uint_ty)),
+        rustc_ty::Float(float_ty) => Ok(Ty::mk_float(*float_ty)),
+        rustc_ty::Param(param_ty) => Ok(Ty::mk_param(*param_ty)),
+        rustc_ty::Adt(adt_def, substs) => {
             let substs = List::from_vec(
                 substs
                     .iter()
@@ -529,10 +528,36 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, E
             );
             Ok(Ty::mk_adt(adt_def.did(), substs))
         }
-        rustc_middle::ty::Never => Ok(Ty::mk_never()),
-        rustc_middle::ty::Str => Ok(Ty::mk_str()),
-        rustc_middle::ty::Tuple(tys) if tys.is_empty() => Ok(Ty::mk_tuple(vec![])),
+        rustc_ty::Never => Ok(Ty::mk_never()),
+        rustc_ty::Str => Ok(Ty::mk_str()),
+        rustc_ty::Tuple(tys) if tys.is_empty() => Ok(Ty::mk_tuple(vec![])),
+        rustc_ty::Array(ty, c) => Ok(Ty::mk_array(lower_ty(tcx, *ty)?, lower_const(tcx, *c)?)),
         _ => emit_err(tcx, None, format!("unsupported type `{ty:?}`, kind: `{:?}`", ty.kind())),
+    }
+}
+
+fn lower_const<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    c: rustc_ty::Const<'tcx>,
+) -> Result<Const, ErrorGuaranteed> {
+    let kind = match c.kind() {
+        rustc_ty::ConstKind::Value(val) => ConstKind::Value(lower_valtree(tcx, val)?),
+        rustc_ty::ConstKind::Param(_)
+        | rustc_ty::ConstKind::Infer(_)
+        | rustc_ty::ConstKind::Bound(_, _)
+        | rustc_ty::ConstKind::Placeholder(_)
+        | rustc_ty::ConstKind::Unevaluated(_)
+        | rustc_ty::ConstKind::Error(_) => {
+            return emit_err(tcx, None, format!("unsupported const `{c:?}`"));
+        }
+    };
+    Ok(Const { ty: lower_ty(tcx, c.ty())?, kind })
+}
+
+fn lower_valtree(tcx: TyCtxt, val: rustc_ty::ValTree) -> Result<ValTree, ErrorGuaranteed> {
+    match val {
+        rustc_ty::ValTree::Leaf(scalar) => Ok(ValTree::Leaf(scalar)),
+        rustc_ty::ValTree::Branch(_) => emit_err(tcx, None, format!("unsupported valtree {val:?}")),
     }
 }
 

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -131,6 +131,7 @@ pub enum Rvalue {
 
 pub enum AggregateKind {
     Adt(DefId, VariantIdx, List<GenericArg>),
+    Array(Ty),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -411,6 +412,9 @@ impl fmt::Debug for Rvalue {
                         args.iter().format(", ")
                     )
                 }
+            }
+            Rvalue::Aggregate(AggregateKind::Array(_), args) => {
+                write!(f, "[{:?}]", args.iter().format(", "))
             }
         }
     }

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rustc_hir::def_id::DefId;
 pub use rustc_middle::{
     mir::Mutability,
-    ty::{FloatTy, IntTy, ParamTy, UintTy},
+    ty::{FloatTy, IntTy, ParamTy, ScalarInt, UintTy},
 };
 
 use crate::intern::{impl_internable, Interned, List};
@@ -52,6 +52,7 @@ struct TyS {
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum TyKind {
     Adt(DefId, List<GenericArg>),
+    Array(Ty, Const),
     Bool,
     Str,
     Float(FloatTy),
@@ -61,6 +62,22 @@ pub enum TyKind {
     Ref(Ty, Mutability),
     Tuple(List<Ty>),
     Uint(UintTy),
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct Const {
+    pub ty: Ty,
+    pub kind: ConstKind,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum ConstKind {
+    Value(ValTree),
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum ValTree {
+    Leaf(ScalarInt),
 }
 
 #[derive(PartialEq, Eq, Hash)]
@@ -87,6 +104,10 @@ impl TyKind {
 impl Ty {
     pub fn mk_adt(def_id: DefId, substs: impl Into<List<GenericArg>>) -> Ty {
         TyKind::Adt(def_id, substs.into()).intern()
+    }
+
+    pub fn mk_array(ty: Ty, c: Const) -> Ty {
+        TyKind::Array(ty, c).intern()
     }
 
     pub fn mk_bool() -> Ty {
@@ -169,6 +190,7 @@ impl std::fmt::Debug for Ty {
             TyKind::Param(param_ty) => write!(f, "{param_ty}"),
             TyKind::Ref(ty, Mutability::Mut) => write!(f, "&mut {ty:?}"),
             TyKind::Ref(ty, Mutability::Not) => write!(f, "&{ty:?}"),
+            TyKind::Array(ty, c) => write!(f, "[{ty:?}; {c:?}]"),
             TyKind::Tuple(tys) => {
                 write!(
                     f,
@@ -177,6 +199,22 @@ impl std::fmt::Debug for Ty {
                         .format_with(", ", |ty, f| f(&format_args!("{:?}", ty)))
                 )
             }
+        }
+    }
+}
+
+impl std::fmt::Debug for Const {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            ConstKind::Value(val) => write!(f, "{val:?}"),
+        }
+    }
+}
+
+impl std::fmt::Debug for ValTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValTree::Leaf(scalar) => write!(f, "{scalar:?}"),
         }
     }
 }

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -270,6 +270,10 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 let pred = conv_expr(pred, &self.name_map, nbinders);
                 ty::Ty::constr(pred, self.conv_ty(ty, nbinders))
             }
+            core::Ty::Array(ty, len) => {
+                let len = ty::Const::from_usize(self.genv.tcx, *len as u128);
+                ty::Ty::array(self.conv_ty(ty, nbinders), len)
+            }
         }
     }
 

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -312,6 +312,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::Adt(adt_def, substs) => {
                 BaseTy::adt(adt_def.clone(), substs.iter().map(|ty| ty.fold_with(folder)))
             }
+            BaseTy::Array(ty, c) => BaseTy::Array(ty.fold_with(folder), c.clone()),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => self.clone(),
         }
     }
@@ -319,6 +320,7 @@ impl TypeFoldable for BaseTy {
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             BaseTy::Adt(_, substs) => substs.iter().for_each(|ty| ty.visit_with(visitor)),
+            BaseTy::Array(ty, _) => ty.visit_with(visitor),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => {}
         }
     }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -101,9 +101,16 @@ pub enum TyKind<T = Ident> {
     /// ty
     Path(Path<T>),
     /// t[e]
-    Indexed { path: Path<T>, indices: Indices },
+    Indexed {
+        path: Path<T>,
+        indices: Indices,
+    },
     /// ty{b:e}
-    Exists { bind: Ident, path: Path<T>, pred: Expr },
+    Exists {
+        bind: Ident,
+        path: Path<T>,
+        pred: Expr,
+    },
     /// Mutable or shared reference
     Ref(RefKind, Box<Ty<T>>),
     /// Strong reference, &strg<self: i32>
@@ -112,6 +119,7 @@ pub enum TyKind<T = Ident> {
     Constr(Expr, Box<Ty<T>>),
     /// ()
     Unit,
+    Array(Box<Ty<T>>, Lit),
 }
 
 #[derive(Debug, Clone)]
@@ -363,6 +371,7 @@ pub mod expand {
             TyKind::Constr(pred, t) => {
                 TyKind::Constr(pred.clone(), Box::new(expand_ty(aliases, t)))
             }
+            TyKind::Array(ty, len) => TyKind::Array(Box::new(expand_ty(aliases, ty)), *len),
         }
     }
 
@@ -473,6 +482,7 @@ pub mod expand {
             TyKind::Constr(pred, t) => {
                 TyKind::Constr(subst_expr(subst, pred), Box::new(subst_ty(subst, t)))
             }
+            TyKind::Array(ty, len) => TyKind::Array(Box::new(subst_ty(subst, ty)), *len),
         }
     }
 }

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -117,6 +117,8 @@ TyKind: surface::TyKind = {
     <path:Path> "{" <bind:Ident> ":" <pred:Level1> "}" => surface::TyKind::Exists { <> },
     <path:Path> "[" <indices:Indices> "]"              => surface::TyKind::Indexed { <> },
 
+    "[" <ty:Ty> ";"  <len:Lit> "]" => surface::TyKind::Array(Box::new(ty), len),
+
     "(" ")"  => surface::TyKind::Unit
 }
 

--- a/flux-tests/tests/neg/surface/array00.rs
+++ b/flux-tests/tests/neg/surface/array00.rs
@@ -1,0 +1,7 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> [i32{v : v > 0}; 2])]
+pub fn array00() -> [i32; 2] {
+    [0, 1] //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -1,6 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
+#[flux::sig(fn() -> [i32{v : v > 0}; 2])]
 pub fn array00() -> [i32; 2] {
     [0, 1]
 }

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -1,0 +1,6 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub fn construct() -> [i32; 2] {
+    [0, 1]
+}

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -1,6 +1,6 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-pub fn construct() -> [i32; 2] {
+pub fn array00() -> [i32; 2] {
     [0, 1]
 }

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-#[flux::sig(fn() -> [i32{v : v > 0}; 2])]
+#[flux::sig(fn() -> [i32{v : v >= 0}; 2])]
 pub fn array00() -> [i32; 2] {
     [0, 1]
 }

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -927,12 +927,12 @@ impl Phase for Inference<'_> {
         modified
     }
 
-    fn clear(&mut self, bb: BasicBlock) {
-        self.bb_envs.remove(&bb);
-    }
-
     fn fresh_kvar(&mut self, sorts: &[Sort]) -> Binders<Pred> {
         Binders::new(Pred::Hole, sorts)
+    }
+
+    fn clear(&mut self, bb: BasicBlock) {
+        self.bb_envs.remove(&bb);
     }
 }
 
@@ -972,12 +972,12 @@ impl Phase for Check<'_> {
         !ck.visited.contains(target)
     }
 
-    fn clear(&mut self, _bb: BasicBlock) {
-        unreachable!();
-    }
-
     fn fresh_kvar(&mut self, sorts: &[Sort]) -> Binders<Pred> {
         self.kvars.fresh(sorts, [])
+    }
+
+    fn clear(&mut self, _bb: BasicBlock) {
+        unreachable!();
     }
 }
 

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -607,6 +607,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                 let sig = self.genv.variant_sig(*def_id, *variant_idx);
                 self.check_call(rcx, env, src_info, sig, substs, args)
             }
+            Rvalue::Aggregate(AggregateKind::Array(ty), args) => {
+                todo!()
+            }
             Rvalue::Discriminant(place) => Ok(Ty::discr(place.clone())),
         }
     }

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -293,6 +293,10 @@ fn bty_subtyping(
             }
         }
         (BaseTy::Bool, BaseTy::Bool) | (BaseTy::Str, BaseTy::Str) => {}
+        (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
+            assert_eq!(len1, len2);
+            subtyping(genv, constr, ty1, ty2, tag);
+        }
         _ => {
             unreachable!("unexpected base types: `{:?}` and `{:?}` at {:?}", bty1, bty2, tag.span())
         }

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -375,6 +375,7 @@ impl TypeEnvInfer {
                 let substs = substs.iter().map(|ty| Self::pack_ty(scope, ty));
                 BaseTy::adt(adt_def.clone(), substs)
             }
+            BaseTy::Array(ty, c) => BaseTy::Array(Self::pack_ty(scope, ty), c.clone()),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Str => bty.clone(),
         }
     }

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -152,6 +152,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 self.check_expr(env, pred, ty::Sort::Bool)?;
                 self.check_type(env, ty, allow_binder)
             }
+            core::Ty::Array(ty, _) => self.check_type(env, ty, allow_binder),
             core::Ty::Never | core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
         }
     }


### PR DESCRIPTION
Add basic support for `TyKind::Array` and `AggregateValue::Array`. The typing rule for for `AggregateValue` is very simple, it creates a fresh kvariables for the type and checks that all the arguments are a subtype, this should allow us to prove that all elements in the array satisfy some property. The way the array len is implemented is a bit hacky, but this should allow us to make some progress. There is still work left to be done to support the examples in https://github.com/liquid-rust/flux/issues/142.