### PR TITLE
Propagate unsupported sig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "flux-common",
  "flux-errors",
  "flux-fixpoint",
+ "flux-macros",
  "itertools",
 ]
 

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -272,7 +272,8 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
             .unwrap();
         }
 
-        let body = rustc::lowering::LoweringCtxt::lower_mir_body(self.genv.tcx, mir)?;
+        let body =
+            rustc::lowering::LoweringCtxt::lower_mir_body(self.genv.tcx, self.genv.sess, mir)?;
 
         typeck::check(self.genv, def_id.to_def_id(), &body, &self.qualifiers)
     }

--- a/flux-errors/locales/en-US/lowering.ftl
+++ b/flux-errors/locales/en-US/lowering.ftl
@@ -14,8 +14,15 @@ lowering_unsupported_statement =
     unsupported statement
     .label = `{$statement}`
 
+lowering_unsupported_constant =
+    unsupported constant
+    .label = `{$constant}`
+
 lowering_unsupported_type_of =
     unsupported type `{$ty}`
 
 lowering_unsupported_fn_sig =
     unsupported signature
+
+lowering_unsupported_generic_param =
+    unsupported generic param

--- a/flux-errors/locales/en-US/lowering.ftl
+++ b/flux-errors/locales/en-US/lowering.ftl
@@ -1,0 +1,21 @@
+lowering_unsupported_local_decl =
+    unsupported local declaration
+    .label = this declaration has type `{$ty}` which is not currently supported
+
+lowering_unsupported_terminator =
+    unsupported terminator
+    .label = `{$terminator}`
+
+lowering_unsupported_rvalue =
+    unsupported rvalue
+    .label = `{$rvalue}`
+
+lowering_unsupported_statement =
+    unsupported statement
+    .label = `{$statement}`
+
+lowering_unsupported_type_of =
+    unsupported type `{$ty}`
+
+lowering_unsupported_fn_sig =
+    unsupported signature

--- a/flux-errors/locales/en-US/refineck.ftl
+++ b/flux-errors/locales/en-US/refineck.ftl
@@ -33,3 +33,7 @@ refineck_overflow_error =
 
 refineck_opaque_struct_error =
     cannot access fields of opaque struct `{$struct}`
+
+refineck_unsupported_call =
+    call to a function with an unsupported type
+    .function_definition = function defined here

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -21,12 +21,13 @@ use rustc_session::{config::ErrorOutputType, parse::ParseSess};
 use rustc_span::source_map::SourceMap;
 
 fluent_messages! {
-    parse => "../locales/en-US/parse.ftl",
-    resolver => "../locales/en-US/resolver.ftl",
     desugar => "../locales/en-US/desugar.ftl",
-    wf => "../locales/en-US/wf.ftl",
-    refineck => "../locales/en-US/refineck.ftl",
     invariants => "../locales/en-US/invariants.ftl",
+    lowering => "../locales/en-US/lowering.ftl",
+    parse => "../locales/en-US/parse.ftl",
+    refineck => "../locales/en-US/refineck.ftl",
+    resolver => "../locales/en-US/resolver.ftl",
+    wf => "../locales/en-US/wf.ftl",
 }
 
 pub use fluent_generated::{self as fluent, DEFAULT_LOCALE_RESOURCES};

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -43,6 +43,10 @@ impl FluxSession {
         Self { parse_sess: ParseSess::with_span_handler(handler, source_map) }
     }
 
+    pub fn err(&self, msg: impl Into<DiagnosticMessage>) -> ErrorGuaranteed {
+        self.diagnostic().err(msg)
+    }
+
     pub fn emit_err<'a>(&'a self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         err.into_diagnostic(&self.parse_sess.span_diagnostic).emit()
     }
@@ -56,6 +60,10 @@ impl FluxSession {
             .span_diagnostic
             .print_error_count(&Registry::new(&[]));
         self.abort_if_errors();
+    }
+
+    pub fn diagnostic(&self) -> &rustc_errors::Handler {
+        &self.parse_sess.span_diagnostic
     }
 }
 

--- a/flux-middle/Cargo.toml
+++ b/flux-middle/Cargo.toml
@@ -10,6 +10,7 @@ dashmap = { version = "4.0.2", features = ["raw-api"] }
 flux-common = { path = "../flux-common" }
 flux-errors = { path = "../flux-errors" }
 flux-fixpoint = { path = "../flux-fixpoint" }
+flux-macros = { path = "../flux-macros" }
 itertools = "0.10"
 
 [package.metadata.rust-analyzer]

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -184,7 +184,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     }
 
     pub fn generics_of(&self, def_id: DefId) -> rustc::ty::Generics<'tcx> {
-        rustc::lowering::lower_generics(self.tcx, self.tcx.generics_of(def_id))
+        rustc::lowering::lower_generics(self.tcx, self.sess, self.tcx.generics_of(def_id))
             .unwrap_or_else(|_| FatalError.raise())
     }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -172,11 +172,16 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 .collect_vec();
 
             let substs = genv
-                .tcx
                 .generics_of(struct_def.def_id)
                 .params
                 .iter()
-                .map(|param| rty::Ty::param(rty::ParamTy { index: param.index, name: param.name }))
+                .map(|param| {
+                    match param.kind {
+                        GenericParamDefKind::Type { .. } => {
+                            rty::Ty::param(rty::ParamTy { index: param.index, name: param.name })
+                        }
+                    }
+                })
                 .collect_vec();
 
             let idxs = sorts

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -1,4 +1,5 @@
 use flux_common::index::IndexVec;
+use flux_errors::{FluxSession, ResultExt};
 use itertools::Itertools;
 use rustc_const_eval::interpret::ConstValue;
 use rustc_errors::{DiagnosticId, ErrorGuaranteed};
@@ -26,17 +27,21 @@ use super::{
 };
 use crate::intern::List;
 
-pub struct LoweringCtxt<'tcx> {
+pub struct LoweringCtxt<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
+    sess: &'a FluxSession,
     rustc_mir: rustc_mir::Body<'tcx>,
 }
 
-impl<'tcx> LoweringCtxt<'tcx> {
+pub struct UnsupportedType;
+
+impl<'a, 'tcx> LoweringCtxt<'a, 'tcx> {
     pub fn lower_mir_body(
         tcx: TyCtxt<'tcx>,
+        sess: &'a FluxSession,
         rustc_mir: rustc_mir::Body<'tcx>,
     ) -> Result<Body<'tcx>, ErrorGuaranteed> {
-        let lower = Self { tcx, rustc_mir };
+        let lower = Self { tcx, sess, rustc_mir };
 
         let basic_blocks = lower
             .rustc_mir
@@ -81,9 +86,10 @@ impl<'tcx> LoweringCtxt<'tcx> {
         &self,
         local_decl: &rustc_mir::LocalDecl<'tcx>,
     ) -> Result<LocalDecl, ErrorGuaranteed> {
-        let span = local_decl.source_info.span;
         Ok(LocalDecl {
-            ty: lower_ty(self.tcx, local_decl.ty, span)?,
+            ty: lower_ty(self.tcx, local_decl.ty)
+                .map_err(|err| errors::UnsupportedLocalDecl::new(local_decl, err))
+                .emit(self.sess)?,
             source_info: local_decl.source_info,
         })
     }
@@ -104,7 +110,9 @@ impl<'tcx> LoweringCtxt<'tcx> {
             }
             rustc_mir::StatementKind::FakeRead(box (cause, place)) => {
                 StatementKind::FakeRead(Box::new((
-                    self.lower_fake_read_cause(*cause)?,
+                    self.lower_fake_read_cause(*cause)
+                        .ok_or_else(|| errors::UnsupportedStatement::new(stmt))
+                        .emit(self.sess)?,
                     self.lower_place(place)?,
                 )))
             }
@@ -122,29 +130,21 @@ impl<'tcx> LoweringCtxt<'tcx> {
             | rustc_mir::StatementKind::AscribeUserType(..)
             | rustc_mir::StatementKind::Coverage(_)
             | rustc_mir::StatementKind::Intrinsic(_) => {
-                return self.emit_err(
-                    Some(stmt.source_info.span),
-                    format!("unsupported statement: `{stmt:?}`"),
-                );
+                return Err(errors::UnsupportedStatement::new(stmt)).emit(self.sess);
             }
         };
         Ok(Statement { kind, source_info: stmt.source_info })
     }
 
-    fn lower_fake_read_cause(
-        &self,
-        cause: rustc_mir::FakeReadCause,
-    ) -> Result<FakeReadCause, ErrorGuaranteed> {
+    fn lower_fake_read_cause(&self, cause: rustc_mir::FakeReadCause) -> Option<FakeReadCause> {
         match cause {
-            rustc_mir::FakeReadCause::ForLet(def_id) => Ok(FakeReadCause::ForLet(def_id)),
+            rustc_mir::FakeReadCause::ForLet(def_id) => Some(FakeReadCause::ForLet(def_id)),
             rustc_mir::FakeReadCause::ForMatchedPlace(def_id) => {
-                Ok(FakeReadCause::ForMatchedPlace(def_id))
+                Some(FakeReadCause::ForMatchedPlace(def_id))
             }
             rustc_mir::FakeReadCause::ForMatchGuard
             | rustc_mir::FakeReadCause::ForGuardBinding
-            | rustc_mir::FakeReadCause::ForIndex { .. } => {
-                self.emit_err(None, format!("unsupported fake read cause: `{:?}`", cause))
-            }
+            | rustc_mir::FakeReadCause::ForIndex { .. } => None,
         }
     }
 
@@ -152,14 +152,13 @@ impl<'tcx> LoweringCtxt<'tcx> {
         &self,
         trait_f: DefId,
         substs: SubstsRef<'tcx>,
-        span: Span,
-    ) -> Result<Option<Instance>, ErrorGuaranteed> {
+    ) -> Result<Option<Instance>, UnsupportedType> {
         let param_env = self.tcx.param_env(self.rustc_mir.source.def_id());
         match rustc_middle::ty::Instance::resolve(self.tcx, param_env, trait_f, substs) {
             Ok(Some(instance)) => {
                 let impl_f = instance.def_id();
                 let inst = if impl_f != trait_f {
-                    let substs = lower_substs(self.tcx, instance.substs, span)?;
+                    let substs = lower_substs(self.tcx, instance.substs)?;
                     Some(Instance { impl_f, substs })
                 } else {
                     None
@@ -174,7 +173,6 @@ impl<'tcx> LoweringCtxt<'tcx> {
         &self,
         terminator: &rustc_mir::Terminator<'tcx>,
     ) -> Result<Terminator<'tcx>, ErrorGuaranteed> {
-        let span = terminator.source_info.span;
         let kind = match &terminator.kind {
             rustc_mir::TerminatorKind::Return => TerminatorKind::Return,
             rustc_mir::TerminatorKind::Call {
@@ -182,20 +180,20 @@ impl<'tcx> LoweringCtxt<'tcx> {
             } => {
                 let (func, substs) = match func.ty(&self.rustc_mir, self.tcx).kind() {
                     rustc_middle::ty::TyKind::FnDef(fn_def, substs) => {
-                        let lowered_substs = lower_substs(self.tcx, substs, span)?;
+                        let lowered_substs = lower_substs(self.tcx, substs)
+                            .map_err(|_| errors::UnsupportedTerminator::new(terminator))
+                            .emit(self.sess)?;
                         (*fn_def, CallSubsts { orig: substs, lowered: lowered_substs })
                     }
-                    _ => {
-                        return self.emit_err(
-                            Some(terminator.source_info.span),
-                            "unsupported function call",
-                        );
-                    }
+                    _ => Err(errors::UnsupportedTerminator::new(terminator)).emit(self.sess)?,
                 };
 
                 let destination = self.lower_place(destination)?;
 
-                let instance = self.lower_instance(func, substs.orig, span)?;
+                let instance = self
+                    .lower_instance(func, substs.orig)
+                    .map_err(|_| errors::UnsupportedTerminator::new(terminator))
+                    .emit(self.sess)?;
 
                 TerminatorKind::Call {
                     func,
@@ -237,7 +235,10 @@ impl<'tcx> LoweringCtxt<'tcx> {
                     cond: self.lower_operand(cond)?,
                     expected: *expected,
                     target: *target,
-                    msg: self.lower_assert_msg(msg)?,
+                    msg: self
+                        .lower_assert_msg(msg)
+                        .ok_or_else(|| errors::UnsupportedTerminator::new(terminator))
+                        .emit(self.sess)?,
                 }
             }
             rustc_mir::TerminatorKind::Unreachable => TerminatorKind::Unreachable,
@@ -255,10 +256,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
             | rustc_mir::TerminatorKind::Yield { .. }
             | rustc_mir::TerminatorKind::GeneratorDrop
             | rustc_mir::TerminatorKind::InlineAsm { .. } => {
-                return self.emit_err(
-                    Some(terminator.source_info.span),
-                    format!("unsupported terminator kind: {:?}", terminator.kind),
-                );
+                return Err(errors::UnsupportedTerminator::new(terminator)).emit(self.sess);
             }
         };
         Ok(Terminator { kind, source_info: terminator.source_info })
@@ -273,7 +271,9 @@ impl<'tcx> LoweringCtxt<'tcx> {
             rustc_mir::Rvalue::Use(op) => Ok(Rvalue::Use(self.lower_operand(op)?)),
             rustc_mir::Rvalue::BinaryOp(bin_op, operands) => {
                 Ok(Rvalue::BinaryOp(
-                    self.lower_bin_op(*bin_op)?,
+                    self.lower_bin_op(*bin_op)
+                        .ok_or_else(|| errors::UnsupportedRvalue::new(source_info.span, rvalue))
+                        .emit(self.sess)?,
                     self.lower_operand(&operands.0)?,
                     self.lower_operand(&operands.1)?,
                 ))
@@ -288,7 +288,10 @@ impl<'tcx> LoweringCtxt<'tcx> {
                 Ok(Rvalue::UnaryOp(*un_op, self.lower_operand(op)?))
             }
             rustc_mir::Rvalue::Aggregate(aggregate_kind, args) => {
-                let aggregate_kind = self.lower_aggregate_kind(aggregate_kind, source_info.span)?;
+                let aggregate_kind = self
+                    .lower_aggregate_kind(aggregate_kind)
+                    .ok_or_else(|| errors::UnsupportedRvalue::new(source_info.span, rvalue))
+                    .emit(self.sess)?;
                 let args = args.iter().map(|op| self.lower_operand(op)).try_collect()?;
                 Ok(Rvalue::Aggregate(aggregate_kind, args))
             }
@@ -303,8 +306,9 @@ impl<'tcx> LoweringCtxt<'tcx> {
                     )
                 })?;
                 let op = self.lower_operand(op)?;
-                let span = source_info.span;
-                let ty = lower_ty(self.tcx, *ty, span)?;
+                let ty = lower_ty(self.tcx, *ty)
+                    .map_err(|_| errors::UnsupportedRvalue::new(source_info.span, rvalue))
+                    .emit(self.sess)?;
                 Ok(Rvalue::Cast(kind, op, ty))
             }
             rustc_mir::Rvalue::Repeat(_, _)
@@ -315,7 +319,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
             | rustc_mir::Rvalue::NullaryOp(_, _)
             | rustc_mir::Rvalue::CopyForDeref(_)
             | rustc_mir::Rvalue::ShallowInitBox(_, _) => {
-                self.emit_err(Some(source_info.span), format!("unsupported rvalue: `{rvalue:?}`"))
+                Err(errors::UnsupportedRvalue::new(source_info.span, rvalue)).emit(self.sess)
             }
         }
     }
@@ -332,48 +336,44 @@ impl<'tcx> LoweringCtxt<'tcx> {
     fn lower_aggregate_kind(
         &self,
         aggregate_kind: &rustc_mir::AggregateKind<'tcx>,
-        span: Span,
-    ) -> Result<AggregateKind, ErrorGuaranteed> {
+    ) -> Option<AggregateKind> {
         match aggregate_kind {
             rustc_mir::AggregateKind::Adt(def_id, variant_idx, substs, None, None) => {
-                Ok(AggregateKind::Adt(*def_id, *variant_idx, lower_substs(self.tcx, substs, span)?))
+                Some(AggregateKind::Adt(
+                    *def_id,
+                    *variant_idx,
+                    lower_substs(self.tcx, substs).ok()?,
+                ))
             }
             rustc_mir::AggregateKind::Array(ty) => {
-                Ok(AggregateKind::Array(lower_ty(self.tcx, *ty, span)?))
+                Some(AggregateKind::Array(lower_ty(self.tcx, *ty).ok()?))
             }
-            rustc_mir::AggregateKind::Tuple => Ok(AggregateKind::Tuple),
+            rustc_mir::AggregateKind::Tuple => Some(AggregateKind::Tuple),
             rustc_mir::AggregateKind::Adt(..)
             | rustc_mir::AggregateKind::Closure(_, _)
-            | rustc_mir::AggregateKind::Generator(_, _, _) => {
-                self.emit_err(
-                    Some(span),
-                    format!("unsupported aggregate kind: `{:?}`", aggregate_kind),
-                )
-            }
+            | rustc_mir::AggregateKind::Generator(_, _, _) => None,
         }
     }
 
-    fn lower_bin_op(&self, bin_op: rustc_mir::BinOp) -> Result<BinOp, ErrorGuaranteed> {
+    fn lower_bin_op(&self, bin_op: rustc_mir::BinOp) -> Option<BinOp> {
         match bin_op {
-            rustc_mir::BinOp::Add => Ok(BinOp::Add),
-            rustc_mir::BinOp::Sub => Ok(BinOp::Sub),
-            rustc_mir::BinOp::Gt => Ok(BinOp::Gt),
-            rustc_mir::BinOp::Ge => Ok(BinOp::Ge),
-            rustc_mir::BinOp::Lt => Ok(BinOp::Lt),
-            rustc_mir::BinOp::Le => Ok(BinOp::Le),
-            rustc_mir::BinOp::Eq => Ok(BinOp::Eq),
-            rustc_mir::BinOp::Ne => Ok(BinOp::Ne),
-            rustc_mir::BinOp::Mul => Ok(BinOp::Mul),
-            rustc_mir::BinOp::Div => Ok(BinOp::Div),
-            rustc_mir::BinOp::Rem => Ok(BinOp::Rem),
-            rustc_mir::BinOp::BitAnd => Ok(BinOp::BitAnd),
+            rustc_mir::BinOp::Add => Some(BinOp::Add),
+            rustc_mir::BinOp::Sub => Some(BinOp::Sub),
+            rustc_mir::BinOp::Gt => Some(BinOp::Gt),
+            rustc_mir::BinOp::Ge => Some(BinOp::Ge),
+            rustc_mir::BinOp::Lt => Some(BinOp::Lt),
+            rustc_mir::BinOp::Le => Some(BinOp::Le),
+            rustc_mir::BinOp::Eq => Some(BinOp::Eq),
+            rustc_mir::BinOp::Ne => Some(BinOp::Ne),
+            rustc_mir::BinOp::Mul => Some(BinOp::Mul),
+            rustc_mir::BinOp::Div => Some(BinOp::Div),
+            rustc_mir::BinOp::Rem => Some(BinOp::Rem),
+            rustc_mir::BinOp::BitAnd => Some(BinOp::BitAnd),
             rustc_mir::BinOp::BitXor
             | rustc_mir::BinOp::BitOr
             | rustc_mir::BinOp::Shl
             | rustc_mir::BinOp::Shr
-            | rustc_mir::BinOp::Offset => {
-                self.emit_err(None, format!("unsupported binary operation: `{bin_op:?}`"))
-            }
+            | rustc_mir::BinOp::Offset => None,
         }
     }
 
@@ -443,24 +443,21 @@ impl<'tcx> LoweringCtxt<'tcx> {
         })
     }
 
-    fn lower_assert_msg(
-        &self,
-        msg: &rustc_mir::AssertMessage,
-    ) -> Result<&'static str, ErrorGuaranteed> {
+    fn lower_assert_msg(&self, msg: &rustc_mir::AssertMessage) -> Option<&'static str> {
         use rustc_mir::AssertKind::*;
         match msg {
-            DivisionByZero(_) => Ok("possible division by zero"),
-            RemainderByZero(_) => Ok("possible remainder with a divisor of zero"),
-            Overflow(rustc_mir::BinOp::Div, _, _) => Ok("possible division with overflow"),
-            Overflow(rustc_mir::BinOp::Rem, _, _) => Ok("possible remainder with overflow"),
-            BoundsCheck { .. } => Ok("index out of bounds"),
-            _ => self.emit_err(None, format!("unsupported assert message: `{msg:?}`")),
+            DivisionByZero(_) => Some("possible division by zero"),
+            RemainderByZero(_) => Some("possible remainder with a divisor of zero"),
+            Overflow(rustc_mir::BinOp::Div, _, _) => Some("possible division with overflow"),
+            Overflow(rustc_mir::BinOp::Rem, _, _) => Some("possible remainder with overflow"),
+            BoundsCheck { .. } => Some("index out of bounds"),
+            _ => None,
         }
     }
 
-    fn emit_err<S: AsRef<str>, T>(&self, span: Option<Span>, msg: S) -> Result<T, ErrorGuaranteed> {
-        Err(emit_err(self.tcx, span, msg))
-    }
+    // fn emit_err<S: AsRef<str>, T>(&self, span: Option<Span>, msg: S) -> Result<T, ErrorGuaranteed> {
+    //     Err(emit_err(self.tcx, span, msg))
+    // }
 }
 
 /// [NOTE:Fake Predecessors] The `FalseEdge/imaginary_target` edges mess up
@@ -488,64 +485,71 @@ fn mk_fake_predecessors(
     res
 }
 
-fn lower_type_of(tcx: TyCtxt, def_id: DefId) -> Result<Ty, ErrorGuaranteed> {
+pub fn lower_type_of(
+    tcx: TyCtxt,
+    sess: &FluxSession,
+    def_id: DefId,
+) -> Result<Ty, ErrorGuaranteed> {
     let span = tcx.def_span(def_id);
-    lower_ty(tcx, tcx.type_of(def_id), span)
+    lower_ty(tcx, tcx.type_of(def_id))
+        .map_err(|_| errors::UnsupportedTypeOf::new(span))
+        .emit(sess)
 }
 
 pub fn lower_enum_def<'tcx>(
     tcx: TyCtxt<'tcx>,
+    sess: &FluxSession,
     adt_def: rustc_ty::AdtDef<'tcx>,
 ) -> Result<EnumDef, ErrorGuaranteed> {
     let adt_def_id = adt_def.did();
     let mut variants = vec![];
     for variant_def in adt_def.variants().into_iter() {
-        variants.push(lower_variant_def(tcx, adt_def_id, variant_def)?)
+        variants.push(lower_variant_def(tcx, sess, adt_def_id, variant_def)?)
     }
     Ok(EnumDef { variants })
 }
 
 pub fn lower_variant_def(
     tcx: TyCtxt,
+    sess: &FluxSession,
     adt_def_id: DefId,
     variant_def: &rustc_ty::VariantDef,
 ) -> Result<VariantDef, ErrorGuaranteed> {
     let fields = variant_def
         .fields
         .iter()
-        .map(|field| lower_type_of(tcx, field.did))
+        .map(|field| lower_type_of(tcx, sess, field.did))
         .collect_vec();
     let fields: Result<Vec<Ty>, ErrorGuaranteed> = fields.into_iter().collect();
     let fields = List::from_vec(fields?);
-    let ret = lower_type_of(tcx, adt_def_id)?;
+    let ret = lower_type_of(tcx, sess, adt_def_id)?;
     Ok(VariantDef { fields, ret })
 }
 
-pub fn lower_fn_sig<'tcx>(
+pub fn lower_fn_sig_of(tcx: TyCtxt, def_id: DefId) -> Result<FnSig, errors::UnsupportedFnSig> {
+    let fn_sig = tcx.fn_sig(def_id);
+    let span = tcx.def_span(def_id);
+    lower_fn_sig(tcx, fn_sig).map_err(|_| errors::UnsupportedFnSig { span })
+}
+
+fn lower_fn_sig<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_sig: rustc_ty::PolyFnSig<'tcx>,
-    span: Span,
-) -> Result<FnSig, ErrorGuaranteed> {
+) -> Result<FnSig, UnsupportedType> {
     let fn_sig = tcx.erase_late_bound_regions(fn_sig);
     let inputs_and_output = List::from_vec(
         fn_sig
             .inputs_and_output
             .iter()
-            .map(|ty| lower_ty(tcx, ty, span))
+            .map(|ty| lower_ty(tcx, ty))
             .try_collect()?,
     );
     Ok(FnSig { inputs_and_output })
 }
 
-pub fn lower_ty<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    ty: rustc_ty::Ty<'tcx>,
-    span: Span,
-) -> Result<Ty, ErrorGuaranteed> {
+pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, UnsupportedType> {
     match ty.kind() {
-        rustc_ty::Ref(_region, ty, mutability) => {
-            Ok(Ty::mk_ref(lower_ty(tcx, *ty, span)?, *mutability))
-        }
+        rustc_ty::Ref(_region, ty, mutability) => Ok(Ty::mk_ref(lower_ty(tcx, *ty)?, *mutability)),
         rustc_ty::Bool => Ok(Ty::mk_bool()),
         rustc_ty::Int(int_ty) => Ok(Ty::mk_int(*int_ty)),
         rustc_ty::Uint(uint_ty) => Ok(Ty::mk_uint(*uint_ty)),
@@ -555,7 +559,7 @@ pub fn lower_ty<'tcx>(
             let substs = List::from_vec(
                 substs
                     .iter()
-                    .map(|arg| lower_generic_arg(tcx, arg, span))
+                    .map(|arg| lower_generic_arg(tcx, arg))
                     .try_collect()?,
             );
             Ok(Ty::mk_adt(adt_def.did(), substs))
@@ -564,30 +568,23 @@ pub fn lower_ty<'tcx>(
         rustc_ty::Str => Ok(Ty::mk_str()),
         rustc_ty::Char => Ok(Ty::mk_char()),
         rustc_ty::Tuple(tys) => {
-            let tys = List::from_vec(tys.iter().map(|ty| lower_ty(tcx, ty, span)).try_collect()?);
+            let tys = List::from_vec(tys.iter().map(|ty| lower_ty(tcx, ty)).try_collect()?);
             Ok(Ty::mk_tuple(tys))
         }
-        rustc_ty::Array(ty, _) => Ok(Ty::mk_array(lower_ty(tcx, *ty, span)?, Const)),
-        rustc_ty::Slice(ty) => Ok(Ty::mk_slice(lower_ty(tcx, *ty, span)?)),
-        _ => {
-            Err(emit_err(
-                tcx,
-                Some(span),
-                format!("unsupported type `{ty:?}`, kind: `{:?}`", ty.kind()),
-            ))
-        }
+        rustc_ty::Array(ty, _) => Ok(Ty::mk_array(lower_ty(tcx, *ty)?, Const)),
+        rustc_ty::Slice(ty) => Ok(Ty::mk_slice(lower_ty(tcx, *ty)?)),
+        _ => Err(UnsupportedType),
     }
 }
 
 fn lower_substs<'tcx>(
     tcx: TyCtxt<'tcx>,
     substs: rustc_middle::ty::subst::SubstsRef<'tcx>,
-    span: Span,
-) -> Result<List<GenericArg>, ErrorGuaranteed> {
+) -> Result<List<GenericArg>, UnsupportedType> {
     Ok(List::from_vec(
         substs
             .iter()
-            .map(|arg| lower_generic_arg(tcx, arg, span))
+            .map(|arg| lower_generic_arg(tcx, arg))
             .try_collect()?,
     ))
 }
@@ -595,13 +592,10 @@ fn lower_substs<'tcx>(
 fn lower_generic_arg<'tcx>(
     tcx: TyCtxt<'tcx>,
     arg: rustc_middle::ty::subst::GenericArg<'tcx>,
-    span: Span,
-) -> Result<GenericArg, ErrorGuaranteed> {
+) -> Result<GenericArg, UnsupportedType> {
     match arg.unpack() {
-        GenericArgKind::Type(ty) => Ok(GenericArg::Ty(lower_ty(tcx, ty, span)?)),
-        GenericArgKind::Const(_) | GenericArgKind::Lifetime(_) => {
-            Err(emit_err(tcx, Some(span), format!("unsupported generic argument: `{arg:?}`")))
-        }
+        GenericArgKind::Type(ty) => Ok(GenericArg::Ty(lower_ty(tcx, ty)?)),
+        GenericArgKind::Const(_) | GenericArgKind::Lifetime(_) => Err(UnsupportedType),
     }
 }
 
@@ -705,4 +699,90 @@ fn scalar_to_uint<'tcx>(
         .unwrap()
         .size;
     scalar.try_to_uint(size).ok()
+}
+
+mod errors {
+    use flux_macros::Diagnostic;
+    use rustc_middle::mir as rustc_mir;
+    use rustc_span::Span;
+
+    use super::UnsupportedType;
+
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_local_decl, code = "FLUX")]
+    pub struct UnsupportedLocalDecl<'tcx> {
+        #[primary_span]
+        #[label]
+        span: Span,
+        ty: rustc_middle::ty::Ty<'tcx>,
+    }
+
+    impl<'tcx> UnsupportedLocalDecl<'tcx> {
+        pub fn new(local_decl: &rustc_mir::LocalDecl<'tcx>, _err: UnsupportedType) -> Self {
+            Self { span: local_decl.source_info.span, ty: local_decl.ty }
+        }
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_terminator, code = "FLUX")]
+    pub struct UnsupportedTerminator {
+        #[primary_span]
+        #[label]
+        span: Span,
+        terminator: String,
+    }
+
+    impl UnsupportedTerminator {
+        pub fn new(terminator: &rustc_mir::Terminator) -> Self {
+            Self { span: terminator.source_info.span, terminator: format!("{terminator:?}") }
+        }
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_rvalue, code = "FLUX")]
+    pub struct UnsupportedRvalue {
+        #[primary_span]
+        #[label]
+        span: Span,
+        rvalue: String,
+    }
+
+    impl UnsupportedRvalue {
+        pub fn new(span: Span, rvalue: &rustc_mir::Rvalue) -> Self {
+            Self { span, rvalue: format!("{rvalue:?}") }
+        }
+    }
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_type_of, code = "FLUX")]
+    pub struct UnsupportedTypeOf {
+        #[primary_span]
+        span: Span,
+    }
+
+    impl UnsupportedTypeOf {
+        pub fn new(span: Span) -> Self {
+            Self { span }
+        }
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_fn_sig, code = "FLUX")]
+    pub struct UnsupportedFnSig {
+        #[primary_span]
+        pub span: Span,
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(lowering::unsupported_statement, code = "FLUX")]
+    pub struct UnsupportedStatement {
+        #[primary_span]
+        pub span: Span,
+        pub statement: String,
+    }
+
+    impl UnsupportedStatement {
+        pub fn new(statement: &rustc_mir::Statement) -> Self {
+            Self { span: statement.source_info.span, statement: format!("{statement:?}") }
+        }
+    }
 }

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -1,3 +1,4 @@
+pub use errors::UnsupportedFnSig;
 use flux_common::index::IndexVec;
 use flux_errors::{FluxSession, ResultExt};
 use itertools::Itertools;

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -6,6 +6,7 @@ pub use rustc_middle::{
     mir::Mutability,
     ty::{FloatTy, IntTy, ParamTy, ScalarInt, UintTy},
 };
+use rustc_span::Symbol;
 
 use crate::intern::{impl_internable, Interned, List};
 
@@ -17,6 +18,8 @@ pub struct Generics<'tcx> {
 #[derive(Hash, Eq, PartialEq)]
 pub struct GenericParamDef {
     pub def_id: DefId,
+    pub index: u32,
+    pub name: Symbol,
     pub kind: GenericParamDefKind,
 }
 


### PR DESCRIPTION
Propagate unsupported function signatures errors and report the span of the offending function call.