### PR TITLE
Unchecked invariants

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -96,12 +96,13 @@ pub fn desugar_enum_def(
     let mut params = ParamsCtxt::new(sess, consts, adt_sorts);
     params.insert_params(enum_def.refined_by.into_iter().flatten())?;
     let def_id = enum_def.def_id.to_def_id();
-    let refined_by = params.params;
     let variants = enum_def
         .variants
         .into_iter()
         .map(|variant| desugar_variant(sess, adt_sorts, consts, variant))
         .try_collect_exhaust()?;
+
+    let refined_by = params.params;
 
     Ok(EnumDef { def_id, refined_by, variants })
 }

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -70,7 +70,8 @@ pub fn desugar_adt_data(
 
     let sorts = cx.params.iter().map(|param| param.sort).collect();
     let fields = params.params.iter().map(|param| param.name.name).collect();
-    Ok(AdtSortInfo { sorts, fields })
+    let refined_by = cx.params;
+    Ok(AdtSortInfo { sorts, fields, refined_by })
 }
 
 pub fn desugar_struct_def(
@@ -95,8 +96,7 @@ pub fn desugar_struct_def(
             .try_collect_exhaust()?;
         StructKind::Transparent { fields }
     };
-    let refined_by = cx.params.params;
-    Ok(StructDef { def_id, kind, refined_by })
+    Ok(StructDef { def_id, kind })
 }
 
 pub fn desugar_enum_def(

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -13,7 +13,7 @@ mod desugar;
 mod table_resolver;
 mod zip_resolver;
 
-pub use desugar::{desugar_qualifier, resolve_sorts, resolve_uf_def};
+pub use desugar::{desugar_adt_data, desugar_qualifier, resolve_sorts, resolve_uf_def};
 use flux_middle::{
     core::{self, AdtSorts},
     global_env::GlobalEnv,

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -15,7 +15,7 @@ mod zip_resolver;
 
 pub use desugar::{desugar_adt_data, desugar_qualifier, resolve_sorts, resolve_uf_def};
 use flux_middle::{
-    core::{self, AdtSorts},
+    core::{self, AdtMap},
     global_env::GlobalEnv,
     rustc,
 };
@@ -26,7 +26,7 @@ use rustc_span::Span;
 
 pub fn desugar_struct_def(
     genv: &GlobalEnv,
-    adt_sorts: &AdtSorts,
+    adt_sorts: &AdtMap,
     struct_def: surface::StructDef,
 ) -> Result<core::StructDef, ErrorGuaranteed> {
     let resolver = table_resolver::Resolver::new(genv, struct_def.def_id)?;
@@ -36,7 +36,7 @@ pub fn desugar_struct_def(
 
 pub fn desugar_enum_def(
     genv: &GlobalEnv,
-    adt_sorts: &AdtSorts,
+    adt_sorts: &AdtMap,
     enum_def: surface::EnumDef,
 ) -> Result<core::EnumDef, ErrorGuaranteed> {
     let def_id = enum_def.def_id;
@@ -50,7 +50,7 @@ pub fn desugar_enum_def(
 
 pub fn desugar_fn_sig(
     genv: &GlobalEnv,
-    sorts: &AdtSorts,
+    sorts: &AdtMap,
     def_id: LocalDefId,
     fn_sig: surface::FnSig,
 ) -> Result<core::FnSig, ErrorGuaranteed> {

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -51,6 +51,7 @@ impl<'genv, 'tcx> Resolver<'genv, 'tcx> {
             def_id: enum_def.def_id,
             refined_by: enum_def.refined_by,
             opaque: enum_def.opaque,
+            invariants: enum_def.invariants,
             variants,
         })
     }

--- a/flux-desugar/src/zip_resolver.rs
+++ b/flux-desugar/src/zip_resolver.rs
@@ -49,6 +49,7 @@ impl<'genv, 'tcx> ZipResolver<'genv, 'tcx> {
             def_id: enum_def.def_id,
             opaque: enum_def.opaque,
             refined_by: enum_def.refined_by,
+            invariants: enum_def.invariants,
             variants,
         })
     }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -159,8 +159,7 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
             .qualifs
             .into_iter()
             .map(|qualifier| {
-                let qualifier =
-                    desugar::desugar_qualifier(genv.sess, &genv.consts, qualifier, &adt_sorts)?;
+                let qualifier = desugar::desugar_qualifier(genv.sess, &genv.consts, qualifier)?;
                 Wf::new(genv).check_qualifier(&qualifier)?;
                 Ok(ty::conv::ConvCtxt::conv_qualifier(&qualifier))
             })

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -2,7 +2,7 @@ use flux_common::iter::IterExt;
 use flux_desugar as desugar;
 use flux_errors::FluxSession;
 use flux_middle::{
-    core::{AdtSortInfo, AdtSorts},
+    core::AdtSorts,
     global_env::{ConstInfo, GlobalEnv},
     rustc, ty,
 };

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -134,10 +134,8 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
         // Register adts
         specs.structs.iter().try_for_each_exhaust(|(def_id, def)| {
             let refined_by = def.refined_by.as_ref().unwrap_or(surface::Params::DUMMY);
-            adt_sorts.insert(
-                def_id.to_def_id(),
-                desugar::desugar_adt_data(genv.sess, &genv.consts, refined_by)?,
-            );
+            adt_sorts
+                .insert(*def_id, desugar::desugar_adt_data(genv.sess, &genv.consts, refined_by)?);
             genv.register_adt_def(
                 def_id.to_def_id(),
                 adt_sorts.get_sorts(def_id.to_def_id()).unwrap(),
@@ -146,10 +144,8 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
         })?;
         specs.enums.iter().try_for_each_exhaust(|(def_id, def)| {
             let refined_by = def.refined_by.as_ref().unwrap_or(surface::Params::DUMMY);
-            adt_sorts.insert(
-                def_id.to_def_id(),
-                desugar::desugar_adt_data(genv.sess, &genv.consts, refined_by)?,
-            );
+            adt_sorts
+                .insert(*def_id, desugar::desugar_adt_data(genv.sess, &genv.consts, refined_by)?);
             genv.register_adt_def(
                 def_id.to_def_id(),
                 adt_sorts.get_sorts(def_id.to_def_id()).unwrap(),
@@ -181,10 +177,13 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
             .structs
             .into_iter()
             .try_for_each_exhaust(|(def_id, struct_def)| {
-                let adt_data = &adt_sorts[def_id.to_def_id()];
                 let struct_def = desugar::desugar_struct_def(genv, &adt_sorts, struct_def)?;
-                Wf::new(genv).check_struct_def(adt_data, &struct_def)?;
-                genv.register_struct_def_variant(def_id.to_def_id(), adt_data, struct_def);
+                Wf::new(genv).check_struct_def(&adt_sorts[def_id], &struct_def)?;
+                genv.register_struct_def_variant(
+                    def_id.to_def_id(),
+                    &adt_sorts[def_id],
+                    struct_def,
+                );
                 Ok(())
             })?;
 

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -141,6 +141,7 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
                 refined_by,
                 vec![],
             )?;
+            Wf::new(genv).check_adt_def(&adt_def)?;
             adt_map.insert(*def_id, adt_def);
             genv.register_adt_def(&adt_map[*def_id]);
             Ok(())
@@ -157,6 +158,7 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
                     refined_by,
                     std::mem::take(&mut def.invariants),
                 )?;
+                Wf::new(genv).check_adt_def(&adt_def)?;
                 adt_map.insert(*def_id, adt_def);
                 genv.register_adt_def(&adt_map[*def_id]);
                 Ok(())

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -198,13 +198,15 @@ impl Lit {
 }
 
 #[derive(Default, Debug)]
-pub struct AdtSorts(FxHashMap<LocalDefId, AdtSortInfo>);
+pub struct AdtMap(FxHashMap<LocalDefId, AdtDef>);
 
 #[derive(Debug)]
-pub struct AdtSortInfo {
+pub struct AdtDef {
+    pub def_id: DefId,
     pub refined_by: Vec<Param>,
     pub fields: Vec<Symbol>,
     pub sorts: Vec<Sort>,
+    pub invariants: Vec<Expr>,
 }
 
 #[derive(Default)]
@@ -233,8 +235,8 @@ impl UFSorts {
     }
 }
 
-impl AdtSorts {
-    pub fn insert(&mut self, def_id: LocalDefId, sort_info: AdtSortInfo) {
+impl AdtMap {
+    pub fn insert(&mut self, def_id: LocalDefId, sort_info: AdtDef) {
         self.0.insert(def_id, sort_info);
     }
 
@@ -249,8 +251,8 @@ impl AdtSorts {
     }
 }
 
-impl std::ops::Index<LocalDefId> for AdtSorts {
-    type Output = AdtSortInfo;
+impl std::ops::Index<LocalDefId> for AdtMap {
+    type Output = AdtDef;
 
     fn index(&self, def_id: LocalDefId) -> &Self::Output {
         &self.0[&def_id]

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -24,6 +24,12 @@ pub struct StructDef {
 }
 
 #[derive(Debug)]
+pub enum StructKind {
+    Transparent { fields: Vec<Option<Ty>> },
+    Opaque,
+}
+
+#[derive(Debug)]
 pub struct EnumDef {
     pub def_id: DefId,
     pub refined_by: Vec<Param>,
@@ -35,12 +41,6 @@ pub struct VariantDef {
     pub params: Vec<Param>,
     pub fields: Vec<Ty>,
     pub ret: Ty,
-}
-
-#[derive(Debug)]
-pub enum StructKind {
-    Transparent { fields: Vec<Option<Ty>> },
-    Opaque,
 }
 
 pub struct FnSig {
@@ -196,12 +196,6 @@ impl Expr {
 
 impl Lit {
     pub const TRUE: Lit = Lit::Bool(true);
-}
-
-impl StructDef {
-    pub fn sorts(&self) -> Vec<Sort> {
-        self.refined_by.iter().map(|param| param.sort).collect()
-    }
 }
 
 #[derive(Default, Debug)]

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -20,7 +20,6 @@ pub use rustc_target::abi::VariantIdx;
 pub struct StructDef {
     pub def_id: DefId,
     pub kind: StructKind,
-    pub refined_by: Vec<Param>,
 }
 
 #[derive(Debug)]
@@ -203,6 +202,7 @@ pub struct AdtSorts(FxHashMap<DefId, AdtSortInfo>);
 
 #[derive(Debug)]
 pub struct AdtSortInfo {
+    pub refined_by: Vec<Param>,
     pub fields: Vec<Symbol>,
     pub sorts: Vec<Sort>,
 }
@@ -246,6 +246,14 @@ impl AdtSorts {
     pub fn get_fields(&self, def_id: DefId) -> Option<&[Symbol]> {
         let info = self.0.get(&def_id)?;
         Some(&info.fields)
+    }
+}
+
+impl std::ops::Index<DefId> for AdtSorts {
+    type Output = AdtSortInfo;
+
+    fn index(&self, def_id: DefId) -> &Self::Output {
+        &self.0[&def_id]
     }
 }
 

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -10,7 +10,7 @@ use flux_common::format::PadAdapter;
 pub use flux_fixpoint::BinOp;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::newtype_index;
 pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, UintTy};
 use rustc_span::{Span, Symbol};
@@ -198,7 +198,7 @@ impl Lit {
 }
 
 #[derive(Default, Debug)]
-pub struct AdtSorts(FxHashMap<DefId, AdtSortInfo>);
+pub struct AdtSorts(FxHashMap<LocalDefId, AdtSortInfo>);
 
 #[derive(Debug)]
 pub struct AdtSortInfo {
@@ -234,25 +234,25 @@ impl UFSorts {
 }
 
 impl AdtSorts {
-    pub fn insert(&mut self, def_id: DefId, sort_info: AdtSortInfo) {
+    pub fn insert(&mut self, def_id: LocalDefId, sort_info: AdtSortInfo) {
         self.0.insert(def_id, sort_info);
     }
 
     pub fn get_sorts(&self, def_id: DefId) -> Option<&[Sort]> {
-        let info = self.0.get(&def_id)?;
+        let info = self.0.get(&def_id.as_local()?)?;
         Some(&info.sorts)
     }
 
     pub fn get_fields(&self, def_id: DefId) -> Option<&[Symbol]> {
-        let info = self.0.get(&def_id)?;
+        let info = self.0.get(&def_id.as_local()?)?;
         Some(&info.fields)
     }
 }
 
-impl std::ops::Index<DefId> for AdtSorts {
+impl std::ops::Index<LocalDefId> for AdtSorts {
     type Output = AdtSortInfo;
 
-    fn index(&self, def_id: DefId) -> &Self::Output {
+    fn index(&self, def_id: LocalDefId) -> &Self::Output {
         &self.0[&def_id]
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -88,13 +88,18 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.fn_sigs.get_mut().insert(def_id, fn_sig);
     }
 
-    pub fn register_struct_def(&mut self, def_id: DefId, struct_def: core::StructDef) {
-        let variant = ty::conv::ConvCtxt::conv_struct_def(self, &struct_def);
+    pub fn register_struct_def_variant(
+        &mut self,
+        def_id: DefId,
+        adt_data: &core::AdtSortInfo,
+        struct_def: core::StructDef,
+    ) {
+        let variant = ty::conv::ConvCtxt::conv_struct_def(self, &adt_data, &struct_def);
         let variants = variant.map(|variant_def| vec![variant_def]);
         self.adt_variants.get_mut().insert(def_id, variants);
     }
 
-    pub fn register_enum_def(&mut self, def_id: DefId, enum_def: core::EnumDef) {
+    pub fn register_enum_def_variants(&mut self, def_id: DefId, enum_def: core::EnumDef) {
         if let Some(variants) = ty::conv::ConvCtxt::conv_enum_def(self, enum_def) {
             self.adt_variants.get_mut().insert(def_id, Some(variants));
         }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -68,14 +68,10 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.uf_sorts.insert(name, ty::UFDef { inputs, output });
     }
 
-    pub fn register_adt_def(&mut self, def_id: DefId, sorts: &[core::Sort]) {
-        let sorts = sorts
-            .iter()
-            .map(|sort| ty::conv::conv_sort(*sort))
-            .collect_vec();
-        self.adt_defs
-            .get_mut()
-            .insert(def_id, ty::AdtDef::new(self.tcx.adt_def(def_id), sorts));
+    pub fn register_adt_def(&mut self, adt_def: &core::AdtDef) {
+        let def_id = adt_def.def_id;
+        let adt_def = ty::conv::ConvCtxt::conv_adt_def(self, adt_def);
+        self.adt_defs.get_mut().insert(def_id, adt_def);
     }
 
     /// This function must be called after all adts are registered
@@ -91,16 +87,16 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     pub fn register_struct_def_variant(
         &mut self,
         def_id: DefId,
-        adt_data: &core::AdtSortInfo,
+        adt_data: &core::AdtDef,
         struct_def: core::StructDef,
     ) {
-        let variant = ty::conv::ConvCtxt::conv_struct_def(self, &adt_data, &struct_def);
+        let variant = ty::conv::ConvCtxt::conv_struct_def_variant(self, adt_data, &struct_def);
         let variants = variant.map(|variant_def| vec![variant_def]);
         self.adt_variants.get_mut().insert(def_id, variants);
     }
 
     pub fn register_enum_def_variants(&mut self, def_id: DefId, enum_def: core::EnumDef) {
-        if let Some(variants) = ty::conv::ConvCtxt::conv_enum_def(self, enum_def) {
+        if let Some(variants) = ty::conv::ConvCtxt::conv_enum_def_variants(self, enum_def) {
             self.adt_variants.get_mut().insert(def_id, Some(variants));
         }
     }
@@ -122,7 +118,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.adt_defs
             .borrow_mut()
             .entry(def_id)
-            .or_insert_with(|| ty::AdtDef::new(self.tcx.adt_def(def_id), vec![]))
+            .or_insert_with(|| ty::AdtDef::new(self.tcx.adt_def(def_id), vec![], vec![]))
             .clone()
     }
 

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -1,7 +1,7 @@
 //! Conversion from desugared types in [`crate::core`] to types in [`crate::ty`]
 use std::iter;
 
-use flux_common::{index::IndexGen, iter::IterExt};
+use flux_common::index::IndexGen;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustc_target::abi::VariantIdx;
@@ -103,7 +103,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         let invariants = adt
             .invariants
             .iter()
-            .map(|invariant| cx.conv_expr(invariant))
+            .map(|invariant| Binders::new(cx.conv_expr(invariant), sorts.as_slice()))
             .collect_vec();
 
         ty::AdtDef::new(genv.tcx.adt_def(adt.def_id), sorts, invariants)

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -8,7 +8,7 @@ use rustc_target::abi::VariantIdx;
 
 use super::{Binders, PolyVariant};
 use crate::{
-    core,
+    core::{self, AdtSortInfo},
     global_env::GlobalEnv,
     rustc::ty::GenericParamDefKind,
     ty::{self, DebruijnIndex},
@@ -132,10 +132,11 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
     pub(crate) fn conv_struct_def(
         genv: &GlobalEnv,
+        adt_data: &AdtSortInfo,
         struct_def: &core::StructDef,
     ) -> Option<ty::PolyVariant> {
         let mut cx = ConvCtxt::new(genv);
-        let sorts = cx.conv_params(&struct_def.refined_by);
+        let sorts = cx.conv_params(&adt_data.refined_by);
         let def_id = struct_def.def_id;
         let rustc_adt = genv.tcx.adt_def(def_id);
         if let core::StructKind::Transparent { fields } = &struct_def.kind {

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -26,6 +26,7 @@ pub struct AdtDef(Interned<AdtDefData>);
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct AdtDefData {
     def_id: DefId,
+    invariants: List<Expr>,
     sorts: List<Sort>,
     flags: AdtFlags,
 }
@@ -287,9 +288,14 @@ impl FnSig {
 }
 
 impl AdtDef {
-    pub fn new(rustc_def: rustc_middle::ty::AdtDef, sorts: impl Into<List<Sort>>) -> Self {
+    pub(crate) fn new(
+        rustc_def: rustc_middle::ty::AdtDef,
+        sorts: impl Into<List<Sort>>,
+        invariants: impl Into<List<Expr>>,
+    ) -> Self {
         AdtDef(Interned::new(AdtDefData {
             def_id: rustc_def.did(),
+            invariants: invariants.into(),
             sorts: sorts.into(),
             flags: rustc_def.flags(),
         }))

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -65,6 +65,10 @@ pub fn parse_variant(tokens: TokenStream, span: Span) -> ParseResult<surface::Va
     parse!(surface_grammar::VariantParser, tokens, span)
 }
 
+pub fn parse_expr(tokens: TokenStream, span: Span) -> ParseResult<surface::Expr> {
+    parse!(surface_grammar::ExprParser, tokens, span)
+}
+
 pub enum UserParseError {
     UnsupportedLiteral(Location, Location),
 }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -60,7 +60,7 @@ pub struct VariantDef<T = Ident> {
     pub span: Span,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Params {
     pub params: Vec<Param>,
     pub span: Span,
@@ -211,6 +211,10 @@ pub enum BinOp {
     Sub,
     Mod,
     Mul,
+}
+
+impl Params {
+    pub const DUMMY: &Params = &Params { params: vec![], span: rustc_span::DUMMY_SP };
 }
 
 impl Path<Res> {

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -243,6 +243,16 @@ impl Params {
     }
 }
 
+impl<'a> IntoIterator for &'a Params {
+    type Item = &'a Param;
+
+    type IntoIter = std::slice::Iter<'a, Param>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.params.iter()
+    }
+}
+
 impl IntoIterator for Params {
     type Item = Param;
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -49,6 +49,7 @@ pub struct EnumDef<T = Ident> {
     pub def_id: LocalDefId,
     pub refined_by: Option<Params>,
     pub variants: Vec<VariantDef<T>>,
+    pub invariants: Vec<Expr>,
     pub opaque: bool,
 }
 

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -24,7 +24,6 @@ pub Alias: surface::Alias = {
     }
 }
 
-
 pub RefinedBy: surface::Params = {
     <lo:@L> <params:Comma<Param>> <hi:@R> => surface::Params { params, span: mk_span(lo, hi) }
 }
@@ -139,8 +138,6 @@ GenericArgs: Vec<surface::Ty> = {
     "<" <Comma<Ty>> ">"
 }
 
-// The code below is duplicated from grammar.lalrpop ---------------------------------
-
 Path: surface::Path = {
     <lo:@L> <ident:Ident> <args:GenericArgs?> <hi:@R> => surface::Path { ident, args: args.unwrap_or_default(), span: mk_span(lo, hi) }
 }
@@ -168,6 +165,7 @@ Index: surface::Index = {
     <Level1>    => surface::Index::Expr(<>),
 };
 
+pub Expr = Level1;
 
 Level1 = NonAssoc<BinOp1, Level2>;  // <=>
 Level2 = LeftAssoc<BinOp2, Level3>; // =>

--- a/flux-tests/tests/neg/enums/invariant00.rs
+++ b/flux-tests/tests/neg/enums/invariant00.rs
@@ -1,0 +1,15 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(n: int)]
+pub enum E {
+    #[flux::variant({{i32[@n] : n > 0}} -> E[n])]
+    Pos(i32),
+    #[flux::variant({i32[0]} -> E[0])]
+    Zero(i32),
+}
+
+#[flux::sig(fn(E[@n], i32[n]) -> i32{v : v > 0})]
+pub fn is_zero(_: E, x: i32) -> i32 {
+    x + 1 //~ ERROR postcondition
+}

--- a/flux-tests/tests/neg/enums/pos00.rs
+++ b/flux-tests/tests/neg/enums/pos00.rs
@@ -1,0 +1,32 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(n: int)]
+pub enum Pos {
+    #[flux::variant({Box<Pos[@n]>} -> Pos[2*n])]
+    XO(Box<Pos>),
+    #[flux::variant({Box<Pos[@n]>} -> Pos[2*n + 1])]
+    XI(Box<Pos>),
+    #[flux::variant(Pos[1])]
+    XH,
+}
+
+impl Pos {
+    #[flux::sig(fn(&Pos[@n]) -> i32[n])]
+    pub fn to_i32(&self) -> i32 {
+        match self {
+            Pos::XH => 1,
+            Pos::XI(rest) => 2 * rest.to_i32(), //~ ERROR postcondition
+            Pos::XO(rest) => 2 * rest.to_i32(),
+        }
+    }
+
+    #[flux::sig(fn(&Pos[@n]) -> bool[n == 1])]
+    pub fn is_one(&self) -> bool {
+        match self {
+            Pos::XH => true,
+            Pos::XI(_) => false, //~ ERROR postcondition
+            Pos::XO(_) => false,
+        }
+    }
+}

--- a/flux-tests/tests/neg/error_messages/ill-formed-invariant.rs
+++ b/flux-tests/tests/neg/error_messages/ill-formed-invariant.rs
@@ -1,0 +1,16 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(n: int)]
+#[flux::invariant(n + 1)] //~ ERROR mismatched sorts
+pub enum A {
+    #[flux::variant(E[0])]
+    V,
+}
+
+#[flux::refined_by(n: int)]
+#[flux::invariant(nn > 0)] //~ ERROR cannot find
+pub enum B {
+    #[flux::variant(E[0])]
+    V,
+}

--- a/flux-tests/tests/pos/enums/invariant00.rs
+++ b/flux-tests/tests/pos/enums/invariant00.rs
@@ -1,0 +1,16 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(n: int)]
+#[flux::invariant(n >= 0)]
+pub enum E {
+    #[flux::variant({{i32[@n] : n > 0}} -> E[n])]
+    Pos(i32),
+    #[flux::variant({i32[0]} -> E[0])]
+    Zero(i32),
+}
+
+#[flux::sig(fn(E[@n], i32[n]) -> i32{v : v > 0})]
+pub fn is_zero(_: E, x: i32) -> i32 {
+    x + 1
+}

--- a/flux-tests/tests/pos/enums/list00.rs
+++ b/flux-tests/tests/pos/enums/list00.rs
@@ -7,10 +7,11 @@ pub fn never<T>(_x: i32) -> T {
 }
 
 #[flux::refined_by(n:int)]
+#[flux::invariant(n >= 0)]
 pub enum List {
     #[flux::variant(List[0])]
     Nil,
-    #[flux::variant({i32, Box<List[@n]>} -> {List[n+1]: 0 <= n})]
+    #[flux::variant({i32, Box<List[@n]>} -> List[n+1])]
     Cons(i32, Box<List>),
 }
 

--- a/flux-tests/tests/pos/enums/pos00.rs
+++ b/flux-tests/tests/pos/enums/pos00.rs
@@ -1,0 +1,33 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(n: int)]
+#[flux::invariant(n > 0)]
+pub enum Pos {
+    #[flux::variant({Box<Pos[@n]>} -> Pos[2*n])]
+    XO(Box<Pos>),
+    #[flux::variant({Box<Pos[@n]>} -> Pos[2*n + 1])]
+    XI(Box<Pos>),
+    #[flux::variant(Pos[1])]
+    XH,
+}
+
+impl Pos {
+    #[flux::sig(fn(&Pos[@n]) -> i32[n])]
+    pub fn to_i32(&self) -> i32 {
+        match self {
+            Pos::XH => 1,
+            Pos::XI(rest) => 2 * rest.to_i32() + 1,
+            Pos::XO(rest) => 2 * rest.to_i32(),
+        }
+    }
+
+    #[flux::sig(fn(&Pos[@n]) -> bool[n == 1])]
+    pub fn is_one(&self) -> bool {
+        match self {
+            Pos::XH => true,
+            Pos::XI(_) => false,
+            Pos::XO(_) => false,
+        }
+    }
+}

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -372,7 +372,7 @@ impl PathsTree {
                         substs,
                         &idxs.to_exprs(),
                     );
-                    ty = Ty::tuple(tys);
+                    ty = rcx.unpack(&Ty::tuple(tys), false);
                 }
                 _ => unreachable!("{elem:?} {ty:?}"),
             }

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -89,6 +89,16 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         self.check_expr(&env, &qualifier.expr, ty::Sort::Bool)
     }
 
+    pub fn check_adt_def(&self, adt_def: &core::AdtDef) -> Result<(), ErrorGuaranteed> {
+        let env = Env::new(&adt_def.refined_by);
+        adt_def
+            .invariants
+            .iter()
+            .try_for_each_exhaust(|invariant| self.check_expr(&env, invariant, ty::Sort::Bool))?;
+
+        Ok(())
+    }
+
     pub fn check_struct_def(
         &self,
         adt_data: &core::AdtDef,

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -89,8 +89,12 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         self.check_expr(&env, &qualifier.expr, ty::Sort::Bool)
     }
 
-    pub fn check_struct_def(&self, def: &core::StructDef) -> Result<(), ErrorGuaranteed> {
-        let mut env = Env::new(&def.refined_by);
+    pub fn check_struct_def(
+        &self,
+        adt_data: &core::AdtSortInfo,
+        def: &core::StructDef,
+    ) -> Result<(), ErrorGuaranteed> {
+        let mut env = Env::new(&adt_data.refined_by);
         if let core::StructKind::Transparent { fields } = &def.kind {
             fields.iter().try_for_each_exhaust(|ty| {
                 if let Some(ty) = ty {

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -91,7 +91,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
 
     pub fn check_struct_def(
         &self,
-        adt_data: &core::AdtSortInfo,
+        adt_data: &core::AdtDef,
         def: &core::StructDef,
     ) -> Result<(), ErrorGuaranteed> {
         let mut env = Env::new(&adt_data.refined_by);


### PR DESCRIPTION
This is part of https://github.com/liquid-rust/flux/issues/165. 

Adds a new flux annotation to specify invariants for enums. Invariants are assumed every time a value of that type is in scope. They are currently not verified and could introduce unsoundness.