### PR TITLE
Rename `core` to `fhir`

### DIFF
--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -14,9 +14,9 @@ mod desugar;
 mod table_resolver;
 mod zip_resolver;
 
-pub use desugar::{desugar_adt_def, desugar_qualifier, resolve_sorts, resolve_uf_def};
+pub use desugar::{desugar_adt_def, desugar_qualifier, resolve_sorts, resolve_uif_def};
 use flux_middle::{
-    core::{self, AdtMap},
+    fhir::{self, AdtMap},
     global_env::GlobalEnv,
     rustc,
 };
@@ -29,7 +29,7 @@ pub fn desugar_struct_def(
     genv: &GlobalEnv,
     adt_sorts: &AdtMap,
     struct_def: surface::StructDef,
-) -> Result<core::StructDef, ErrorGuaranteed> {
+) -> Result<fhir::StructDef, ErrorGuaranteed> {
     let resolver = table_resolver::Resolver::new(genv, struct_def.def_id)?;
     let struct_def = resolver.resolve_struct_def(struct_def)?;
     desugar::desugar_struct_def(genv.sess, &genv.consts, adt_sorts, struct_def)
@@ -39,7 +39,7 @@ pub fn desugar_enum_def(
     genv: &GlobalEnv,
     adt_sorts: &AdtMap,
     enum_def: surface::EnumDef,
-) -> Result<core::EnumDef, ErrorGuaranteed> {
+) -> Result<fhir::EnumDef, ErrorGuaranteed> {
     let def_id = enum_def.def_id;
     let rust_adt_def = genv.tcx.adt_def(def_id.to_def_id());
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
@@ -54,7 +54,7 @@ pub fn desugar_fn_sig(
     sorts: &AdtMap,
     def_id: LocalDefId,
     fn_sig: surface::FnSig,
-) -> Result<core::FnSig, ErrorGuaranteed> {
+) -> Result<fhir::FnSig, ErrorGuaranteed> {
     let rust_fn_sig = genv.tcx.fn_sig(def_id);
     let resolver = table_resolver::Resolver::new(genv, def_id)?;
     let span = genv.tcx.def_span(def_id.to_def_id());
@@ -70,15 +70,15 @@ pub fn const_ty(
     rust_ty: &flux_middle::rustc::ty::Ty,
     val: i128,
     span: Span,
-) -> flux_middle::core::Ty {
+) -> flux_middle::fhir::Ty {
     let bty = match rust_ty.kind() {
-        rustc::ty::TyKind::Int(i) => core::BaseTy::Int(*i),
-        rustc::ty::TyKind::Uint(u) => core::BaseTy::Uint(*u),
+        rustc::ty::TyKind::Int(i) => fhir::BaseTy::Int(*i),
+        rustc::ty::TyKind::Uint(u) => fhir::BaseTy::Uint(*u),
         kind => panic!("const_ty: cannot handle {kind:?}"),
     };
 
-    let expr = core::Expr::from_i128(val);
-    let idx = core::Index { expr, is_binder: false };
-    let indices = core::Indices { indices: vec![idx], span };
-    core::Ty::Indexed(bty, indices)
+    let expr = fhir::Expr::from_i128(val);
+    let idx = fhir::Index { expr, is_binder: false };
+    let indices = fhir::Indices { indices: vec![idx], span };
+    fhir::Ty::Indexed(bty, indices)
 }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -2,7 +2,7 @@ use flux_common::iter::IterExt;
 use flux_desugar as desugar;
 use flux_errors::FluxSession;
 use flux_middle::{
-    core::AdtMap,
+    fhir::AdtMap,
     global_env::{ConstInfo, GlobalEnv},
     rustc, ty,
 };
@@ -138,10 +138,10 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
             })?;
 
         // Gather UFs
-        specs.uifs.into_iter().try_for_each_exhaust(|uf_def| {
-            let name = uf_def.name;
-            let uf_def = desugar::resolve_uf_def(genv.sess, uf_def)?;
-            genv.register_uf_def(name.name, uf_def);
+        specs.uifs.into_iter().try_for_each_exhaust(|uif_def| {
+            let name = uif_def.name;
+            let uif_def = desugar::resolve_uif_def(genv.sess, uif_def)?;
+            genv.register_uif_def(name.name, uif_def);
             Ok(())
         })?;
 

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -7,7 +7,7 @@ use flux_common::{
 use flux_errors::{FluxSession, ResultExt};
 use flux_syntax::{
     parse_expr, parse_fn_surface_sig, parse_qualifier, parse_refined_by, parse_ty,
-    parse_type_alias, parse_uf_def, parse_variant, surface, ParseResult,
+    parse_type_alias, parse_uif_def, parse_variant, surface, ParseResult,
 };
 use itertools::Itertools;
 use rustc_ast::{
@@ -42,7 +42,7 @@ pub(crate) struct Specs {
     pub structs: FxHashMap<LocalDefId, surface::StructDef>,
     pub enums: FxHashMap<LocalDefId, surface::EnumDef>,
     pub qualifs: Vec<surface::Qualifier>,
-    pub uifs: Vec<surface::UFDef>,
+    pub uifs: Vec<surface::UifDef>,
     pub aliases: surface::AliasMap,
     pub ignores: Ignores,
     pub consts: FxHashMap<LocalDefId, ConstSig>,
@@ -238,8 +238,8 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         let mut qualifiers = attrs.qualifiers();
         self.specs.qualifs.append(&mut qualifiers);
 
-        let mut uf_defs = attrs.uf_defs();
-        self.specs.uifs.append(&mut uf_defs);
+        let mut uif_defs = attrs.uif_defs();
+        self.specs.uifs.append(&mut uif_defs);
 
         let crate_config = attrs.crate_config();
         self.specs.crate_config = crate_config;
@@ -306,8 +306,8 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 FluxAttrKind::Qualifier(qualifer)
             }
             ("uf", MacArgs::Delimited(span, _, tokens)) => {
-                let uf_def = self.parse(tokens.clone(), span.entire(), parse_uf_def)?;
-                FluxAttrKind::UFDef(uf_def)
+                let uif_def = self.parse(tokens.clone(), span.entire(), parse_uif_def)?;
+                FluxAttrKind::UifDef(uif_def)
             }
             ("cfg", MacArgs::Delimited(_, _, _)) => {
                 let crate_cfg = FluxAttrCFG::parse_cfg(attr_item)
@@ -419,7 +419,7 @@ enum FluxAttrKind {
     FnSig(surface::FnSig),
     RefinedBy(surface::Params),
     Qualifier(surface::Qualifier),
-    UFDef(surface::UFDef),
+    UifDef(surface::UifDef),
     TypeAlias(surface::Alias),
     Field(surface::Ty),
     Variant(surface::VariantDef),
@@ -502,8 +502,8 @@ impl FluxAttrs {
         read_attrs!(self, Qualifier)
     }
 
-    fn uf_defs(&mut self) -> Vec<surface::UFDef> {
-        read_attrs!(self, UFDef)
+    fn uif_defs(&mut self) -> Vec<surface::UifDef> {
+        read_attrs!(self, UifDef)
     }
 
     fn alias(&mut self) -> Option<surface::Alias> {
@@ -545,7 +545,7 @@ impl FluxAttrKind {
             FluxAttrKind::TypeAlias(_) => attr_name!(TypeAlias),
             FluxAttrKind::CrateConfig(_) => attr_name!(CrateConfig),
             FluxAttrKind::Ignore => attr_name!(Ignore),
-            FluxAttrKind::UFDef(_) => attr_name!(UFDef),
+            FluxAttrKind::UifDef(_) => attr_name!(UifDef),
             FluxAttrKind::Invariant(_) => attr_name!(Invariant),
         }
     }

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -61,15 +61,15 @@ pub struct Qualifier {
     pub name: String,
 }
 
-pub struct UFDef {
+pub struct UifDef {
     pub name: String,
     pub inputs: Vec<Sort>,
     pub output: Sort,
 }
 
-impl UFDef {
+impl UifDef {
     pub fn new(name: String, inputs: Vec<Sort>, output: Sort) -> Self {
-        UFDef { name, inputs, output }
+        UifDef { name, inputs, output }
     }
 }
 #[derive(Clone, Copy, Debug)]

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 
 pub use constraint::{
     BinOp, Const, Constant, Constraint, Expr, KVid, Name, Pred, Proj, Qualifier, Sign, Sort, UFArg,
-    UFDef, UnOp,
+    UifDef, UnOp,
 };
 use flux_common::format::PadAdapter;
 use itertools::Itertools;
@@ -27,7 +27,7 @@ pub struct Task<Tag> {
     pub kvars: Vec<KVar>,
     pub constraint: Constraint<Tag>,
     pub qualifiers: Vec<Qualifier>,
-    pub uifs: Vec<UFDef>,
+    pub uifs: Vec<UifDef>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -65,7 +65,7 @@ impl<Tag: fmt::Display + FromStr> Task<Tag> {
         kvars: Vec<KVar>,
         constraint: Constraint<Tag>,
         qualifiers: Vec<Qualifier>,
-        uifs: Vec<UFDef>,
+        uifs: Vec<UifDef>,
     ) -> Self {
         Task { constants, kvars, constraint, qualifiers, uifs }
     }
@@ -113,8 +113,8 @@ impl<Tag: fmt::Display> fmt::Display for Task<Tag> {
             write!(f, "(constant {name:?} {sort:?})")?;
         }
 
-        for uf_def in &self.uifs {
-            writeln!(f, "{uf_def}")?;
+        for uif_def in &self.uifs {
+            writeln!(f, "{uif_def}")?;
         }
 
         for kvar in &self.kvars {
@@ -141,7 +141,7 @@ impl fmt::Display for KVar {
     }
 }
 
-impl fmt::Display for UFDef {
+impl fmt::Display for UifDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -13,7 +13,7 @@ extern crate rustc_serialize;
 extern crate rustc_span;
 extern crate rustc_target;
 
-pub mod core;
+pub mod fhir;
 pub mod global_env;
 pub mod intern;
 pub mod pretty;

--- a/flux-middle/src/ty/mod.rs
+++ b/flux-middle/src/ty/mod.rs
@@ -16,7 +16,7 @@ use rustc_span::{SpanData, DUMMY_SP};
 pub use rustc_target::abi::VariantIdx;
 
 use self::{fold::TypeFoldable, subst::BVarFolder};
-pub use crate::{core::RefKind, rustc::ty::Const};
+pub use crate::{fhir::RefKind, rustc::ty::Const};
 use crate::{
     intern::{impl_internable, Interned, List},
     rustc::mir::Place,
@@ -38,7 +38,7 @@ pub struct AdtDefData {
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct Invariant {
     pub pred: Binders<Expr>,
-    /// The source span of the invariant. Used for error reporting
+    /// The source span of the invariant. Used for error reporting.
     ///
     /// FIXME(nlehmann) We should't be storing spans here. Probably a
     /// better approach would be to assign a unique id to the invariant
@@ -178,7 +178,7 @@ pub enum Sort {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct UFDef {
+pub struct UifDef {
     pub inputs: Vec<Sort>,
     pub output: Sort,
 }

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -53,8 +53,8 @@ pub fn parse_qualifier(tokens: TokenStream, span: Span) -> ParseResult<surface::
     parse!(surface_grammar::QualifierParser, tokens, span)
 }
 
-pub fn parse_uf_def(tokens: TokenStream, span: Span) -> ParseResult<surface::UFDef> {
-    parse!(surface_grammar::UFDefParser, tokens, span)
+pub fn parse_uif_def(tokens: TokenStream, span: Span) -> ParseResult<surface::UifDef> {
+    parse!(surface_grammar::UifDefParser, tokens, span)
 }
 
 pub fn parse_ty(tokens: TokenStream, span: Span) -> ParseResult<surface::Ty> {

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -17,7 +17,7 @@ pub struct Qualifier {
 }
 
 #[derive(Debug)]
-pub struct UFDef {
+pub struct UifDef {
     /// name of the uninterpreted function
     pub name: Ident,
     /// input sorts

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -28,7 +28,7 @@ pub RefinedBy: surface::Params = {
     <lo:@L> <params:Comma<Param>> <hi:@R> => surface::Params { params, span: mk_span(lo, hi) }
 }
 
-pub UFDef: surface::UFDef = {
+pub UifDef: surface::UifDef = {
     <lo:@L>
     "fn"
     <name:Ident>
@@ -36,7 +36,7 @@ pub UFDef: surface::UFDef = {
     "->"
     <output:Ident>
     <hi:@R> => {
-        surface::UFDef { name, inputs, output, span: mk_span(lo, hi) }
+        surface::UifDef { name, inputs, output, span: mk_span(lo, hi) }
     }
 }
 

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             }
             StatementKind::SetDiscriminant { .. } => {
                 // TODO(nilehmann) double check here that the place is unfolded to
-                // the corect variant. This should be guaranteed by rustc
+                // the correct variant. This should be guaranteed by rustc
             }
             StatementKind::FakeRead(_) => {
                 // TODO(nilehmann) fake reads should be folding points

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -123,7 +123,7 @@ where
         did: DefId,
         constraint: fixpoint::Constraint<TagIdx>,
         qualifiers: &[ty::Qualifier],
-        uf_sorts: &FxHashMap<Symbol, ty::UFDef>,
+        uifs: &FxHashMap<Symbol, ty::UifDef>,
     ) -> Result<(), Vec<T>> {
         let kvars = self
             .fixpoint_kvars
@@ -147,9 +147,9 @@ where
             .map(|const_info| (const_info.name, fixpoint::Sort::Int))
             .collect();
 
-        let uifs = uf_sorts
+        let uifs = uifs
             .iter()
-            .map(|(sym, uf_def)| uf_def_to_fixpoint(sym, uf_def))
+            .map(|(sym, uif_def)| uif_def_to_fixpoint(sym, uif_def))
             .collect_vec();
 
         let task = fixpoint::Task::new(constants, kvars, closed_constraint, qualifiers, uifs);
@@ -411,10 +411,10 @@ fn dump_constraint<C: std::fmt::Debug>(
     write!(file, "{:?}", c)
 }
 
-fn uf_def_to_fixpoint(name: &Symbol, uf_def: &ty::UFDef) -> fixpoint::UFDef {
-    let inputs = uf_def.inputs.iter().map(sort_to_fixpoint).collect_vec();
-    let output = sort_to_fixpoint(&uf_def.output);
-    fixpoint::UFDef::new(name.to_string(), inputs, output)
+fn uif_def_to_fixpoint(name: &Symbol, uif_def: &ty::UifDef) -> fixpoint::UifDef {
+    let inputs = uif_def.inputs.iter().map(sort_to_fixpoint).collect_vec();
+    let output = sort_to_fixpoint(&uif_def.output);
+    fixpoint::UifDef::new(name.to_string(), inputs, output)
 }
 
 fn qualifier_to_fixpoint(const_map: &ConstMap, qualifier: &ty::Qualifier) -> fixpoint::Qualifier {

--- a/flux-typeck/src/invariants.rs
+++ b/flux-typeck/src/invariants.rs
@@ -46,7 +46,7 @@ fn check_invariant(
     }
     let mut fcx = FixpointCtxt::new(&genv.consts, Default::default());
     let constraint = refine_tree.into_fixpoint(&mut fcx);
-    fcx.check(genv.tcx, adt_def.def_id(), constraint, &[], &genv.uf_sorts)
+    fcx.check(genv.tcx, adt_def.def_id(), constraint, &[], &genv.uif_defs)
         .map_err(|_| {
             genv.sess
                 .emit_err(errors::Invalid { span: invariant.source_info.span() })

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -52,7 +52,7 @@ pub fn check<'a, 'tcx>(
 
     let constraint = refine_tree.into_fixpoint(&mut fcx);
 
-    match fcx.check(genv.tcx, def_id, constraint, qualifiers, &genv.uf_sorts) {
+    match fcx.check(genv.tcx, def_id, constraint, qualifiers, &genv.uif_defs) {
         Ok(_) => Ok(()),
         Err(tags) => report_errors(genv, body.span(), tags),
     }


### PR DESCRIPTION
The name core was confusing as it made it sound like it was the lowest of the levels in the pipeline, when in fact we have even lower levels. I borrowed the name hir from rustc to refer to something a bit lower than the surface syntax.