### PR TITLE
Unpack constr inside mut ref

### DIFF
--- a/flux-tests/tests/neg/surface/constr03.rs
+++ b/flux-tests/tests/neg/surface/constr03.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+
+use rvec::RVec;
+
+#[flux::sig(fn(&mut {RVec<i32>[@n] : n > 0}) -> ())]
+pub fn test1(vec: &mut RVec<i32>) {
+    vec[1] = 5; //~ ERROR precondition
+}
+
+#[flux::sig(fn({&mut RVec<i32>[@n] : n > 0}) -> ())]
+pub fn test2(vec: &mut RVec<i32>) {
+    vec[1] = 5; //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/constr03.rs
+++ b/flux-tests/tests/pos/surface/constr03.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+
+use rvec::RVec;
+
+#[flux::sig(fn(&mut {RVec<i32>[@n] : n > 0}) -> ())]
+pub fn test1(vec: &mut RVec<i32>) {
+    vec[0] = 5;
+}
+
+#[flux::sig(fn({&mut RVec<i32>[@n] : n > 0}) -> ())]
+pub fn test2(vec: &mut RVec<i32>) {
+    vec[0] = 5;
+}


### PR DESCRIPTION
Unpacking constrs inside any reference is always sound because they have to refer to global binders.

Partially addresses https://github.com/liquid-rust/flux/issues/158