### PR TITLE
Ignore consts without a #[flux::constant] annotation

### DIFF
--- a/flux-tests/tests/pos/surface/issue-185.rs
+++ b/flux-tests/tests/pos/surface/issue-185.rs
@@ -1,0 +1,4 @@
+#![feature(register_tool, box_patterns)]
+#![register_tool(flux)]
+
+const BASE_PRIMES: [u32; 11] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31];


### PR DESCRIPTION
Closes https://github.com/liquid-rust/flux/pull/185