### PR TITLE
Tweak pprint

### DIFF
--- a/flux-middle/src/pretty.rs
+++ b/flux-middle/src/pretty.rs
@@ -110,15 +110,15 @@ macro_rules! _impl_debug_with_default_cx {
 
 pub use crate::_impl_debug_with_default_cx as impl_debug_with_default_cx;
 
-pub enum Visibility {
-    Show,
+pub enum KVarArgs {
+    All,
+    SelfOnly,
     Hide,
-    Truncate(usize),
 }
 
 pub struct PPrintCx<'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    pub kvar_args: Visibility,
+    pub kvar_args: KVarArgs,
     pub fully_qualified_paths: bool,
     pub simplify_exprs: bool,
     pub tags: bool,
@@ -166,7 +166,7 @@ impl PPrintCx<'_> {
     pub fn default(tcx: TyCtxt) -> PPrintCx {
         PPrintCx {
             tcx,
-            kvar_args: Visibility::Show,
+            kvar_args: KVarArgs::SelfOnly,
             fully_qualified_paths: false,
             simplify_exprs: true,
             tags: true,
@@ -194,7 +194,7 @@ impl PPrintCx<'_> {
         );
     }
 
-    pub fn kvar_args(self, kvar_args: Visibility) -> Self {
+    pub fn kvar_args(self, kvar_args: KVarArgs) -> Self {
         Self { kvar_args, ..self }
     }
 
@@ -343,19 +343,12 @@ impl FromOpt for bool {
     }
 }
 
-impl FromOpt for Visibility {
+impl FromOpt for KVarArgs {
     fn from_opt(opt: &config::Value) -> Option<Self> {
         match opt.as_str() {
-            Some("show") => Some(Visibility::Show),
-            Some("hide") => Some(Visibility::Hide),
-            Some(s) => {
-                let n = s
-                    .strip_prefix("truncate(")?
-                    .strip_suffix(')')?
-                    .parse()
-                    .ok()?;
-                Some(Visibility::Truncate(n))
-            }
+            Some("self") => Some(KVarArgs::SelfOnly),
+            Some("hide") => Some(KVarArgs::Hide),
+            Some("all") => Some(KVarArgs::All),
             _ => None,
         }
     }

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -489,7 +489,6 @@ mod pretty {
     use flux_common::format::PadAdapter;
     use flux_middle::{intern::List, pretty::*};
     use itertools::Itertools;
-    use rustc_middle::ty::TyCtxt;
 
     use super::*;
 
@@ -549,10 +548,6 @@ mod pretty {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!("{:?}", &self.root)
-        }
-
-        fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx).kvar_args(Visibility::Truncate(1))
         }
     }
 
@@ -657,15 +652,11 @@ mod pretty {
                             NodeKind::ForAll(name, sort) => {
                                 f(&format_args_cx!("{:?}: {:?}", ^name, sort))
                             }
-                            NodeKind::Guard(e) => f(&format_args!("{:?}", e)),
+                            NodeKind::Guard(pred) => f(&format_args_cx!("{:?}", pred)),
                             NodeKind::Conj | NodeKind::Head(..) => unreachable!(),
                         }
                     })
             )
-        }
-
-        fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx).kvar_args(Visibility::Truncate(1))
         }
     }
 

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -723,7 +723,7 @@ mod pretty {
         }
 
         fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx).kvar_args(Visibility::Hide)
+            PPrintCx::default(tcx).kvar_args(KVarArgs::Hide)
         }
     }
 
@@ -734,7 +734,7 @@ mod pretty {
         }
 
         fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx).kvar_args(Visibility::Hide)
+            PPrintCx::default(tcx).kvar_args(KVarArgs::Hide)
         }
     }
 
@@ -763,7 +763,7 @@ mod pretty {
         }
 
         fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx).kvar_args(Visibility::Hide)
+            PPrintCx::default(tcx).kvar_args(KVarArgs::Hide)
         }
     }
 

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -685,6 +685,7 @@ mod pretty {
 
     use flux_middle::pretty::*;
     use itertools::Itertools;
+    use rustc_middle::ty::TyCtxt;
 
     use super::*;
 
@@ -710,6 +711,10 @@ mod pretty {
                         }
                     })
             )
+        }
+
+        fn default_cx(tcx: TyCtxt) -> PPrintCx {
+            PPrintCx::default(tcx).kvar_args(KVarArgs::Hide)
         }
     }
 


### PR DESCRIPTION
* Use `[]` instead of `<>` when pprinting indexed types
* Update pprint format for kvars and config to distinguish between self args and the scope (closes #204)