### PR TITLE
Various fixes

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -322,12 +322,6 @@ impl<'a> DesugarCtxt<'a> {
             surface::TyKind::Ref(rk, ty) => {
                 Ty::Ref(desugar_ref_kind(rk), Box::new(self.desugar_ty(*ty)?))
             }
-            surface::TyKind::StrgRef(loc, ty) => {
-                let loc = self.binders.as_expr_ctxt().desugar_loc(loc)?;
-                let ty = self.desugar_ty(*ty)?;
-                self.requires.push(Constraint::Type(loc, ty));
-                Ty::Ptr(loc)
-            }
             surface::TyKind::Unit => Ty::Tuple(vec![]),
             surface::TyKind::Constr(pred, ty) => {
                 let pred = self.binders.as_expr_ctxt().desugar_expr(pred)?;
@@ -408,9 +402,6 @@ impl<'a> DesugarCtxt<'a> {
             }
             Res::Float(float_ty) => BtyOrTy::Ty(Ty::Float(float_ty)),
             Res::Param(param_ty) => BtyOrTy::Ty(Ty::Param(param_ty)),
-            Res::Tuple => {
-                todo!("support for tuples")
-            }
         };
         Ok(bty)
     }
@@ -691,8 +682,7 @@ impl<'a> Binders<'a> {
                 }
                 Ok(())
             }
-            surface::TyKind::StrgRef(_, ty)
-            | surface::TyKind::Ref(_, ty)
+            surface::TyKind::Ref(_, ty)
             | surface::TyKind::Array(ty, _)
             | surface::TyKind::Slice(ty)
             | surface::TyKind::Constr(_, ty) => self.ty_gather_params(ty, adt_map),
@@ -738,7 +728,7 @@ fn sorts<'a>(adt_sorts: &'a AdtMap, path: &surface::Path<Res>) -> &'a [Sort] {
         Res::Bool => &[Sort::Bool],
         Res::Int(_) | Res::Uint(_) => &[Sort::Int],
         Res::Adt(def_id) => adt_sorts.get_sorts(def_id).unwrap_or_default(),
-        Res::Float(_) | Res::Param(_) | Res::Tuple => &[],
+        Res::Float(_) | Res::Param(_) => &[],
     }
 }
 
@@ -778,7 +768,7 @@ impl Binder {
                     Binder::Aggregate(fields)
                 }
             }
-            Res::Float(_) | Res::Param(_) | Res::Tuple => Binder::Unrefined,
+            Res::Float(_) | Res::Param(_) => Binder::Unrefined,
         }
     }
 

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -402,6 +402,7 @@ impl<'a> DesugarCtxt<'a> {
             }
             Res::Float(float_ty) => BtyOrTy::Ty(Ty::Float(float_ty)),
             Res::Param(param_ty) => BtyOrTy::Ty(Ty::Param(param_ty)),
+            Res::Str => BtyOrTy::Ty(Ty::Str),
         };
         Ok(bty)
     }
@@ -728,7 +729,7 @@ fn sorts<'a>(adt_sorts: &'a AdtMap, path: &surface::Path<Res>) -> &'a [Sort] {
         Res::Bool => &[Sort::Bool],
         Res::Int(_) | Res::Uint(_) => &[Sort::Int],
         Res::Adt(def_id) => adt_sorts.get_sorts(def_id).unwrap_or_default(),
-        Res::Float(_) | Res::Param(_) => &[],
+        Res::Float(_) | Res::Param(_) | Res::Str => &[],
     }
 }
 
@@ -768,7 +769,7 @@ impl Binder {
                     Binder::Aggregate(fields)
                 }
             }
-            Res::Float(_) | Res::Param(_) => Binder::Unrefined,
+            Res::Float(_) | Res::Param(_) | Res::Str => Binder::Unrefined,
         }
     }
 

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -44,7 +44,7 @@ pub fn desugar_enum_def(
     let rust_adt_def = genv.tcx.adt_def(def_id.to_def_id());
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
     let rust_enum_def = rustc::lowering::lower_enum_def(genv.tcx, rust_adt_def)?;
-    let enum_def = zip_resolver::ZipResolver::new(genv.tcx, genv.sess, &resolver)
+    let enum_def = zip_resolver::ZipResolver::new(genv.sess, &resolver)
         .zip_enum_def(enum_def, &rust_enum_def)?;
     desugar::desugar_enum_def(genv.sess, &genv.consts, adt_sorts, enum_def)
 }
@@ -59,8 +59,7 @@ pub fn desugar_fn_sig(
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
     let span = genv.tcx.def_span(def_id.to_def_id());
     let rust_sig = rustc::lowering::lower_fn_sig(genv.tcx, rust_fn_sig, span)?;
-    let sig = zip_resolver::ZipResolver::new(genv.tcx, genv.sess, &resolver)
-        .zip_fn_sig(fn_sig, &rust_sig)?;
+    let sig = zip_resolver::ZipResolver::new(genv.sess, &resolver).zip_fn_sig(fn_sig, &rust_sig)?;
     desugar::desugar_fn_sig(genv.sess, sorts, &genv.consts, sig)
 }
 

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -44,7 +44,7 @@ pub fn desugar_enum_def(
     let rust_adt_def = genv.tcx.adt_def(def_id.to_def_id());
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
     let rust_enum_def = rustc::lowering::lower_enum_def(genv.tcx, rust_adt_def)?;
-    let enum_def = zip_resolver::ZipResolver::new(genv.sess, &resolver)
+    let enum_def = zip_resolver::ZipResolver::new(genv.tcx, genv.sess, &resolver)
         .zip_enum_def(enum_def, &rust_enum_def)?;
     desugar::desugar_enum_def(genv.sess, &genv.consts, adt_sorts, enum_def)
 }
@@ -59,7 +59,8 @@ pub fn desugar_fn_sig(
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
     let span = genv.tcx.def_span(def_id.to_def_id());
     let rust_sig = rustc::lowering::lower_fn_sig(genv.tcx, rust_fn_sig, span)?;
-    let sig = zip_resolver::ZipResolver::new(genv.sess, &resolver).zip_fn_sig(fn_sig, &rust_sig)?;
+    let sig = zip_resolver::ZipResolver::new(genv.tcx, genv.sess, &resolver)
+        .zip_fn_sig(fn_sig, &rust_sig)?;
     desugar::desugar_fn_sig(genv.sess, sorts, &genv.consts, sig)
 }
 

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -145,10 +145,6 @@ impl<'genv, 'tcx> Resolver<'genv, 'tcx> {
                 let path = self.resolve_path(path)?;
                 surface::TyKind::Exists { bind, path, pred }
             }
-            surface::TyKind::StrgRef(loc, ty) => {
-                let ty = self.resolve_ty(*ty)?;
-                surface::TyKind::StrgRef(loc, Box::new(ty))
-            }
             surface::TyKind::Ref(rk, ty) => {
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Ref(rk, Box::new(ty))
@@ -456,10 +452,8 @@ impl<'genv, 'tcx> NameResTable<'genv, 'tcx> {
 
 pub mod errors {
     use flux_macros::Diagnostic;
-    use flux_middle::rustc::ty::Mutability;
-    use flux_syntax::surface::{self, RefKind, Res};
-    use rustc_hir::def_id::DefId;
-    use rustc_middle::ty::TyCtxt;
+    use flux_middle::rustc::ty::{self as rustc_ty, Mutability};
+    use flux_syntax::surface::{self, RefKind};
     use rustc_span::{symbol::Ident, Span};
 
     #[derive(Diagnostic)]
@@ -531,16 +525,17 @@ pub mod errors {
 
     #[derive(Diagnostic)]
     #[diag(resolver::mismatched_type, code = "FLUX")]
-    pub struct MismatchedType {
+    pub struct TypeMismatch {
         #[primary_span]
+        #[label]
         pub span: Span,
         pub rust_type: String,
         pub flux_type: Ident,
     }
 
-    impl MismatchedType {
-        pub fn new(tcx: TyCtxt, rust_res: Res, flux_type: Ident) -> Self {
-            let rust_type = print_res(tcx, rust_res);
+    impl TypeMismatch {
+        pub fn new(rust_ty: &rustc_ty::Ty, flux_type: Ident) -> Self {
+            let rust_type = format!("{rust_ty:?}");
             Self { span: flux_type.span, rust_type, flux_type }
         }
     }
@@ -576,22 +571,5 @@ pub mod errors {
                 },
             }
         }
-    }
-
-    fn print_res(tcx: TyCtxt, res: Res) -> String {
-        match res {
-            Res::Bool => "bool".to_string(),
-            Res::Int(int_ty) => int_ty.name_str().to_string(),
-            Res::Uint(uint_ty) => uint_ty.name_str().to_string(),
-            Res::Float(float_ty) => float_ty.name_str().to_string(),
-            Res::Adt(def_id) => print_def_id(tcx, def_id),
-            Res::Param(_) => todo!(),
-            Res::Tuple => "()".to_string(),
-        }
-    }
-
-    fn print_def_id(tcx: TyCtxt, def_id: DefId) -> String {
-        let crate_name = tcx.crate_name(def_id.krate);
-        format!("{crate_name}{}", tcx.def_path(def_id).to_string_no_crate_verbose())
     }
 }

--- a/flux-errors/locales/en-US/resolver.ftl
+++ b/flux-errors/locales/en-US/resolver.ftl
@@ -15,7 +15,8 @@ resolver_mismatched_fields =
     field count mismatch in flux signature: rust signature has {$rust_fields} but flux signature has {$flux_fields}
 
 resolver_mismatched_type =
-    type mismatch in flux signature: expected `{$rust_type}` but saw `{$flux_type}`
+    type mismatch in flux signature
+    .label =  expected `{$rust_type}`, found `{$flux_type}`
 
 resolver_mutability_mismatch =
     mutability mismatch in flux signature: rust signature has a `{$rust_ref}` reference but flux signature has a `{$flux_ref}` reference

--- a/flux-middle/src/core.rs
+++ b/flux-middle/src/core.rs
@@ -95,6 +95,7 @@ pub enum Ty {
     /// for specifying constraints on indexed values e.g. `{i32[@a] | 0 <= a}`
     Constr(Expr, Box<Ty>),
     Float(FloatTy),
+    Str,
     Ptr(Ident),
     Ref(RefKind, Box<Ty>),
     Param(ParamTy),
@@ -351,6 +352,7 @@ impl fmt::Debug for Ty {
             Ty::Constr(pred, ty) => write!(f, "{{{ty:?} : {pred:?}}}"),
             Ty::Array(ty, len) => write!(f, "[{ty:?}; {len:?}]"),
             Ty::Slice(ty) => write!(f, "[{ty:?}]"),
+            Ty::Str => write!(f, "str"),
         }
     }
 }

--- a/flux-middle/src/ty/conv.rs
+++ b/flux-middle/src/ty/conv.rs
@@ -309,6 +309,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             core::Ty::Array(ty, _) => ty::Ty::array(self.conv_ty(ty, nbinders), ty::Const),
             core::Ty::Slice(ty) => ty::Ty::slice(self.conv_ty(ty, nbinders)),
+            core::Ty::Str => ty::Ty::str(),
         }
     }
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -134,8 +134,6 @@ pub enum TyKind<T = Ident> {
     },
     /// Mutable or shared reference
     Ref(RefKind, Box<Ty<T>>),
-    /// Strong reference, &strg<self: i32>
-    StrgRef(Ident, Box<Ty<T>>),
     /// Constrained type: an exists without binder
     Constr(Expr, Box<Ty<T>>),
     /// ()
@@ -177,7 +175,6 @@ pub enum Res {
     Float(FloatTy),
     Adt(DefId),
     Param(ParamTy),
-    Tuple,
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
@@ -427,7 +424,6 @@ pub mod expand {
                 }
             }
             TyKind::Ref(rk, t) => TyKind::Ref(*rk, Box::new(expand_ty(aliases, t))),
-            TyKind::StrgRef(rk, t) => TyKind::StrgRef(*rk, Box::new(expand_ty(aliases, t))),
             TyKind::Unit => TyKind::Unit,
             TyKind::Constr(pred, t) => {
                 TyKind::Constr(pred.clone(), Box::new(expand_ty(aliases, t)))
@@ -556,7 +552,6 @@ pub mod expand {
                 }
             }
             TyKind::Ref(rk, t) => TyKind::Ref(*rk, Box::new(subst_ty(subst, t))),
-            TyKind::StrgRef(rk, t) => TyKind::StrgRef(*rk, Box::new(subst_ty(subst, t))),
             TyKind::Unit => TyKind::Unit,
             TyKind::Constr(pred, t) => {
                 TyKind::Constr(subst_expr(subst, pred), Box::new(subst_ty(subst, t)))

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -174,6 +174,7 @@ pub enum Res {
     Uint(UintTy),
     Float(FloatTy),
     Adt(DefId),
+    Str,
     Param(ParamTy),
 }
 

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -116,8 +116,6 @@ pub Ty: surface::Ty = {
 }
 
 TyKind: surface::TyKind = {
-    "&" "strg" "<" <loc:Ident> ":" <ty:Ty> ">"  => surface::TyKind::StrgRef(loc, Box::new(ty)),
-
     "&"        <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),
     "&" "mut"  <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty)),
 

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -95,17 +95,16 @@ Ensures = <Comma<(<Ident> ":" <Ty>)>>;
 
 
 Arg: surface::Arg = {
-    <bind:Ident> ":" "&" "strg" <ty:Ty>                => surface::Arg::StrgRef(bind, ty),
-    <bind:Ident> ":" <path:Path>                       => surface::Arg::Constr(bind, path, None),
-    <bind:Ident> ":" <path:Path> "{" <pred:Level1> "}" => surface::Arg::Constr(bind, path, Some(pred)),
+    <bind:Ident> ":" "&" "strg" <ty:Ty>                    => surface::Arg::StrgRef(bind, ty),
+    <bind:Ident> ":" <path:Path>                           => surface::Arg::Constr(bind, path, None),
+    <bind:Ident> ":" <path:Path> "{" <pred:Level1> "}"     => surface::Arg::Constr(bind, path, Some(pred)),
     <bind:Ident> ":" <path:Path> "[" <indices:Indices> "]" => surface::Arg::Alias(bind, path, indices),
-    <bind:Ident> ":" "&" "mut" <ty:Ty> => {
-        let span = ty.span;
+    <bind:Ident> ":" <lo:@L> "&" "mut" <ty:Ty> <hi:@R> => {
         let kind = surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty));
-        let arg_ty = surface::Ty { kind, span };
+        let arg_ty = surface::Ty { kind, span: mk_span(lo, hi) };
         surface::Arg::Ty(arg_ty)
     },
-    <ty:Ty>                                            => surface::Arg::Ty(<>),
+    <ty:Ty> => surface::Arg::Ty(<>),
 }
 
 pub Ty: surface::Ty = {

--- a/flux-tests/tests/neg/error_messages/fun_sig_error.rs
+++ b/flux-tests/tests/neg/error_messages/fun_sig_error.rs
@@ -61,3 +61,9 @@ fn hipa(x: &[i32]) {}
 
 #[flux::sig(fn(Option<i32[@n]>))] //~ ERROR illegal binder
 fn ira(x: Option<i32>) {}
+
+#[flux::sig(fn(x: f32))] //~ ERROR type mismatch
+fn hefe(f: &mut f32) {}
+
+#[flux::sig(fn(x: &mut f32))] //~ ERROR type mismatch
+fn quad(f: f32) {}

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -189,7 +189,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 self.check_type(env, ty, allow_binder)
             }
             core::Ty::Slice(ty) | core::Ty::Array(ty, _) => self.check_type(env, ty, false),
-            core::Ty::Never | core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
+            core::Ty::Never | core::Ty::Param(_) | core::Ty::Float(_) | core::Ty::Str => Ok(()),
         }
     }
 


### PR DESCRIPTION
* Remove `surface::TyKind::StrgRef`: this variant wasn't used in any test and we currently don't support strong references in arbitrary positions
* Add `str` to `Res`
* Fix some panics in some mismatched flux signature errors