### PR TITLE
Check dom(requires) = dom(ensures)

### DIFF
--- a/flux-desugar/src/zip_checker.rs
+++ b/flux-desugar/src/zip_checker.rs
@@ -198,7 +198,7 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
             (Res::Str, rustc_ty::TyKind::Str) => Ok(()),
 
             _ => {
-                return Err(self
+                Err(self
                     .sess
                     .emit_err(errors::TypeMismatch::from_span(self.tcx, rust_ty, path.span)))
             }

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -16,3 +16,9 @@ wf_illegal_binder =
 wf_unresolved_function =
     unresolved function
     .label = function is not defined in this scope
+
+wf_duplicated_ensures =
+    an ensures clause already exists for `{$loc}`
+
+wf_missing_ensures =
+    missing ensures clause for `&strg` reference

--- a/flux-tests/tests/neg/error_messages/constr_wf.rs
+++ b/flux-tests/tests/neg/error_messages/constr_wf.rs
@@ -1,0 +1,12 @@
+#![feature(register_tool, box_patterns)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x: &strg i32[@n]))] //~ ERROR missing ensures clause
+fn inc_1(x: &mut i32) {
+    *x += 1;
+}
+
+#[flux::sig(fn(x: &strg i32[@n]) ensures x: i32[n + 2], x: i32 [n + 1])] //~ ERROR an ensures clause already exists
+fn inc1(x: &mut i32) {
+    *x += 1;
+}


### PR DESCRIPTION
Check that the locations mentioned in the requires clauses are the same as the locations in &strg arguments. This is important for soundness as the implementation of function calls doesn't do explicit framing and expects all the locations passed to the function to be returned back. Additionally, it checks there are no duplicates in the ensure clauses