### PR TITLE
Blame correct span when reporting ill-sorted indices

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -316,7 +316,7 @@ impl<'a> DesugarCtxt<'a> {
                     .iter()
                     .map(|(_, name)| {
                         let kind = ExprKind::Var(*name, ident.name, ident.span);
-                        Index { expr: Expr { kind, span: Some(ident.span) }, is_binder: true }
+                        Index { expr: Expr { kind, span: ident.span }, is_binder: true }
                     })
                     .collect();
                 Ok(indices)
@@ -418,7 +418,7 @@ impl<'a> ParamsCtxt<'a> {
                 ExprKind::IfThenElse(Box::new(p?), Box::new(e1?), Box::new(e2?))
             }
         };
-        Ok(Expr { kind, span: Some(expr.span) })
+        Ok(Expr { kind, span: expr.span })
     }
 
     fn fresh(&self) -> Name {
@@ -445,11 +445,11 @@ impl<'a> ParamsCtxt<'a> {
     fn desugar_var(&self, ident: surface::Ident) -> Result<Expr, ErrorGuaranteed> {
         if let Some(&name) = self.name_map.get(&ident.name) {
             let kind = ExprKind::Var(name, ident.name, ident.span);
-            return Ok(Expr { kind, span: Some(ident.span) });
+            return Ok(Expr { kind, span: ident.span });
         }
         if let Some(&did) = self.const_map.get(&ident.name) {
             let kind = ExprKind::Const(did, ident.span);
-            return Ok(Expr { kind, span: Some(ident.span) });
+            return Ok(Expr { kind, span: ident.span });
         }
         if let Some(fields) = self.dot_map.get(&ident.name) {
             return Err(self
@@ -467,7 +467,7 @@ impl<'a> ParamsCtxt<'a> {
         if let surface::ExprKind::Var(ident) = expr.kind {
             if let Some(&name) = self.field_map.get(&(ident.name, fld.name)) {
                 let kind = ExprKind::Var(name, ident.name, ident.span);
-                return Ok(Expr { kind, span: Some(ident.span) });
+                return Ok(Expr { kind, span: ident.span });
             }
             return Err(self
                 .sess

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::newtype_index;
 pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, UintTy};
-use rustc_span::{Span, Symbol};
+use rustc_span::{Span, Symbol, DUMMY_SP};
 pub use rustc_target::abi::VariantIdx;
 
 #[derive(Debug)]
@@ -135,7 +135,7 @@ pub enum Sort {
 
 pub struct Expr {
     pub kind: ExprKind,
-    pub span: Option<Span>,
+    pub span: Span,
 }
 
 pub enum ExprKind {
@@ -185,11 +185,19 @@ impl Lit {
     }
 }
 
-impl Expr {
-    pub const TRUE: Expr = Expr { kind: ExprKind::Literal(Lit::TRUE), span: None };
+impl<'a> IntoIterator for &'a Indices {
+    type Item = &'a Index;
 
+    type IntoIter = std::slice::Iter<'a, Index>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.indices.iter()
+    }
+}
+
+impl Expr {
     pub fn from_i128(v: i128) -> Expr {
-        Expr { kind: ExprKind::Literal(Lit::from_i128(v)), span: None }
+        Expr { kind: ExprKind::Literal(Lit::from_i128(v)), span: DUMMY_SP }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/liquid-rust/flux/issues/162