### PR TITLE
Do not infer under ptrs when jumping to a bb

### DIFF
--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -129,7 +129,7 @@ pub fn infer_from_exprs(exprs: &mut Exprs, e1: &Expr, e2: &Expr) {
     match (e1.kind(), e2.kind()) {
         (_, ExprKind::BoundVar(bvar)) if bvar.debruijn == INNERMOST => {
             if let Some(old_e) = exprs.insert(bvar.index, e1.clone()) {
-                if &old_e != e2 {
+                if &old_e != e1 {
                     todo!(
                         "ambiguous instantiation for parameter: {:?} -> [{:?}, {:?}]",
                         bvar,

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -205,11 +205,7 @@ impl TypeEnv {
             }
             (TyKind::Ptr(rk1, path1), TyKind::Ptr(rk2, path2)) => {
                 debug_assert_eq!(rk1, rk2);
-                subst.infer_from_exprs(params, &path1.to_expr(), &path2.to_expr());
-                if let Binding::Owned(ty1) = self.bindings.get(path1) &&
-                   let Binding::Owned(ty2) = bb_env.bindings.get(path2) {
-                    self.infer_subst_for_bb_env_ty(bb_env, params, &ty1, &ty2, subst);
-                }
+                debug_assert_eq!(path1, path2);
             }
             (TyKind::Ref(rk1, ty1), TyKind::Ref(rk2, ty2)) => {
                 debug_assert_eq!(rk1, rk2);


### PR DESCRIPTION
The assumption we are making when we have a join point is that we fold all pointers for variables that go out of scope so we should have two pointers pointing to a different path. Thus, we shouldn't follow pointers when inferring parameters in a basic block. 

Also fixes the same bug fixed in https://github.com/liquid-rust/flux/pull/200 but for bound variables.