### PR TITLE
Treat array len opaquely

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -4,9 +4,9 @@ use flux_common::{index::IndexGen, iter::IterExt};
 use flux_errors::FluxSession;
 use flux_middle::{
     core::{
-        AdtDef, AdtMap, BaseTy, BinOp, Constraint, EnumDef, Expr, ExprKind, FnSig, Ident, Index,
-        Indices, Lit, Name, Param, Qualifier, RefKind, Sort, StructDef, StructKind, Ty, UFDef,
-        UFun, VariantDef, VariantRet,
+        AdtDef, AdtMap, ArrayLen, BaseTy, BinOp, Constraint, EnumDef, Expr, ExprKind, FnSig, Ident,
+        Index, Indices, Lit, Name, Param, Qualifier, RefKind, Sort, StructDef, StructKind, Ty,
+        UFDef, UFun, VariantDef, VariantRet,
     },
     global_env::ConstInfo,
 };
@@ -280,17 +280,9 @@ impl<'a> DesugarCtxt<'a> {
                 let ty = self.desugar_ty(*ty)?;
                 Ty::Constr(pred, Box::new(ty))
             }
-            surface::TyKind::Array(ty, len) => {
-                let span = len.span;
-                let Lit::Int(len) = self.params.desugar_lit(len)? else {
-                    return Err(self.params.sess.emit_err(errors::InvalidArrayLen { span }))
-                };
-                let len: usize = len
-                    .try_into()
-                    .map_err(|_| self.params.sess.emit_err(errors::InvalidArrayLen { span }))?;
-
+            surface::TyKind::Array(ty, _) => {
                 let ty = self.desugar_ty(*ty)?;
-                Ty::Array(Box::new(ty), len)
+                Ty::Array(Box::new(ty), ArrayLen)
             }
             surface::TyKind::Slice(ty) => Ty::Slice(Box::new(self.desugar_ty(*ty)?)),
         };

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -97,10 +97,12 @@ pub enum Ty {
     Ref(RefKind, Box<Ty>),
     Param(ParamTy),
     Tuple(Vec<Ty>),
-    Array(Box<Ty>, usize),
+    Array(Box<Ty>, ArrayLen),
     Slice(Box<Ty>),
     Never,
 }
+
+pub struct ArrayLen;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub enum RefKind {
@@ -348,6 +350,12 @@ impl fmt::Debug for Ty {
             Ty::Array(ty, len) => write!(f, "[{ty:?}; {len:?}]"),
             Ty::Slice(ty) => write!(f, "[{ty:?}]"),
         }
+    }
+}
+
+impl fmt::Debug for ArrayLen {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "_")
     }
 }
 

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -2,7 +2,6 @@
 
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::TyCtxt;
 pub use rustc_middle::{
     mir::Mutability,
     ty::{FloatTy, IntTy, ParamTy, ScalarInt, UintTy},
@@ -67,20 +66,7 @@ pub enum TyKind {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Const {
-    pub ty: Ty,
-    pub kind: ConstKind,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ConstKind {
-    Value(ValTree),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ValTree {
-    Leaf(ScalarInt),
-}
+pub struct Const;
 
 #[derive(PartialEq, Eq, Hash)]
 pub enum GenericArg {
@@ -161,17 +147,6 @@ impl Ty {
     }
 }
 
-impl Const {
-    pub fn from_usize(tcx: TyCtxt, bits: u128) -> Self {
-        let size = tcx
-            .layout_of(rustc_middle::ty::ParamEnv::empty().and(tcx.types.usize))
-            .unwrap()
-            .size;
-        let scalar = ScalarInt::try_from_uint(bits, size).unwrap();
-        Const { ty: Ty::mk_usize(), kind: ConstKind::Value(ValTree::Leaf(scalar)) }
-    }
-}
-
 impl_internable!(TyS, [Ty], [GenericArg], [GenericParamDef]);
 
 impl std::fmt::Debug for GenericArg {
@@ -227,16 +202,6 @@ impl std::fmt::Debug for Ty {
 
 impl std::fmt::Debug for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind {
-            ConstKind::Value(val) => write!(f, "{val:?}"),
-        }
-    }
-}
-
-impl std::fmt::Debug for ValTree {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ValTree::Leaf(scalar) => write!(f, "{scalar:?}"),
-        }
+        write!(f, "_")
     }
 }

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -307,10 +307,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 let pred = conv_expr(pred, &self.name_map, nbinders);
                 ty::Ty::constr(pred, self.conv_ty(ty, nbinders))
             }
-            core::Ty::Array(ty, len) => {
-                let len = ty::Const::from_usize(self.genv.tcx, *len as u128);
-                ty::Ty::array(self.conv_ty(ty, nbinders), len)
-            }
+            core::Ty::Array(ty, _) => ty::Ty::array(self.conv_ty(ty, nbinders), ty::Const),
             core::Ty::Slice(ty) => ty::Ty::slice(self.conv_ty(ty, nbinders)),
         }
     }

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -70,7 +70,7 @@ pub fn parse_expr(tokens: TokenStream, span: Span) -> ParseResult<surface::Expr>
 }
 
 pub enum UserParseError {
-    UnsupportedLiteral(Location, Location),
+    UnexpectedToken(Location, Location),
 }
 
 type LalrpopError = lalrpop_util::ParseError<Location, Token, UserParseError>;
@@ -110,7 +110,7 @@ fn map_err(
 ) -> ParseError {
     match err {
         LalrpopError::InvalidToken { .. } => unreachable!(),
-        LalrpopError::User { error: UserParseError::UnsupportedLiteral(lo, hi) } => {
+        LalrpopError::User { error: UserParseError::UnexpectedToken(lo, hi) } => {
             ParseErrorKind::UnexpectedToken.into_error(offset, lo, hi, ctx, parent)
         }
         LalrpopError::UnrecognizedEOF { location, expected: _ } => {

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -140,9 +140,12 @@ pub enum TyKind<T = Ident> {
     Constr(Expr, Box<Ty<T>>),
     /// ()
     Unit,
-    Array(Box<Ty<T>>, Lit),
+    Array(Box<Ty<T>>, ArrayLen),
     Slice(Box<Ty<T>>),
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct ArrayLen;
 
 #[derive(Debug, Clone)]
 pub struct Indices {

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -127,7 +127,13 @@ TyKind: surface::TyKind = {
     <path:Path> "{" <bind:Ident> ":" <pred:Level1> "}" => surface::TyKind::Exists { <> },
     <path:Path> "[" <indices:Indices> "]"              => surface::TyKind::Indexed { <> },
 
-    "[" <ty:Ty> ";"  <len:Lit> "]" => surface::TyKind::Array(Box::new(ty), len),
+    "[" <ty:Ty> ";"  <lo:@L> <ident:Ident> <hi:@R> "]" =>? {
+        if ident.name.as_str() == "_" {
+            Ok(surface::TyKind::Array(Box::new(ty), surface::ArrayLen))
+        } else {
+            Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
+        }
+    },
     "[" <ty:Ty> "]" => surface::TyKind::Slice(Box::new(ty)),
     "[" <ty:Ty> "]""[" <indices:Indices> "]" => surface::TyKind::Slice(Box::new(ty)),
 

--- a/flux-tests/tests/neg/surface/array00.rs
+++ b/flux-tests/tests/neg/surface/array00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-#[flux::sig(fn() -> [i32{v : v > 0}; 2])]
+#[flux::sig(fn() -> [i32{v : v > 0}; _])]
 pub fn array00() -> [i32; 2] {
     [0, 1] //~ ERROR postcondition
 }

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -1,7 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-#[flux::sig(fn() -> [i32{v : v >= 0}; 2])]
+#[flux::sig(fn() -> [i32{v : v >= 0}; _])]
 pub fn array00() -> [i32; 2] {
     [0, 1]
+}
+
+pub fn read_u16() -> u16 {
+    let bytes: [u8; 2] = [10, 20];
+    const BASE_PRIMES: [u32; 11] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31];
+    u16::from_le_bytes(bytes)
 }

--- a/flux-tests/tests/pos/surface/array00.rs
+++ b/flux-tests/tests/pos/surface/array00.rs
@@ -8,6 +8,5 @@ pub fn array00() -> [i32; 2] {
 
 pub fn read_u16() -> u16 {
     let bytes: [u8; 2] = [10, 20];
-    const BASE_PRIMES: [u32; 11] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31];
     u16::from_le_bytes(bytes)
 }

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -618,7 +618,6 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                 self.check_call(rcx, env, src_info, sig, substs, args)
             }
             Rvalue::Aggregate(AggregateKind::Array(ty), args) => {
-                let len = Const::from_usize(self.genv.tcx, args.len() as u128);
                 let args = args
                     .iter()
                     .map(|op| self.check_operand(rcx, env, src_info, op))
@@ -630,7 +629,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                 for arg in args {
                     gen.subtyping(rcx, &arg, &ty);
                 }
-                Ok(Ty::array(ty, len))
+                Ok(Ty::array(ty, Const))
             }
             Rvalue::Discriminant(place) => Ok(Ty::discr(place.clone())),
             Rvalue::Len(_) => Ok(Ty::usize()),

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -295,7 +295,7 @@ fn bty_subtyping(
         }
         (BaseTy::Bool, BaseTy::Bool) | (BaseTy::Str, BaseTy::Str) => {}
         (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
-            assert_eq!(len1, len2);
+            debug_assert_eq!(len1, len2);
             subtyping(genv, constr, ty1, ty2, tag);
         }
         (BaseTy::Slice(ty1), BaseTy::Slice(ty2)) => {


### PR DESCRIPTION
The previous implementation tried to lower the array len into flux for the cases where it was explicitly an integer, this prevented calling functions like `u16::from_le_bytes` that use a more complex const expression. Since we weren't taking advantage of the length for refinements there wasn't much use in trying to keep track of the length. This PR treats array lengths opaquely (assuming rustc made all the necessary checks on the lengths for array subtyping). Thus, we can now use `u16::from_le_bytes` partially addressing https://github.com/liquid-rust/flux/issues/142 (we still don't have support for array indexing nor support array constants).