### PR TITLE
Fixes to allow running flux inside a cargo project with dependencies

### DIFF
--- a/flux-driver/src/lib.rs
+++ b/flux-driver/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private, box_patterns, once_cell)]
 
 extern crate rustc_ast;
+extern crate rustc_ast_pretty;
 extern crate rustc_borrowck;
 extern crate rustc_driver;
 extern crate rustc_errors;
@@ -27,13 +28,15 @@ fn sysroot() -> Option<String> {
 }
 
 /// Run Flux Rust and return the exit status code.
-pub fn run_compiler(mut args: Vec<String>) -> i32 {
+pub fn run_compiler(mut args: Vec<String>, in_cargo: bool) -> i32 {
     // Add the sysroot path to the arguments.
     args.push("--sysroot".into());
     args.push(sysroot().expect("Flux Rust requires rustup to be built."));
     // Add release mode to the arguments.
     args.push("-O".into());
-    // Run the rust compiler with the arguments.
-    let mut callbacks = FluxCallbacks::default();
+    // HACK(nilehmann) When running flux we want to stop compilation after analysis
+    // to avoid creating a binary. However, stopping compilation messes up with cargo so we
+    // pass full_compilation=true if we detect we are being called from cargo
+    let mut callbacks = FluxCallbacks::new(in_cargo);
     catch_with_exit_code(move || RunCompiler::new(&args, &mut callbacks).run())
 }

--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -7,13 +7,17 @@ const CMD_RUSTC: &str = "rustc";
 fn main() -> io::Result<()> {
     logger::install()?;
 
-    // the extra != CMD_RUSTC is because the `rust-analyzer` plugin calls the `flux` binary
-    // with that extra argument that we want stripped out...
+    // HACK(nilehmann) Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
+    // We igore the argument and use it to determine if the binary is being called from cargo.
+    let mut in_cargo = false;
     let args: Vec<String> = args()
-        .filter(|x| !x.starts_with(CMD_PREFIX) && x != CMD_RUSTC)
+        .filter(|x| {
+            in_cargo |= x == CMD_RUSTC;
+            !x.starts_with(CMD_PREFIX) && x != CMD_RUSTC
+        })
         .collect();
 
-    let exit_code = flux_driver::run_compiler(args);
+    let exit_code = flux_driver::run_compiler(args, in_cargo);
     // Exit with the exit code returned by the compiler.
     exit(exit_code)
 }


### PR DESCRIPTION
Fixes to allow running cargo with flux as the `RUSTC_WRAPPER` in a crate with dependencies.

* When checking a crate see if it contains the `#![register_tool(flux)]` attribute, otherwise ignore it
* Do not stop compilation if we detect the binary is being called from cargo