### PR TITLE
Revamp of desugaring code

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -595,7 +595,7 @@ impl<'a> ParamsCtxt<'a> {
 
         if is_param {
             for (name, sort) in iter::zip(binder.names(), sorts) {
-                self.params.push(param_from_bind(bind, name, *sort));
+                self.params.push(param_from_ident(bind, name, *sort));
             }
         }
         Ok(self.binders.insert(bind.name, binder))
@@ -605,7 +605,7 @@ impl<'a> ParamsCtxt<'a> {
         let name = self.fresh();
         self.binders.insert(bind.name, Binder::Single(name, sort));
         if push_param {
-            self.params.push(param_from_bind(bind, name, sort))
+            self.params.push(param_from_ident(bind, name, sort))
         }
     }
 
@@ -681,26 +681,15 @@ impl<'a> ParamsCtxt<'a> {
         }
     }
 
-    fn desugar_uf(&self, f: surface::Ident) -> flux_middle::core::UFun {
-        UFun { symbol: f.name, span: f.span }
-    }
-
     fn as_expr_ctxt(&self) -> ExprCtxt {
         ExprCtxt { sess: self.sess, const_map: &self.const_map, binders: &self.binders }
     }
 }
 
-fn param_from_bind(bind: surface::Ident, name: Name, sort: Sort) -> Param {
-    let source_info = (bind.span, bind.name);
+fn param_from_ident(ident: surface::Ident, name: Name, sort: Sort) -> Param {
+    let source_info = (ident.span, ident.name);
     let name = Ident { name, source_info };
     Param { name, sort }
-}
-
-fn fields<'a>(adt_sorts: &'a AdtMap, path: &surface::Path<Res>) -> Option<&'a [Symbol]> {
-    match path.ident {
-        Res::Adt(def_id) => Some(adt_sorts.get_fields(def_id).unwrap_or_default()),
-        _ => None,
-    }
 }
 
 fn sorts<'a>(

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -213,9 +213,11 @@ enum Binder {
     /// or by explicitly listing the indices for a type with multiple indices, e.g,
     /// `RMat[@row, @cols]`.
     Single(Name, Sort),
-    /// A binder that will desugar into multiple indices and can be "projected" using
-    /// dot syntax. They come from binders to user defined types with `#[refined_by]`
-    /// annotation, e.g., `mat: RMat` or `RMat[@mat]`.
+    /// A binder that will desugar into multiple indices and must be "projected" using
+    /// dot syntax. They come from binders to user defined types with a `#[refined_by]`
+    /// annotation, e.g., `mat: RMat` or `RMat[@mat]`. User defined types with a single
+    /// index are treated especially as they can be used either with a projection or the
+    /// binder directly.
     Aggregate(FxIndexMap<Symbol, (Name, Sort)>),
     /// A binder to an unrefined type (a type that cannot be refined). We try to catch this
     /// situation "eagerly" as it will often result in better error messages, e.g., we will

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -601,7 +601,7 @@ impl<'a> ParamsCtxt<'a> {
         path: &Path<Res>,
         f: impl FnOnce(&mut Self) -> Result<R, ErrorGuaranteed>,
         adt_sorts: &AdtMap,
-    ) -> Result<(Vec<Ident>, R), ErrorGuaranteed> {
+    ) -> Result<(Vec<Name>, R), ErrorGuaranteed> {
         match self.fresh_bind_idents(bind, path, adt_sorts)? {
             FreshIdents::Single(param) => {
                 let symb = bind.name;
@@ -612,7 +612,7 @@ impl<'a> ParamsCtxt<'a> {
                 } else {
                     self.name_map.remove(&symb);
                 };
-                let binders = vec![param.name];
+                let binders = vec![param.name.name];
                 Ok((binders, r))
             }
             FreshIdents::Dot(params) => {
@@ -620,7 +620,7 @@ impl<'a> ParamsCtxt<'a> {
                     self.field_map.insert((bind.name, *fld), param.name.name);
                 }
                 let r = f(self)?;
-                let binders = params.iter().map(|(_, p)| p.name).collect();
+                let binders = params.iter().map(|(_, p)| p.name.name).collect();
                 Ok((binders, r))
             }
         }

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(min_specialization)]
 #![feature(box_patterns, once_cell)]
 
+extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -24,9 +24,6 @@ desugar_refined_type_param =
     type parameters cannot be refined
     .label = this type parameter has a refinement
 
-desugar_invalid_array_len =
-    unsupported or invalid array length
-
 desugar_invalid_dot_var =
     unsupported field access in refinement
 
@@ -39,3 +36,6 @@ desugar_param_count_mismatch =
         *[other] {$found} were found
     }
     .label = expected {$expected} arguments, found {$found}
+
+desugar_invalid_dot_access =
+    the field `{$fld}` is not valid for param `{$ident}`

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -39,3 +39,7 @@ desugar_param_count_mismatch =
 
 desugar_invalid_dot_access =
     the field `{$fld}` is not valid for param `{$ident}`
+
+desugar_invalid_unrefined_param =
+    invalid use of parameter for an unrefined type
+    .label = name `{$var}` is bound to an unrefined type

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -20,15 +20,8 @@ desugar_int_too_large =
 desugar_unexpected_literal =
     unexpected literal
 
-desugar_refined_type_param =
-    type parameters cannot be refined
-    .label = this type parameter has a refinement
-
 desugar_invalid_dot_var =
     unsupported field access in refinement
-
-desugar_unresolved_dot_field =
-    cannot find `{$ident}.{$field}` in this scope
 
 desugar_param_count_mismatch =
     this type takes {$expected} refinement parameters but {$found ->

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -88,7 +88,7 @@ pub enum Ty {
     /// Existential types in core are represented with an explicit list of binders for
     /// every index of the [`BaseTy`], e.g., `i32{v : v > 0}` for one index and `RMat{v0,v1 : v0 == v1}`.
     /// for two indices. (there's currently no equivalent surface syntax).
-    Exists(BaseTy, Vec<Ident>, Expr),
+    Exists(BaseTy, Vec<Name>, Expr),
     /// Constrained types `{T : p}` are like existentials but without binders, and are useful
     /// for specifying constraints on indexed values e.g. `{i32[@a] | 0 <= a}`
     Constr(Expr, Box<Ty>),

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -16,6 +16,8 @@ pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, UintTy};
 use rustc_span::{Span, Symbol, DUMMY_SP};
 pub use rustc_target::abi::VariantIdx;
 
+use crate::pretty;
+
 #[derive(Debug)]
 pub struct StructDef {
     pub def_id: DefId,
@@ -370,7 +372,7 @@ fn fmt_bty(bty: &BaseTy, e: Option<&Indices>, f: &mut fmt::Formatter<'_>) -> fmt
         BaseTy::Int(int_ty) => write!(f, "{}", int_ty.name_str())?,
         BaseTy::Uint(uint_ty) => write!(f, "{}", uint_ty.name_str())?,
         BaseTy::Bool => write!(f, "bool")?,
-        BaseTy::Adt(did, _) => write!(f, "{did:?}")?,
+        BaseTy::Adt(did, _) => write!(f, "{}", pretty::def_id_to_string(*did))?,
     }
     match bty {
         BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Bool => {

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -53,16 +53,16 @@ impl NameMap {
 
     fn with_binders<R>(
         &mut self,
-        binders: &[core::Ident],
+        binders: &[core::Name],
         nbinders: u32,
         f: impl FnOnce(&mut Self, u32) -> R,
     ) -> R {
         for (index, binder) in binders.iter().enumerate() {
-            self.insert(binder.name, Entry::Bound { index, level: nbinders });
+            self.insert(*binder, Entry::Bound { index, level: nbinders });
         }
         let r = f(self, nbinders + 1);
         for binder in binders {
-            self.map.remove(&binder.name);
+            self.map.remove(binder);
         }
         r
     }

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -12,11 +12,6 @@ pub fn mk_chair() -> Chair {
     Chair { x: 0 }
 }
 
-#[flux::sig(fn(c:Chair) -> i32)] //~ ERROR this type takes 0 refinement parameters but 1 was found
-pub fn use_chair(c: Chair) -> i32 {
-    c.x
-}
-
 #[flux::refined_by(x:int, y:int)]
 pub struct Pair {
     #[flux::field(i32[@x])]
@@ -48,4 +43,24 @@ pub fn myint1(x: i32) -> i32 {
 #[flux::sig(fn(i32) -> i32[@n])] //~ ERROR cannot find
 pub fn myint2(x: i32) -> i32 {
     x
+}
+
+#[flux::sig(fn(f: f32) -> i32[f])] //~ ERROR invalid use of parameter
+fn ipa(f: f32) -> i32 {
+    0
+}
+
+#[flux::sig(fn(f: f32) -> i32[f.x])] //~ ERROR invalid use of parameter
+fn ris(f: f32) -> i32 {
+    0
+}
+
+#[flux::sig(fn(c: Chair) -> i32[c.a])] //~ ERROR invalid use of parameter
+pub fn use_chair(c: Chair) -> i32 {
+    c.x
+}
+
+#[flux::sig(fn(f: &mut f32[@x]) -> i32[f])] //~ ERROR this type takes 0 refinement parameters
+fn dipa(f: &mut f32) -> i32 {
+    0
 }

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -34,3 +34,21 @@ pub fn mytuple1(p: Pair) -> i32 {
 pub fn mytuple2(p: Pair) -> i32 {
     p.x
 }
+
+#[flux::sig(fn(Pair[@p1]) -> i32[p.x])] //~ ERROR cannot find value
+pub fn mytuple3(p: Pair) -> i32 {
+    p.x
+}
+
+#[flux::sig(fn(i32[@n]) -> i32[n.x])] //~ ERROR the field `x` is not valid
+pub fn myint1(x: i32) -> i32 {
+    x
+}
+
+#[flux::sig(fn(i32) -> i32[@n])] //~ ERROR cannot find
+pub fn myint2(x: i32) -> i32 {
+    x
+}
+
+#[flux::sig(fn(x: i32, x: i32) -> i32[x + y])]
+pub fn foo() {}

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -64,3 +64,11 @@ pub fn use_chair(c: Chair) -> i32 {
 fn dipa(f: &mut f32) -> i32 {
     0
 }
+
+#[flux::sig(fn(f32{v : v > 0}) -> i32[0])] //~ ERROR this type takes 0 refinement parameters
+fn ira(f: f32) -> i32 {
+    0
+}
+
+#[flux::sig(fn(x: i32, i32[@x]))] //~ ERROR the name `x` is already used
+fn stout(x: i32, y: i32) {}

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -12,7 +12,7 @@ pub fn mk_chair() -> Chair {
     Chair { x: 0 }
 }
 
-#[flux::sig(fn (c:Chair) -> i32)] //~ ERROR this type takes 0 refinement parameters but 1 was found
+#[flux::sig(fn(c:Chair) -> i32)] //~ ERROR this type takes 0 refinement parameters but 1 was found
 pub fn use_chair(c: Chair) -> i32 {
     c.x
 }
@@ -49,6 +49,3 @@ pub fn myint1(x: i32) -> i32 {
 pub fn myint2(x: i32) -> i32 {
     x
 }
-
-#[flux::sig(fn(x: i32, x: i32) -> i32[x + y])]
-pub fn foo() {}

--- a/flux-tests/tests/pos/structs/dot00.rs
+++ b/flux-tests/tests/pos/structs/dot00.rs
@@ -9,16 +9,16 @@ pub struct Pair {
     pub y: i32,
 }
 
-// // forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0 + a1 + 1>
-// #[flux::sig(fn(Pair[@p]) -> i32[p.x + p.y + 1])]
-// pub fn sum_pair(p: Pair) -> i32 {
-//     p.x + p.y + 1
-// }
+// forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0 + a1 + 1>
+#[flux::sig(fn(Pair[@p]) -> i32[p.x + p.y + 1])]
+pub fn sum_pair(p: Pair) -> i32 {
+    p.x + p.y + 1
+}
 
-// #[flux::sig(fn (p:Pair) -> i32[p.x + p.y])]
-// pub fn sum_pair2(p: Pair) -> i32 {
-//     p.x + p.y
-// }
+#[flux::sig(fn (p:Pair) -> i32[p.x + p.y])]
+pub fn sum_pair2(p: Pair) -> i32 {
+    p.x + p.y
+}
 
 // forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0>
 #[flux::sig(fn(p: Pair) -> i32[p.x])]
@@ -26,32 +26,32 @@ pub fn fst(p: Pair) -> i32 {
     p.x
 }
 
-// // forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair<a, b>
-// #[flux::sig(fn(a: i32, b: i32) -> Pair[a, b])]
-// pub fn mk_pair1(a: i32, b: i32) -> Pair {
-//     Pair { x: a, y: b }
-// }
+// forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair<a, b>
+#[flux::sig(fn(a: i32, b: i32) -> Pair[a, b])]
+pub fn mk_pair1(a: i32, b: i32) -> Pair {
+    Pair { x: a, y: b }
+}
 
-// // forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair{v0 v1: v0 == a && v1 == b}
-// #[flux::sig(fn(a: i32, b: i32) -> Pair {v : v.x == a && v.y == b})]
-// pub fn mk_pair2(a: i32, b: i32) -> Pair {
-//     Pair { x: a, y: b }
-// }
+// forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair{v0 v1: v0 == a && v1 == b}
+#[flux::sig(fn(a: i32, b: i32) -> Pair {v : v.x == a && v.y == b})]
+pub fn mk_pair2(a: i32, b: i32) -> Pair {
+    Pair { x: a, y: b }
+}
 
-// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a}
-// #[flux::sig(fn(a: i32) -> Pair{v : v.x == a})]
-// pub fn mk_pair_with_first(a: i32) -> Pair {
-//     Pair { x: a, y: 0 }
-// }
+// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a}
+#[flux::sig(fn(a: i32) -> Pair{v : v.x == a})]
+pub fn mk_pair_with_first(a: i32) -> Pair {
+    Pair { x: a, y: 0 }
+}
 
-// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a && v1 > 0}
-// #[flux::sig(fn(a: i32) -> Pair{v : v.x == a && v.y > 0})]
-// pub fn mk_pair_with_pos(a: i32) -> Pair {
-//     Pair { x: a, y: 10 }
-// }
+// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a && v1 > 0}
+#[flux::sig(fn(a: i32) -> Pair{v : v.x == a && v.y > 0})]
+pub fn mk_pair_with_pos(a: i32) -> Pair {
+    Pair { x: a, y: 10 }
+}
 
-// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 + v1 <= a}
-// #[flux::sig(fn(a: i32) -> Pair{v : v.x + v.y <= a })]
-// pub fn mk_pair_with_bound(a: i32) -> Pair {
-//     Pair { x: a, y: 0 }
-// }
+// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 + v1 <= a}
+#[flux::sig(fn(a: i32) -> Pair{v : v.x + v.y <= a })]
+pub fn mk_pair_with_bound(a: i32) -> Pair {
+    Pair { x: a, y: 0 }
+}

--- a/flux-tests/tests/pos/structs/dot00.rs
+++ b/flux-tests/tests/pos/structs/dot00.rs
@@ -9,49 +9,49 @@ pub struct Pair {
     pub y: i32,
 }
 
-// forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0 + a1>
-#[flux::sig(fn (Pair[@p]) -> i32[p.x + p.y + 1])]
-pub fn sum_pair(p: Pair) -> i32 {
-    p.x + p.y + 1
-}
+// // forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0 + a1 + 1>
+// #[flux::sig(fn(Pair[@p]) -> i32[p.x + p.y + 1])]
+// pub fn sum_pair(p: Pair) -> i32 {
+//     p.x + p.y + 1
+// }
 
-#[flux::sig(fn (p:Pair) -> i32[p.x + p.y])]
-pub fn sum_pair2(p: Pair) -> i32 {
-    p.x + p.y
-}
+// #[flux::sig(fn (p:Pair) -> i32[p.x + p.y])]
+// pub fn sum_pair2(p: Pair) -> i32 {
+//     p.x + p.y
+// }
 
 // forall a0: int, a1: int. fn(Pair<a0, a1>) -> i32<a0>
-#[flux::sig(fn (p: Pair) -> i32[p.x])]
+#[flux::sig(fn(p: Pair) -> i32[p.x])]
 pub fn fst(p: Pair) -> i32 {
     p.x
 }
 
-// forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair<a, b>
-#[flux::sig(fn (a: i32, b: i32) -> Pair[a, b])]
-pub fn mk_pair1(a: i32, b: i32) -> Pair {
-    Pair { x: a, y: b }
-}
+// // forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair<a, b>
+// #[flux::sig(fn(a: i32, b: i32) -> Pair[a, b])]
+// pub fn mk_pair1(a: i32, b: i32) -> Pair {
+//     Pair { x: a, y: b }
+// }
 
-// forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair{v0 v1: v0 == a && v1 == b}
-#[flux::sig(fn (a: i32, b: i32) -> Pair {v : v.x == a && v.y == b})]
-pub fn mk_pair2(a: i32, b: i32) -> Pair {
-    Pair { x: a, y: b }
-}
+// // forall a: int, b: int. fn(i32<a>, i32<b>) -> Pair{v0 v1: v0 == a && v1 == b}
+// #[flux::sig(fn(a: i32, b: i32) -> Pair {v : v.x == a && v.y == b})]
+// pub fn mk_pair2(a: i32, b: i32) -> Pair {
+//     Pair { x: a, y: b }
+// }
 
-// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a}
-#[flux::sig(fn (a: i32) -> Pair{v : v.x == a})]
-pub fn mk_pair_with_first(a: i32) -> Pair {
-    Pair { x: a, y: 0 }
-}
+// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a}
+// #[flux::sig(fn(a: i32) -> Pair{v : v.x == a})]
+// pub fn mk_pair_with_first(a: i32) -> Pair {
+//     Pair { x: a, y: 0 }
+// }
 
-// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a && v1 > 0}
-#[flux::sig(fn (a: i32) -> Pair{v : v.x == a && v.y > 0})]
-pub fn mk_pair_with_pos(a: i32) -> Pair {
-    Pair { x: a, y: 10 }
-}
+// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 == a && v1 > 0}
+// #[flux::sig(fn(a: i32) -> Pair{v : v.x == a && v.y > 0})]
+// pub fn mk_pair_with_pos(a: i32) -> Pair {
+//     Pair { x: a, y: 10 }
+// }
 
-// forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 + v1 <= a}
-#[flux::sig(fn (a: i32) -> Pair{v : v.x + v.y <= a })]
-pub fn mk_pair_with_bound(a: i32) -> Pair {
-    Pair { x: a, y: 0 }
-}
+// // forall a: int. fn(i32<a>) -> Pair{v0, v1 : v0 + v1 <= a}
+// #[flux::sig(fn(a: i32) -> Pair{v : v.x + v.y <= a })]
+// pub fn mk_pair_with_bound(a: i32) -> Pair {
+//     Pair { x: a, y: 0 }
+// }

--- a/flux-tests/tests/pos/surface/rmat.rs
+++ b/flux-tests/tests/pos/surface/rmat.rs
@@ -15,25 +15,25 @@ pub struct RMat {
 }
 
 impl RMat {
-    // #[flux::sig(fn(rows: usize, cols: usize, f32) -> RMat[rows, cols])]
-    // pub fn new(rows: usize, cols: usize, elem: f32) -> RMat {
-    //     let mut inner = RVec::new();
-    //     let mut i = 0;
-    //     while i < rows {
-    //         let r = RVec::from_elem_n(elem, cols);
-    //         inner.push(r);
-    //         i += 1;
-    //     }
-    //     Self { cols, inner }
-    // }
+    #[flux::sig(fn(rows: usize, cols: usize, f32) -> RMat[rows, cols])]
+    pub fn new(rows: usize, cols: usize, elem: f32) -> RMat {
+        let mut inner = RVec::new();
+        let mut i = 0;
+        while i < rows {
+            let r = RVec::from_elem_n(elem, cols);
+            inner.push(r);
+            i += 1;
+        }
+        Self { cols, inner }
+    }
 
     #[flux::sig(fn(&RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &f32)]
     pub fn get(&self, i: usize, j: usize) -> &f32 {
         &self.inner.get(i).get(j)
     }
 
-    // #[flux::sig(fn(&mut RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &mut f32)]
-    // pub fn get_mut(&mut self, i: usize, j: usize) -> &mut f32 {
-    //     self.inner.get_mut(i).get_mut(j)
-    // }
+    #[flux::sig(fn(&mut RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &mut f32)]
+    pub fn get_mut(&mut self, i: usize, j: usize) -> &mut f32 {
+        self.inner.get_mut(i).get_mut(j)
+    }
 }

--- a/flux-tests/tests/pos/surface/rmat.rs
+++ b/flux-tests/tests/pos/surface/rmat.rs
@@ -15,25 +15,25 @@ pub struct RMat {
 }
 
 impl RMat {
-    #[flux::sig(fn(rows: usize, cols: usize, f32) -> RMat[rows, cols])]
-    pub fn new(rows: usize, cols: usize, elem: f32) -> RMat {
-        let mut inner = RVec::new();
-        let mut i = 0;
-        while i < rows {
-            let r = RVec::from_elem_n(elem, cols);
-            inner.push(r);
-            i += 1;
-        }
-        Self { cols, inner }
-    }
+    // #[flux::sig(fn(rows: usize, cols: usize, f32) -> RMat[rows, cols])]
+    // pub fn new(rows: usize, cols: usize, elem: f32) -> RMat {
+    //     let mut inner = RVec::new();
+    //     let mut i = 0;
+    //     while i < rows {
+    //         let r = RVec::from_elem_n(elem, cols);
+    //         inner.push(r);
+    //         i += 1;
+    //     }
+    //     Self { cols, inner }
+    // }
 
     #[flux::sig(fn(&RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &f32)]
     pub fn get(&self, i: usize, j: usize) -> &f32 {
         &self.inner.get(i).get(j)
     }
 
-    #[flux::sig(fn(&mut RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &mut f32)]
-    pub fn get_mut(&mut self, i: usize, j: usize) -> &mut f32 {
-        self.inner.get_mut(i).get_mut(j)
-    }
+    // #[flux::sig(fn(&mut RMat[@m, @n], usize{v: v < m}, usize{v: v < n}) -> &mut f32)]
+    // pub fn get_mut(&mut self, i: usize, j: usize) -> &mut f32 {
+    //     self.inner.get_mut(i).get_mut(j)
+    // }
 }

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -27,17 +27,17 @@ impl Env {
 
     fn with_binders<R>(
         &mut self,
-        binders: &[core::Ident],
+        binders: &[core::Name],
         sorts: &[ty::Sort],
         f: impl FnOnce(&Self) -> R,
     ) -> R {
         debug_assert_eq!(binders.len(), sorts.len());
         for (binder, sort) in iter::zip(binders, sorts) {
-            self.sorts.insert(binder.name, sort.clone());
+            self.sorts.insert(*binder, sort.clone());
         }
         let r = f(self);
         for binder in binders {
-            self.sorts.remove(&binder.name);
+            self.sorts.remove(binder);
         }
         r
     }


### PR DESCRIPTION
Major refactor of the desugaring code. The main observable change is that after this PR we accept argument syntax for more types, e.g., previously the following code wasn't accepted as `f32` wasn't considered a refined type, thus it couldn't be bound to a name.

```rust
#[flux::sig(fn(f: f32) -> f32 )]
fn foo(f: f32) -> f32 {
    f + 1
}
```

We now accept the code, keep track of the binder, and report an error if used in any way.