### PR TITLE
Initial support for slices

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -292,6 +292,7 @@ impl<'a> DesugarCtxt<'a> {
                 let ty = self.desugar_ty(*ty)?;
                 Ty::Array(Box::new(ty), len)
             }
+            surface::TyKind::Slice(ty) => Ty::Slice(Box::new(self.desugar_ty(*ty)?)),
         };
         Ok(ty)
     }
@@ -706,8 +707,9 @@ impl<'a> ParamsCtxt<'a> {
             }
             surface::TyKind::StrgRef(_, ty)
             | surface::TyKind::Ref(_, ty)
-            | surface::TyKind::Array(ty, _) => self.ty_gather_params(ty, adt_sorts),
-            surface::TyKind::Constr(_, ty) => self.ty_gather_params(ty, adt_sorts),
+            | surface::TyKind::Array(ty, _)
+            | surface::TyKind::Slice(ty)
+            | surface::TyKind::Constr(_, ty) => self.ty_gather_params(ty, adt_sorts),
             surface::TyKind::Path(path) => {
                 for ty in &path.args {
                     self.ty_gather_params(ty, adt_sorts)?;

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -154,6 +154,10 @@ impl<'genv, 'tcx> Resolver<'genv, 'tcx> {
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Array(Box::new(ty), len)
             }
+            surface::TyKind::Slice(ty) => {
+                let ty = self.resolve_ty(*ty)?;
+                surface::TyKind::Slice(Box::new(ty))
+            }
         };
         Ok(surface::Ty { kind, span: ty.span })
     }

--- a/flux-desugar/src/zip_resolver.rs
+++ b/flux-desugar/src/zip_resolver.rs
@@ -213,6 +213,9 @@ impl<'genv, 'tcx> ZipResolver<'genv, 'tcx> {
             (TyKind::Array(ty, len), rustc_ty::TyKind::Array(rust_ty, _)) => {
                 TyKind::Array(Box::new(self.zip_ty(*ty, rust_ty)?), len)
             }
+            (TyKind::Slice(ty), rustc_ty::TyKind::Slice(rust_ty)) => {
+                TyKind::Slice(Box::new(self.zip_ty(*ty, rust_ty)?))
+            }
 
             _ => panic!("incompatible types: `{rust_ty:?}`"),
         };

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -11,7 +11,7 @@ wf_param_count_mismatch =
 
 wf_illegal_binder =
     illegal binder
-    .label = binder not allowed under ADT parameter
+    .label = binder not allowed in this position
 
 wf_unresolved_function =
     unresolved function

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -92,6 +92,7 @@ pub enum Ty {
     Param(ParamTy),
     Tuple(Vec<Ty>),
     Array(Box<Ty>, usize),
+    Slice(Box<Ty>),
     Never,
 }
 
@@ -339,6 +340,7 @@ impl fmt::Debug for Ty {
             Ty::Never => write!(f, "!"),
             Ty::Constr(pred, ty) => write!(f, "{{{ty:?} : {pred:?}}}"),
             Ty::Array(ty, len) => write!(f, "[{ty:?}; {len:?}]"),
+            Ty::Slice(ty) => write!(f, "[{ty:?}]"),
         }
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -264,6 +264,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Array(ty, len) => {
                 ty::BaseTy::Array(self.refine_ty(ty, mk_pred), len.clone())
             }
+            rustc::ty::TyKind::Slice(ty) => ty::BaseTy::Slice(self.refine_ty(ty, mk_pred)),
         };
         let sorts = bty.sorts();
         if sorts.is_empty() {

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -560,10 +560,14 @@ pub fn lower_ty<'tcx>(
         }
         rustc_ty::Never => Ok(Ty::mk_never()),
         rustc_ty::Str => Ok(Ty::mk_str()),
-        rustc_ty::Tuple(tys) if tys.is_empty() => Ok(Ty::mk_tuple(vec![])),
+        rustc_ty::Tuple(tys) => {
+            let tys = List::from_vec(tys.iter().map(|ty| lower_ty(tcx, ty, span)).try_collect()?);
+            Ok(Ty::mk_tuple(tys))
+        }
         rustc_ty::Array(ty, c) => {
             Ok(Ty::mk_array(lower_ty(tcx, *ty, span)?, lower_const(tcx, *c, span)?))
         }
+        rustc_ty::Slice(ty) => Ok(Ty::mk_slice(lower_ty(tcx, *ty, span)?)),
         _ => {
             Err(emit_err(
                 tcx,

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -63,6 +63,7 @@ pub enum TyKind {
     Ref(Ty, Mutability),
     Tuple(List<Ty>),
     Uint(UintTy),
+    Slice(Ty),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -109,6 +110,10 @@ impl Ty {
 
     pub fn mk_array(ty: Ty, c: Const) -> Ty {
         TyKind::Array(ty, c).intern()
+    }
+
+    pub fn mk_slice(ty: Ty) -> Ty {
+        TyKind::Slice(ty).intern()
     }
 
     pub fn mk_bool() -> Ty {
@@ -215,6 +220,7 @@ impl std::fmt::Debug for Ty {
                         .format_with(", ", |ty, f| f(&format_args!("{:?}", ty)))
                 )
             }
+            TyKind::Slice(ty) => write!(f, "[{ty:?}]"),
         }
     }
 }

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -298,6 +298,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 let len = ty::Const::from_usize(self.genv.tcx, *len as u128);
                 ty::Ty::array(self.conv_ty(ty, nbinders), len)
             }
+            core::Ty::Slice(ty) => ty::Ty::slice(self.conv_ty(ty, nbinders)),
         }
     }
 

--- a/flux-middle/src/ty/expr.rs
+++ b/flux-middle/src/ty/expr.rs
@@ -146,7 +146,11 @@ impl Expr {
             }
             BaseTy::Uint(_) => ExprKind::Constant(Constant::from(bits)).intern(),
             BaseTy::Bool => ExprKind::Constant(Constant::Bool(bits != 0)).intern(),
-            BaseTy::Adt(_, _) | BaseTy::Array(..) | BaseTy::Str | BaseTy::Float(_) => panic!(),
+            BaseTy::Adt(_, _)
+            | BaseTy::Array(..)
+            | BaseTy::Str
+            | BaseTy::Float(_)
+            | BaseTy::Slice(_) => panic!(),
         }
     }
 

--- a/flux-middle/src/ty/fold.rs
+++ b/flux-middle/src/ty/fold.rs
@@ -305,6 +305,7 @@ impl TypeFoldable for BaseTy {
                 BaseTy::adt(adt_def.clone(), substs.iter().map(|ty| ty.fold_with(folder)))
             }
             BaseTy::Array(ty, c) => BaseTy::Array(ty.fold_with(folder), c.clone()),
+            BaseTy::Slice(ty) => BaseTy::Slice(ty.fold_with(folder)),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Float(_) | BaseTy::Str => {
                 self.clone()
             }
@@ -314,7 +315,7 @@ impl TypeFoldable for BaseTy {
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             BaseTy::Adt(_, substs) => substs.iter().for_each(|ty| ty.visit_with(visitor)),
-            BaseTy::Array(ty, _) => ty.visit_with(visitor),
+            BaseTy::Array(ty, _) | BaseTy::Slice(ty) => ty.visit_with(visitor),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Float(_) | BaseTy::Str => {}
         }
     }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -133,6 +133,7 @@ pub enum TyKind<T = Ident> {
     /// ()
     Unit,
     Array(Box<Ty<T>>, Lit),
+    Slice(Box<Ty<T>>),
 }
 
 #[derive(Debug, Clone)]
@@ -421,6 +422,7 @@ pub mod expand {
                 TyKind::Constr(pred.clone(), Box::new(expand_ty(aliases, t)))
             }
             TyKind::Array(ty, len) => TyKind::Array(Box::new(expand_ty(aliases, ty)), *len),
+            TyKind::Slice(ty) => TyKind::Slice(Box::new(expand_ty(aliases, ty))),
         }
     }
 
@@ -549,6 +551,7 @@ pub mod expand {
                 TyKind::Constr(subst_expr(subst, pred), Box::new(subst_ty(subst, t)))
             }
             TyKind::Array(ty, len) => TyKind::Array(Box::new(subst_ty(subst, ty)), *len),
+            TyKind::Slice(ty) => TyKind::Slice(Box::new(subst_ty(subst, ty))),
         }
     }
 }

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -122,6 +122,7 @@ TyKind: surface::TyKind = {
     <path:Path> "[" <indices:Indices> "]"              => surface::TyKind::Indexed { <> },
 
     "[" <ty:Ty> ";"  <len:Lit> "]" => surface::TyKind::Array(Box::new(ty), len),
+    "[" <ty:Ty> "]" => surface::TyKind::Slice(Box::new(ty)),
 
     "(" ")"  => surface::TyKind::Unit
 }

--- a/flux-tests/tests/neg/error_messages/fun_sig_error.rs
+++ b/flux-tests/tests/neg/error_messages/fun_sig_error.rs
@@ -55,3 +55,9 @@ type A<'a> = &'a [i32];
 
 #[flux::sig(fn())]
 fn dipa(x: A) {} //~ ERROR unsupported function signature
+
+#[flux::sig(fn(&[i32[@n]]))] //~ ERROR illegal binder
+fn hipa(x: &[i32]) {}
+
+#[flux::sig(fn(Option<i32[@n]>))] //~ ERROR illegal binder
+fn ira(x: Option<i32>) {}

--- a/flux-tests/tests/neg/surface/slice00.rs
+++ b/flux-tests/tests/neg/surface/slice00.rs
@@ -1,0 +1,21 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(&mut [i32{v : v > 0}]) -> &mut [i32{v : v >= 0}])]
+fn first_half(slice: &mut [i32]) -> &mut [i32] {
+    let mid = slice.len() / 2;
+    let (fst, snd) = slice.split_at_mut(mid); //~ ERROR precondition
+    fst
+}
+
+#[flux::sig(fn(&[i32{v : v >= 0}]) -> Option<&i32{v : v > 0}>)]
+fn first(slice: &[i32]) -> Option<&i32> {
+    slice.first() //~ ERROR postcondition
+}
+
+#[flux::sig(fn(&mut [i32{v : v > 0}]))]
+fn inc_fst(slice: &mut [i32]) {
+    if let Some(x) = slice.first_mut() { //~ ERROR precondition
+        *x -= 1;
+    }
+}

--- a/flux-tests/tests/pos/surface/slice00.rs
+++ b/flux-tests/tests/pos/surface/slice00.rs
@@ -1,0 +1,21 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(&[i32{v : v > 0}]) -> &[i32{v : v >= 0}])]
+fn first_half(slice: &[i32]) -> &[i32] {
+    let mid = slice.len() / 2;
+    let (fst, snd) = slice.split_at(mid);
+    fst
+}
+
+#[flux::sig(fn(&[i32{v : v > 0}]) -> Option<&i32{v : v >= 0}>)]
+fn first(slice: &[i32]) -> Option<&i32> {
+    slice.first()
+}
+
+#[flux::sig(fn(&mut [i32{v : v > 0}]))]
+fn inc_fst(slice: &mut [i32]) {
+    if let Some(x) = slice.first_mut() {
+        *x += 1;
+    }
+}

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -298,6 +298,9 @@ fn bty_subtyping(
             assert_eq!(len1, len2);
             subtyping(genv, constr, ty1, ty2, tag);
         }
+        (BaseTy::Slice(ty1), BaseTy::Slice(ty2)) => {
+            subtyping(genv, constr, ty1, ty2, tag);
+        }
         _ => {
             unreachable!("unexpected base types: `{:?}` and `{:?}` at {:?}", bty1, bty2, tag.span())
         }

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -375,6 +375,7 @@ impl TypeEnvInfer {
                 BaseTy::adt(adt_def.clone(), substs)
             }
             BaseTy::Array(ty, c) => BaseTy::Array(Self::pack_ty(scope, ty), c.clone()),
+            BaseTy::Slice(ty) => BaseTy::Slice(Self::pack_ty(scope, ty)),
             BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool | BaseTy::Float(_) | BaseTy::Str => {
                 bty.clone()
             }

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -167,7 +167,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 self.check_expr(env, pred, ty::Sort::Bool)?;
                 self.check_type(env, ty, allow_binder)
             }
-            core::Ty::Array(ty, _) => self.check_type(env, ty, allow_binder),
+            core::Ty::Slice(ty) | core::Ty::Array(ty, _) => self.check_type(env, ty, false),
             core::Ty::Never | core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
         }
     }


### PR DESCRIPTION
Support for slices with no index. This should be enough to use slices "opaquely", i.e., without being able to index them with the `[]` operator but with the ability to call methods on them.