### PR TITLE
Basic support for int-to-int cast

### DIFF
--- a/flux-macros/src/diagnostics/mod.rs
+++ b/flux-macros/src/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(clippy::all)]
 
 mod diagnostic;
 mod diagnostic_builder;

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -232,7 +232,7 @@ impl<'tcx> Body<'tcx> {
         // an implicit goto from the environment at the beginning of the function.
         let real_preds =
             self.rustc_mir.basic_blocks.predecessors()[bb].len() - self.fake_predecessors[bb];
-        real_preds > (if bb == START_BLOCK { 0 } else { 1 })
+        real_preds > usize::from(bb != START_BLOCK)
     }
 
     #[inline]

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -128,6 +128,12 @@ pub enum Rvalue {
     Aggregate(AggregateKind, Vec<Operand>),
     Discriminant(Place),
     Len(Place),
+    Cast(CastKind, Operand, Ty),
+}
+
+#[derive(Copy, Clone)]
+pub enum CastKind {
+    IntToInt,
 }
 
 pub enum AggregateKind {
@@ -418,6 +424,7 @@ impl fmt::Debug for Rvalue {
                 write!(f, "[{:?}]", args.iter().format(", "))
             }
             Rvalue::Len(place) => write!(f, "Len({place:?})"),
+            Rvalue::Cast(CastKind::IntToInt, op, ty) => write!(f, "{op:?} as {ty:?}"),
         }
     }
 }

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -623,10 +623,7 @@ impl Expr {
                 let bits = bits as i128;
                 ExprKind::Constant(Constant::from(bits)).intern()
             }
-            BaseTy::Uint(_) => {
-                let bits = bits as u128;
-                ExprKind::Constant(Constant::from(bits)).intern()
-            }
+            BaseTy::Uint(_) => ExprKind::Constant(Constant::from(bits)).intern(),
             BaseTy::Bool => ExprKind::Constant(Constant::Bool(bits != 0)).intern(),
             BaseTy::Adt(_, _) | BaseTy::Array(..) | BaseTy::Str | BaseTy::Float(_) => panic!(),
         }

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -582,6 +582,12 @@ impl Expr {
             .clone()
     }
 
+    pub fn one() -> Expr {
+        static ONE: OnceLock<Expr> = OnceLock::new();
+        ONE.get_or_init(|| ExprKind::Constant(Constant::ONE).intern())
+            .clone()
+    }
+
     pub fn unit() -> Expr {
         Expr::tuple(vec![])
     }

--- a/flux-tests/tests/neg/casts/int_to_int.rs
+++ b/flux-tests/tests/neg/casts/int_to_int.rs
@@ -1,0 +1,27 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> i32[0])]
+pub fn bool_int() -> i32 {
+    true as i32 //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> u32[1])]
+pub fn bool_uint() -> u32 {
+    false as u32 //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> u32[43])]
+pub fn uint_uint_lossless() -> u32 {
+    42u8 as u32 //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> i32[43])]
+pub fn int_int_lossless() -> i32 {
+    42i8 as i32 //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> i32[43])]
+pub fn uint_int_lossless() -> i32 {
+    42u8 as i32 //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/casts/int_to_int.rs
+++ b/flux-tests/tests/pos/casts/int_to_int.rs
@@ -1,0 +1,27 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> i32[1])]
+pub fn bool_int() -> i32 {
+    true as i32
+}
+
+#[flux::sig(fn() -> u32[0])]
+pub fn bool_uint() -> u32 {
+    false as u32
+}
+
+#[flux::sig(fn() -> u32[42])]
+pub fn uint_uint_lossless() -> u32 {
+    42u8 as u32
+}
+
+#[flux::sig(fn() -> i32[42])]
+pub fn int_int_lossless() -> i32 {
+    42i8 as i32
+}
+
+#[flux::sig(fn() -> i32[42])]
+pub fn uint_int_lossless() -> i32 {
+    42u8 as i32
+}

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -15,13 +15,14 @@ use flux_middle::{
     rustc::{
         self,
         mir::{
-            self, AggregateKind, BasicBlock, Body, Constant, Operand, Place, Rvalue, SourceInfo,
-            Statement, StatementKind, Terminator, TerminatorKind, RETURN_PLACE, START_BLOCK,
+            self, AggregateKind, BasicBlock, Body, CastKind, Constant, Operand, Place, Rvalue,
+            SourceInfo, Statement, StatementKind, Terminator, TerminatorKind, RETURN_PLACE,
+            START_BLOCK,
         },
     },
     ty::{
-        self, BaseTy, BinOp, Binders, BoundVar, Const, Constraint, Constraints, Expr, FnSig,
-        PolySig, Pred, RefKind, Sort, Ty, TyKind, VariantIdx,
+        self, BaseTy, BinOp, Binders, BoundVar, Const, Constraint, Constraints, Expr, FnSig, IntTy,
+        PolySig, Pred, RefKind, Sort, Ty, TyKind, UintTy, VariantIdx,
     },
 };
 use itertools::Itertools;
@@ -629,6 +630,10 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             }
             Rvalue::Discriminant(place) => Ok(Ty::discr(place.clone())),
             Rvalue::Len(_) => Ok(Ty::usize()),
+            Rvalue::Cast(kind, op, to) => {
+                let from = self.check_operand(rcx, env, src_info, op);
+                Ok(Self::check_cast(*kind, from, to))
+            }
         }
     }
 
@@ -857,6 +862,37 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         }
     }
 
+    fn check_cast(kind: CastKind, from: Ty, to: &rustc::ty::Ty) -> Ty {
+        use rustc::ty::TyKind as RustTyKind;
+        match kind {
+            CastKind::IntToInt => {
+                match (from.kind(), to.kind()) {
+                    (TyKind::Indexed(BaseTy::Bool, idxs), RustTyKind::Int(int_ty)) => {
+                        bool_int_cast(&idxs[0].expr, *int_ty)
+                    }
+                    (TyKind::Indexed(BaseTy::Bool, idxs), RustTyKind::Uint(uint_ty)) => {
+                        bool_uint_cast(&idxs[0].expr, *uint_ty)
+                    }
+                    (TyKind::Indexed(BaseTy::Int(int_ty1), idxs), RustTyKind::Int(int_ty2)) => {
+                        int_int_cast(&idxs[0].expr, *int_ty1, *int_ty2)
+                    }
+                    (TyKind::Indexed(BaseTy::Uint(uint_ty1), idxs), RustTyKind::Uint(uint_ty2)) => {
+                        uint_uint_cast(&idxs[0].expr, *uint_ty1, *uint_ty2)
+                    }
+                    (TyKind::Indexed(BaseTy::Uint(uint_ty), idxs), RustTyKind::Int(int_ty)) => {
+                        uint_int_cast(&idxs[0].expr, *uint_ty, *int_ty)
+                    }
+                    (TyKind::Indexed(BaseTy::Int(_), _), RustTyKind::Uint(uint_ty)) => {
+                        Ty::uint(*uint_ty)
+                    }
+                    _ => {
+                        panic!("invalid int to int cast")
+                    }
+                }
+            }
+        }
+    }
+
     fn check_operand(
         &mut self,
         rcx: &mut RefineCtxt,
@@ -908,6 +944,76 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
     fn snapshot_at_dominator(&self, bb: BasicBlock) -> &Snapshot {
         let dominator = self.dominators.immediate_dominator(bb);
         self.snapshots[dominator].as_ref().unwrap()
+    }
+}
+
+fn bool_int_cast(b: &Expr, int_ty: IntTy) -> Ty {
+    let expr = Expr::if_then_else(b.clone(), Expr::one(), Expr::zero()).into();
+    Ty::indexed(BaseTy::Int(int_ty), vec![expr])
+}
+
+fn bool_uint_cast(b: &Expr, uint_ty: UintTy) -> Ty {
+    let expr = Expr::if_then_else(b.clone(), Expr::one(), Expr::zero()).into();
+    Ty::indexed(BaseTy::Uint(uint_ty), vec![expr])
+}
+
+fn int_int_cast(idx: &Expr, int_ty1: IntTy, int_ty2: IntTy) -> Ty {
+    if is_lossless_int_to_int(int_ty1, int_ty2) {
+        Ty::indexed(BaseTy::Int(int_ty2), vec![idx.clone().into()])
+    } else {
+        Ty::int(int_ty2)
+    }
+}
+
+fn uint_int_cast(idx: &Expr, uint_ty: UintTy, int_ty: IntTy) -> Ty {
+    if is_lossless_uint_to_int(uint_ty, int_ty) {
+        Ty::indexed(BaseTy::Int(int_ty), vec![idx.clone().into()])
+    } else {
+        Ty::int(int_ty)
+    }
+}
+
+fn uint_uint_cast(idx: &Expr, uint_ty1: UintTy, uint_ty2: UintTy) -> Ty {
+    if is_lossless_uint_to_uint(uint_ty1, uint_ty2) {
+        Ty::indexed(BaseTy::Uint(uint_ty2), vec![idx.clone().into()])
+    } else {
+        Ty::uint(uint_ty2)
+    }
+}
+
+fn is_lossless_uint_to_uint(uint_ty1: UintTy, uint_ty2: UintTy) -> bool {
+    use UintTy::*;
+    match (uint_ty1, uint_ty2) {
+        (U8, Usize | U16 | U32 | U64 | U128)
+        | (U16, U16 | U32 | U64 | U128)
+        | (U32, U32 | U64 | U128)
+        | (U64, U64 | U128)
+        | (U128, U128) => true,
+        _ => false,
+    }
+}
+
+fn is_lossless_int_to_int(int_ty1: IntTy, int_ty2: IntTy) -> bool {
+    use IntTy::*;
+    match (int_ty1, int_ty2) {
+        (I8, Isize | I16 | I32 | I64 | I128)
+        | (I16, I16 | I32 | I64 | I128)
+        | (I32, I32 | I64 | I128)
+        | (I64, I64 | I128)
+        | (I128, I128) => true,
+        _ => false,
+    }
+}
+
+fn is_lossless_uint_to_int(uint_ty: UintTy, int_ty: IntTy) -> bool {
+    use IntTy::*;
+    use UintTy::*;
+    match (uint_ty, int_ty) {
+        (U8, I16 | I32 | I64 | I128)
+        | (U16, I32 | I64 | I128)
+        | (U32, I64 | I128)
+        | (U64, I128) => true,
+        _ => false,
     }
 }
 

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -983,38 +983,35 @@ fn uint_uint_cast(idx: &Expr, uint_ty1: UintTy, uint_ty2: UintTy) -> Ty {
 
 fn is_lossless_uint_to_uint(uint_ty1: UintTy, uint_ty2: UintTy) -> bool {
     use UintTy::*;
-    match (uint_ty1, uint_ty2) {
+    matches!(
+        (uint_ty1, uint_ty2),
         (U8, Usize | U16 | U32 | U64 | U128)
-        | (U16, U16 | U32 | U64 | U128)
-        | (U32, U32 | U64 | U128)
-        | (U64, U64 | U128)
-        | (U128, U128) => true,
-        _ => false,
-    }
+            | (U16, U16 | U32 | U64 | U128)
+            | (U32, U32 | U64 | U128)
+            | (U64, U64 | U128)
+            | (U128, U128)
+    )
 }
 
 fn is_lossless_int_to_int(int_ty1: IntTy, int_ty2: IntTy) -> bool {
     use IntTy::*;
-    match (int_ty1, int_ty2) {
+    matches!(
+        (int_ty1, int_ty2),
         (I8, Isize | I16 | I32 | I64 | I128)
-        | (I16, I16 | I32 | I64 | I128)
-        | (I32, I32 | I64 | I128)
-        | (I64, I64 | I128)
-        | (I128, I128) => true,
-        _ => false,
-    }
+            | (I16, I16 | I32 | I64 | I128)
+            | (I32, I32 | I64 | I128)
+            | (I64, I64 | I128)
+            | (I128, I128)
+    )
 }
 
 fn is_lossless_uint_to_int(uint_ty: UintTy, int_ty: IntTy) -> bool {
     use IntTy::*;
     use UintTy::*;
-    match (uint_ty, int_ty) {
-        (U8, I16 | I32 | I64 | I128)
-        | (U16, I32 | I64 | I128)
-        | (U32, I64 | I128)
-        | (U64, I128) => true,
-        _ => false,
-    }
+    matches!(
+        (uint_ty, int_ty),
+        (U8, I16 | I32 | I64 | I128) | (U16, I32 | I64 | I128) | (U32, I64 | I128) | (U64, I128)
+    )
 }
 
 impl Phase for Inference<'_> {

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -143,8 +143,8 @@ where
 
         let constants = self
             .const_map
-            .iter()
-            .map(|(_, const_info)| (const_info.name, fixpoint::Sort::Int))
+            .values()
+            .map(|const_info| (const_info.name, fixpoint::Sort::Int))
             .collect();
 
         let uifs = uf_sorts


### PR DESCRIPTION
Basic support for int-to-int cast that keeps track of the index if the cast is guaranteed to be lossless and otherwise forgets about the index.