### PR TITLE
Initial support for structs with generic lifetimes

### DIFF
--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -308,35 +308,14 @@ impl<'genv, 'tcx> NameResTable<'genv, 'tcx> {
             TyKind::Int(int_ty) => Ok(Res::Int(*int_ty)),
             TyKind::Uint(uint_ty) => Ok(Res::Uint(*uint_ty)),
             TyKind::Float(float_ty) => Ok(Res::Float(*float_ty)),
-            TyKind::Param(pty) => Ok(Res::Param(*pty)),
-            // TyKind::Adt(did, what) => todo!(),
-            // TyKind::Char => todo!(),
+            TyKind::Param(param_ty) => Ok(Res::Param(*param_ty)),
+            TyKind::Char => Ok(Res::Char),
             _ => {
-            Err(self.sess.emit_err(errors::UnsupportedSignature {
-                span,
-                msg: "path resolved to an unsupported type",
-            }))
-        }
-            // rustc_type_ir::TyKind::Foreign(_) => todo!(),
-            // rustc_type_ir::TyKind::Str => todo!(),
-            // rustc_type_ir::TyKind::Array(_, _) => todo!(),
-            // rustc_type_ir::TyKind::Slice(_) => todo!(),
-            // rustc_type_ir::TyKind::RawPtr(_) => todo!(),
-            // rustc_type_ir::TyKind::Ref(_, _, _) => todo!(),
-            // rustc_type_ir::TyKind::FnDef(_, _) => todo!(),
-            // rustc_type_ir::TyKind::FnPtr(_) => todo!(),
-            // rustc_type_ir::TyKind::Dynamic(_, _) => todo!(),
-            // rustc_type_ir::TyKind::Closure(_, _) => todo!(),
-            // rustc_type_ir::TyKind::Generator(_, _, _) => todo!(),
-            // rustc_type_ir::TyKind::GeneratorWitness(_) => todo!(),
-            // rustc_type_ir::TyKind::Never => todo!(),
-            // rustc_type_ir::TyKind::Tuple(_) => todo!(),
-            // rustc_type_ir::TyKind::Projection(_) => todo!(),
-            // rustc_type_ir::TyKind::Opaque(_, _) => todo!(),
-            // rustc_type_ir::TyKind::Bound(_, _) => todo!(),
-            // rustc_type_ir::TyKind::Placeholder(_) => todo!(),
-            // rustc_type_ir::TyKind::Infer(_) => todo!(),
-            // rustc_type_ir::TyKind::Error(_) => todo!(),
+                Err(self.sess.emit_err(errors::UnsupportedSignature {
+                    span,
+                    msg: "path resolved to an unsupported type",
+                }))
+            }
         }
     }
 

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -401,12 +401,7 @@ impl<'genv, 'tcx> NameResTable<'genv, 'tcx> {
     fn collect_from_generic_arg(&mut self, arg: &hir::GenericArg) -> Result<(), ErrorGuaranteed> {
         match arg {
             hir::GenericArg::Type(ty) => self.collect_from_ty(ty),
-            hir::GenericArg::Lifetime(_) => {
-                Err(self.sess.emit_err(errors::UnsupportedSignature {
-                    span: arg.span(),
-                    msg: "lifetime parameters are not supported yet",
-                }))
-            }
+            hir::GenericArg::Lifetime(_) => Ok(()),
             hir::GenericArg::Const(_) => {
                 Err(self.sess.emit_err(errors::UnsupportedSignature {
                     span: arg.span(),

--- a/flux-desugar/src/zip_checker.rs
+++ b/flux-desugar/src/zip_checker.rs
@@ -162,8 +162,9 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
     fn zip_path(&self, path: &Path<Res>, rust_ty: &rustc_ty::Ty) -> Result<(), ErrorGuaranteed> {
         match (&path.ident, rust_ty.kind()) {
             (Res::Adt(def_id1), rustc_ty::TyKind::Adt(def_id2, substs)) if def_id1 == def_id2 => {
-                let max_args = substs.len();
-                let default_args = self.tcx.generics_of(def_id1).own_defaults().types;
+                let generics = self.tcx.generics_of(def_id1);
+                let max_args = generics.own_counts().types;
+                let default_args = generics.own_defaults().types;
                 let min_args = max_args - default_args;
 
                 let found = path.args.len();
@@ -177,8 +178,7 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
                         .emit_err(errors::TooManyArgs::new(path.span, found, max_args)))
                 } else {
                     // zip the supplied args
-                    iter::zip(&path.args, substs)
-                        .try_for_each_exhaust(|(arg, rust_arg)| self.zip_generic_arg(arg, rust_arg))
+                    self.zip_generic_args(&path.args, substs)
                 }
             }
             (Res::Uint(uint_ty1), rustc_ty::TyKind::Uint(uint_ty2)) if uint_ty1 == uint_ty2 => {
@@ -223,15 +223,20 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
         }
     }
 
-    fn zip_generic_arg(
+    fn zip_generic_args(
         &self,
-        arg: &Ty<Res>,
-        rust_arg: &rustc_ty::GenericArg,
+        args: &[Ty<Res>],
+        rust_args: &[rustc_ty::GenericArg],
     ) -> Result<(), ErrorGuaranteed> {
-        match rust_arg {
-            rustc_ty::GenericArg::Ty(ty) => self.zip_ty(arg, ty),
-            rustc_ty::GenericArg::Lifetime(_) => todo!(),
-        }
+        let rust_args = rust_args.iter().filter_map(|rust_arg| {
+            match rust_arg {
+                rustc_ty::GenericArg::Ty(ty) => Some(ty),
+                rustc_ty::GenericArg::Lifetime(_) => None,
+            }
+        });
+        iter::zip(args, rust_args)
+            .into_iter()
+            .try_for_each_exhaust(|(arg, rust_arg)| self.zip_ty(arg, rust_arg))
     }
 }
 

--- a/flux-desugar/src/zip_checker.rs
+++ b/flux-desugar/src/zip_checker.rs
@@ -56,8 +56,9 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
     pub fn zip_fn_sig(
         &self,
         sig: &FnSig<Res>,
-        rust_sig: &rustc_ty::FnSig,
+        rust_sig: &rustc_ty::PolyFnSig,
     ) -> Result<(), ErrorGuaranteed> {
+        let rust_sig = rust_sig.as_ref().skip_binder();
         let mut locs = Locs::new();
         self.zip_args(sig.span, &sig.args, rust_sig.inputs(), &mut locs)?;
         self.zip_return_ty(sig.span, &sig.returns, &rust_sig.output())?;
@@ -229,6 +230,7 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
     ) -> Result<(), ErrorGuaranteed> {
         match rust_arg {
             rustc_ty::GenericArg::Ty(ty) => self.zip_ty(arg, ty),
+            rustc_ty::GenericArg::Lifetime(_) => todo!(),
         }
     }
 }

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -136,7 +136,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         let span = item.span;
         let val = match eval_const(self.tcx, def_id) {
             Some(val) => val,
-            None => return self.emit_err(errors::InvalidConstant { span }),
+            None => return Err(self.emit_err(errors::InvalidConstant { span })),
         };
 
         let size = val.size();
@@ -144,7 +144,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             self.specs.consts.insert(def_id, ConstSig { _ty, val });
             Ok(())
         } else {
-            self.emit_err(errors::InvalidConstant { span })
+            Err(self.emit_err(errors::InvalidConstant { span }))
         }
     }
     fn parse_tyalias_spec(
@@ -289,7 +289,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
     fn parse_flux_attr(&mut self, attr_item: &AttrItem) -> Result<FluxAttr, ErrorGuaranteed> {
         let segment = match &attr_item.path.segments[..] {
             [_, segment] => segment,
-            _ => return self.emit_err(errors::InvalidAttr { span: attr_item.span() }),
+            _ => return Err(self.emit_err(errors::InvalidAttr { span: attr_item.span() })),
         };
 
         let kind = match (segment.ident.as_str(), &attr_item.args) {
@@ -338,7 +338,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             ("ignore", MacArgs::Empty) => FluxAttrKind::Ignore,
             ("opaque", MacArgs::Empty) => FluxAttrKind::Opaque,
             ("assume", MacArgs::Empty) => FluxAttrKind::Assume,
-            _ => return self.emit_err(errors::InvalidAttr { span: attr_item.span() }),
+            _ => return Err(self.emit_err(errors::InvalidAttr { span: attr_item.span() })),
         };
         Ok(FluxAttr { kind, span: attr_item.span() })
     }
@@ -349,9 +349,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         input_span: Span,
         parser: impl FnOnce(TokenStream, Span) -> ParseResult<T>,
     ) -> Result<T, ErrorGuaranteed> {
-        parser(tokens, input_span)
-            .map_err(errors::SyntaxErr::from)
-            .emit(self.sess)
+        parser(tokens, input_span).map_err(|err| self.emit_err(errors::SyntaxErr::from(err)))
     }
 
     fn report_dups(&mut self, attrs: &FluxAttrs) -> Result<(), ErrorGuaranteed> {
@@ -360,10 +358,8 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 if attr.allow_dups() {
                     continue;
                 }
-                self.error_guaranteed = Some(
-                    self.sess
-                        .emit_err(errors::DuplicatedAttr { span: attr.span, name }),
-                );
+                self.error_guaranteed =
+                    Some(self.emit_err(errors::DuplicatedAttr { span: attr.span, name }));
             }
         }
         if let Some(e) = self.error_guaranteed {
@@ -373,10 +369,10 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         }
     }
 
-    fn emit_err<T>(&mut self, err: impl IntoDiagnostic<'a>) -> Result<T, ErrorGuaranteed> {
+    fn emit_err(&mut self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         let e = self.sess.emit_err(err);
         self.error_guaranteed = Some(e);
-        Err(e)
+        e
     }
 }
 

--- a/flux-errors/locales/en-US/refineck.ftl
+++ b/flux-errors/locales/en-US/refineck.ftl
@@ -35,5 +35,5 @@ refineck_opaque_struct_error =
     cannot access fields of opaque struct `{$struct}`
 
 refineck_unsupported_call =
-    call to a function with an unsupported type
+    unsupported type in function call
     .function_definition = function defined here

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -146,7 +146,8 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         debug_assert_eq!(self.generics_of(def_id).params.len(), 2);
         debug_assert!(adt_def.sorts().is_empty());
 
-        let bty = rty::BaseTy::adt(adt_def, vec![ty, alloc]);
+        let bty =
+            rty::BaseTy::adt(adt_def, vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)]);
         rty::Ty::indexed(bty, vec![])
     }
 
@@ -303,9 +304,9 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         &self,
         ty: &rustc::ty::GenericArg,
         mk_pred: &mut impl FnMut(&[rty::Sort]) -> Binders<rty::Pred>,
-    ) -> rty::Ty {
+    ) -> rty::GenericArg {
         match ty {
-            rustc::ty::GenericArg::Ty(ty) => self.refine_ty(ty, mk_pred),
+            rustc::ty::GenericArg::Ty(ty) => rty::GenericArg::Ty(self.refine_ty(ty, mk_pred)),
         }
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -119,7 +119,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     }
 
     fn default_fn_sig(&self, def_id: DefId) -> Result<rty::PolySig, UnsupportedFnSig> {
-        let fn_sig = rustc::lowering::lower_fn_sig_of(self.tcx, def_id)?;
+        let fn_sig = rustc::lowering::lower_fn_sig_of(self.tcx, def_id)?.skip_binder();
         Ok(self.refine_fn_sig(&fn_sig, &mut |sorts| Binders::new(rty::Pred::tt(), sorts)))
     }
 
@@ -307,6 +307,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     ) -> rty::GenericArg {
         match ty {
             rustc::ty::GenericArg::Ty(ty) => rty::GenericArg::Ty(self.refine_ty(ty, mk_pred)),
+            rustc::ty::GenericArg::Lifetime(_) => rty::GenericArg::Lifetime,
         }
     }
 }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -183,6 +183,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                                 name: param.name,
                             }))
                         }
+                        GenericParamDefKind::Lifetime => rty::GenericArg::Lifetime,
                     }
                 })
                 .collect_vec();
@@ -348,6 +349,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                         GenericParamDefKind::Type { has_default } => {
                             debug_assert!(has_default);
                             rty::GenericArg::Ty(self.genv.default_type_of(generic.def_id))
+                        }
+                        GenericParamDefKind::Lifetime => {
+                            unreachable!("missing lifetime argument during conversion")
                         }
                     }
                 });

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use super::{
-    BaseTy, Binders, Constraint, Expr, ExprKind, FnSig, Index, KVar, Name, Pred, Sort, Ty, TyKind,
-    VariantRet,
+    BaseTy, Binders, Constraint, Expr, ExprKind, FnSig, GenericArg, Index, KVar, Name, Pred, Sort,
+    Ty, TyKind, VariantRet,
 };
 use crate::{
     intern::{Internable, List},
@@ -106,20 +106,21 @@ pub trait TypeFoldable: Sized {
         self.fold_with(&mut WithHoles)
     }
 
-    fn replace_generic_types(&self, tys: &[Ty]) -> Self {
-        struct GenericsFolder<'a>(&'a [Ty]);
+    fn replace_generic_args(&self, args: &[GenericArg]) -> Self {
+        struct GenericsFolder<'a>(&'a [GenericArg]);
 
         impl TypeFolder for GenericsFolder<'_> {
             fn fold_ty(&mut self, ty: &Ty) -> Ty {
                 if let TyKind::Param(param_ty) = ty.kind() {
-                    self.0[param_ty.index as usize].clone()
+                    let GenericArg::Ty(ty) = &self.0[param_ty.index as usize];
+                    ty.clone()
                 } else {
                     ty.super_fold_with(self)
                 }
             }
         }
 
-        self.fold_with(&mut GenericsFolder(tys))
+        self.fold_with(&mut GenericsFolder(args))
     }
 }
 
@@ -321,7 +322,8 @@ impl TypeFoldable for BaseTy {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self {
             BaseTy::Adt(adt_def, substs) => {
-                BaseTy::adt(adt_def.clone(), substs.iter().map(|ty| ty.fold_with(folder)))
+                let substs = List::from_vec(substs.iter().map(|ty| ty.fold_with(folder)).collect());
+                BaseTy::adt(adt_def.clone(), substs)
             }
             BaseTy::Array(ty, c) => BaseTy::Array(ty.fold_with(folder), c.clone()),
             BaseTy::Slice(ty) => BaseTy::Slice(ty.fold_with(folder)),
@@ -344,6 +346,20 @@ impl TypeFoldable for BaseTy {
             | BaseTy::Float(_)
             | BaseTy::Str
             | BaseTy::Char => {}
+        }
+    }
+}
+
+impl TypeFoldable for GenericArg {
+    fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
+        match self {
+            GenericArg::Ty(ty) => GenericArg::Ty(ty.fold_with(folder)),
+        }
+    }
+
+    fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
+        match self {
+            GenericArg::Ty(ty) => ty.visit_with(visitor),
         }
     }
 }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -158,6 +158,8 @@ pub type Substs = List<GenericArg>;
 #[derive(PartialEq, Eq, Hash)]
 pub enum GenericArg {
     Ty(Ty),
+    /// We treat lifetime opaquely
+    Lifetime,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -869,6 +871,7 @@ mod pretty {
             define_scoped!(cx, f);
             match self {
                 GenericArg::Ty(ty) => w!("{:?}", ty),
+                GenericArg::Lifetime => w!("'_"),
             }
         }
     }

--- a/flux-tests/tests/neg/lifetimes/struct_generic_lifetime_mut.rs
+++ b/flux-tests/tests/neg/lifetimes/struct_generic_lifetime_mut.rs
@@ -1,0 +1,14 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+struct S<'a> {
+    #[flux::field(&mut i32{v : v > 0})]
+    x: &'a mut i32,
+}
+
+#[flux::sig(fn(x: i32{x >= 0}))]
+fn test(x: i32) {
+    let mut y = x + 1;
+    let mut s = S { x: &mut y };
+    *s.x -= 1; //~ ERROR assignment might be unsafe
+}

--- a/flux-tests/tests/neg/lifetimes/struct_generic_lifetime_shr.rs
+++ b/flux-tests/tests/neg/lifetimes/struct_generic_lifetime_shr.rs
@@ -1,0 +1,18 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+struct S<'a> {
+    #[flux::field(&i32{v : v > 0})]
+    x: &'a i32,
+}
+
+#[flux::sig(fn(x: i32))]
+fn construct(x: i32) {
+    let y = x + 1;
+    let s = S { x: &y }; //~ ERROR precondition
+}
+
+#[flux::sig(fn(x: S) -> i32{v : v > 0})]
+fn project(s: S) -> i32 {
+    *s.x - 1 //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/lifetimes/struct_generic_lifetime_mut.rs
+++ b/flux-tests/tests/pos/lifetimes/struct_generic_lifetime_mut.rs
@@ -1,0 +1,14 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+struct S<'a> {
+    #[flux::field(&mut i32{v : v > 0})]
+    x: &'a mut i32,
+}
+
+#[flux::sig(fn(x: i32{x >= 0}))]
+fn test(x: i32) {
+    let mut y = x + 1;
+    let mut s = S { x: &mut y };
+    *s.x += 1;
+}

--- a/flux-tests/tests/pos/lifetimes/struct_generic_lifetime_shr.rs
+++ b/flux-tests/tests/pos/lifetimes/struct_generic_lifetime_shr.rs
@@ -1,0 +1,18 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+struct S<'a> {
+    #[flux::field(&i32{v : v > 0})]
+    x: &'a i32,
+}
+
+#[flux::sig(fn(x: i32{x >= 0}))]
+fn construct(x: i32) {
+    let y = x + 1;
+    let s = S { x: &y };
+}
+
+#[flux::sig(fn(x: S) -> i32{v : v > 0})]
+fn project(s: S) -> i32 {
+    *s.x + 1
+}

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -1100,7 +1100,7 @@ pub(crate) mod errors {
     pub enum CheckerErrKind {
         Inference,
         OpaqueStruct(DefId),
-        UnsupportedCall { def_span: Span },
+        UnsupportedCall { def_span: Span, reason: String },
     }
 
     impl CheckerError {
@@ -1139,8 +1139,9 @@ pub(crate) mod errors {
                 CheckerErrKind::OpaqueStruct(def_id) => {
                     builder.set_arg("struct", pretty::def_id_to_string(def_id));
                 }
-                CheckerErrKind::UnsupportedCall { def_span } => {
+                CheckerErrKind::UnsupportedCall { def_span, reason } => {
                     builder.span_note(def_span, refineck::function_definition);
+                    builder.note(reason);
                 }
             }
             builder
@@ -1162,7 +1163,7 @@ pub(crate) mod errors {
     impl From<UnsupportedFnSig> for CheckerError {
         fn from(err: UnsupportedFnSig) -> Self {
             CheckerError {
-                kind: CheckerErrKind::UnsupportedCall { def_span: err.span },
+                kind: CheckerErrKind::UnsupportedCall { def_span: err.span, reason: err.reason },
                 span: None,
             }
         }

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -131,8 +131,9 @@ fn infer_from_generic_args(
     env2: &impl PathMap,
     arg2: &GenericArg,
 ) {
-    let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2);
-    infer_from_tys(exprs, env1, ty1, env2, ty2)
+    if let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2) {
+        infer_from_tys(exprs, env1, ty1, env2, ty2)
+    }
 }
 
 fn infer_from_exprs(exprs: &mut Exprs, e1: &Expr, e2: &Expr) {

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use flux_middle::rty::{
-    subst::FVarSubst, BaseTy, Binders, Constraint, Expr, ExprKind, Name, Path, PolySig,
+    subst::FVarSubst, BaseTy, Binders, Constraint, Expr, ExprKind, GenericArg, Name, Path, PolySig,
     PolyVariant, Ty, TyKind, INNERMOST,
 };
 use rustc_hash::FxHashMap;
@@ -78,13 +78,8 @@ pub fn check_inference(
     }
     Ok(())
 }
-fn infer_from_tys<M1: PathMap, M2: PathMap>(
-    exprs: &mut Exprs,
-    env1: &M1,
-    ty1: &Ty,
-    env2: &M2,
-    ty2: &Ty,
-) {
+
+fn infer_from_tys(exprs: &mut Exprs, env1: &impl PathMap, ty1: &Ty, env2: &impl PathMap, ty2: &Ty) {
     match (ty1.unconstr().kind(), ty2.unconstr().kind()) {
         (TyKind::Indexed(_, indices1), TyKind::Indexed(_, indices2)) => {
             for (idx1, idx2) in iter::zip(indices1, indices2) {
@@ -111,11 +106,11 @@ fn infer_from_tys<M1: PathMap, M2: PathMap>(
     infer_from_btys(exprs, env1, ty1, env2, ty2);
 }
 
-fn infer_from_btys<M1: PathMap, M2: PathMap>(
+fn infer_from_btys(
     exprs: &mut Exprs,
-    env1: &M1,
+    env1: &impl PathMap,
     ty1: &Ty,
-    env2: &M2,
+    env2: &impl PathMap,
     ty2: &Ty,
 ) {
     if let Some(bt1) = ty1.bty() &&
@@ -124,12 +119,23 @@ fn infer_from_btys<M1: PathMap, M2: PathMap>(
        let BaseTy::Adt(_, args2) = bt2 &&
        bt1.is_box() {
             for (arg1, arg2) in iter::zip(args1, args2) {
-                infer_from_tys(exprs, env1, arg1, env2, arg2);
+                infer_from_generic_args(exprs, env1, arg1, env2, arg2);
             }
        }
 }
 
-pub fn infer_from_exprs(exprs: &mut Exprs, e1: &Expr, e2: &Expr) {
+fn infer_from_generic_args(
+    exprs: &mut Exprs,
+    env1: &impl PathMap,
+    arg1: &GenericArg,
+    env2: &impl PathMap,
+    arg2: &GenericArg,
+) {
+    let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2);
+    infer_from_tys(exprs, env1, ty1, env2, ty2)
+}
+
+fn infer_from_exprs(exprs: &mut Exprs, e1: &Expr, e2: &Expr) {
     match (e1.kind(), e2.kind()) {
         (_, ExprKind::BoundVar(bvar)) if bvar.debruijn == INNERMOST => {
             if let Some(old_e) = exprs.insert(bvar.index, e1.clone()) {

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -234,8 +234,9 @@ impl TypeEnv {
         arg2: &GenericArg,
         subst: &mut FVarSubst,
     ) {
-        let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2);
-        self.infer_subst_for_bb_env_ty(bb_env, params, ty1, ty2, subst);
+        if let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2) {
+            self.infer_subst_for_bb_env_ty(bb_env, params, ty1, ty2, subst);
+        }
     }
 
     fn infer_subst_for_bb_env_bty(
@@ -430,6 +431,7 @@ impl TypeEnvInfer {
     fn pack_generic_arg(scope: &Scope, arg: &GenericArg) -> GenericArg {
         match arg {
             GenericArg::Ty(ty) => GenericArg::Ty(Self::pack_ty(scope, ty)),
+            GenericArg::Lifetime => GenericArg::Lifetime,
         }
     }
 
@@ -570,7 +572,7 @@ impl TypeEnvInfer {
                 );
                 Ty::tuple(vec![])
             }
-            _ => todo!("`{ty1:?}` -- `{ty2:?}`"),
+            _ => unreachable!("`{ty1:?}` -- `{ty2:?}`"),
         }
     }
 
@@ -601,6 +603,8 @@ impl TypeEnvInfer {
             (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) => {
                 GenericArg::Ty(self.join_ty(genv, ty1, ty2))
             }
+            (GenericArg::Lifetime, GenericArg::Lifetime) => GenericArg::Lifetime,
+            _ => panic!("incompatible generic args: `{arg1:?}` `{arg2:?}`"),
         }
     }
 

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -5,9 +5,10 @@ use std::iter;
 use flux_common::index::IndexGen;
 use flux_middle::{
     global_env::{GlobalEnv, OpaqueStructErr},
+    intern::List,
     rty::{
-        fold::TypeFoldable, subst::FVarSubst, BaseTy, Binders, Expr, Index, Path, RefKind, Ty,
-        TyKind,
+        box_args, fold::TypeFoldable, subst::FVarSubst, BaseTy, Binders, Expr, GenericArg, Index,
+        Path, RefKind, Ty, TyKind,
     },
     rustc::mir::{Local, Place, PlaceElem},
 };
@@ -225,6 +226,18 @@ impl TypeEnv {
         }
     }
 
+    fn infer_subst_for_bb_env_generic_arg(
+        &self,
+        bb_env: &BasicBlockEnv,
+        params: &FxHashSet<Name>,
+        arg1: &GenericArg,
+        arg2: &GenericArg,
+        subst: &mut FVarSubst,
+    ) {
+        let (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) = (arg1, arg2);
+        self.infer_subst_for_bb_env_ty(bb_env, params, ty1, ty2, subst);
+    }
+
     fn infer_subst_for_bb_env_bty(
         &self,
         bb_env: &BasicBlockEnv,
@@ -236,8 +249,8 @@ impl TypeEnv {
         if bty1.is_box()  &&
            let BaseTy::Adt(_, substs1) = bty1 &&
            let BaseTy::Adt(_, substs2) = bty2 {
-            for (ty1, ty2) in iter::zip(substs1, substs2) {
-                self.infer_subst_for_bb_env_ty(bb_env, params, ty1, ty2, subst);
+            for (arg1, arg2) in iter::zip(substs1, substs2) {
+                self.infer_subst_for_bb_env_generic_arg(bb_env, params, arg1, arg2, subst);
             }
         }
     }
@@ -395,7 +408,12 @@ impl TypeEnvInfer {
     fn pack_bty(scope: &Scope, bty: &BaseTy) -> BaseTy {
         match bty {
             BaseTy::Adt(adt_def, substs) => {
-                let substs = substs.iter().map(|ty| Self::pack_ty(scope, ty));
+                let substs = List::from_vec(
+                    substs
+                        .iter()
+                        .map(|arg| Self::pack_generic_arg(scope, arg))
+                        .collect(),
+                );
                 BaseTy::adt(adt_def.clone(), substs)
             }
             BaseTy::Array(ty, c) => BaseTy::Array(Self::pack_ty(scope, ty), c.clone()),
@@ -406,6 +424,12 @@ impl TypeEnvInfer {
             | BaseTy::Float(_)
             | BaseTy::Str
             | BaseTy::Char => bty.clone(),
+        }
+    }
+
+    fn pack_generic_arg(scope: &Scope, arg: &GenericArg) -> GenericArg {
+        match arg {
+            GenericArg::Ty(ty) => GenericArg::Ty(Self::pack_ty(scope, ty)),
         }
     }
 
@@ -554,14 +578,29 @@ impl TypeEnvInfer {
         if let (BaseTy::Adt(def1, substs1), BaseTy::Adt(def2, substs2)) = (bty1, bty2) {
             debug_assert_eq!(def1.def_id(), def2.def_id());
             let variances = genv.variances_of(def1.def_id());
-            let substs = izip!(variances, substs1, substs2).map(|(variance, ty1, ty2)| {
-                assert!(matches!(variance, rustc_middle::ty::Variance::Covariant));
-                self.join_ty(genv, ty1, ty2)
-            });
-            BaseTy::adt(def1.clone(), substs)
+            let substs = izip!(variances, substs1, substs2)
+                .map(|(variance, arg1, arg2)| {
+                    assert!(matches!(variance, rustc_middle::ty::Variance::Covariant));
+                    self.join_generic_arg(genv, arg1, arg2)
+                })
+                .collect();
+            BaseTy::adt(def1.clone(), List::from_vec(substs))
         } else {
             debug_assert_eq!(bty1, bty2);
             bty1.clone()
+        }
+    }
+
+    fn join_generic_arg(
+        &self,
+        genv: &GlobalEnv,
+        arg1: &GenericArg,
+        arg2: &GenericArg,
+    ) -> GenericArg {
+        match (arg1, arg2) {
+            (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) => {
+                GenericArg::Ty(self.join_ty(genv, ty1, ty2))
+            }
         }
     }
 
@@ -649,8 +688,9 @@ fn generalize_bty(
 ) -> BaseTy {
     match bty {
         BaseTy::Adt(adt_def, substs) if adt_def.is_box() => {
-            let ty = generalize(name_gen, &substs[0], names, sorts, preds);
-            BaseTy::adt(adt_def.clone(), vec![ty, substs[1].clone()])
+            let (boxed, alloc) = box_args(substs);
+            let boxed = generalize(name_gen, boxed, names, sorts, preds);
+            BaseTy::adt(adt_def.clone(), vec![GenericArg::Ty(boxed), GenericArg::Ty(alloc.clone())])
         }
         _ => bty.clone(),
     }


### PR DESCRIPTION
Implement support for structs with generic lifetimes by treating them opaquely during refinement type checking. The implementation tries to keep lifetime information as much as possible, thus, lifetimes are lowered into `flux_middle::rustc::ty` but then "erased" during conversion in `flux_middle::rty::conv`. The parser doesn't support lifetimes, but a function with lifetime annotations can be refined the flux annotation just needs to omit the lifetime, e.g.,

```rust
struct S<'a, T> { x: &'a T }

#[flux::sig(fn(S<i32{v: v >= 0}>) -> i32{v : v > 0})]
fn foo<'a>(s: S<'a, i32>) -> i32 {
    *x.s + 1
}
```
note:
we still don't support iteration over `Vec` because the signature of `IntoIterator` instantiated for `Vec` has a type projection.