### PR TITLE
Accept more types with arg syntax

### DIFF
--- a/flux-desugar/src/annot_check.rs
+++ b/flux-desugar/src/annot_check.rs
@@ -167,7 +167,7 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
 
     fn zip_arg(&self, arg: &Arg<Res>, rust_ty: &rustc_ty::Ty) -> Result<(), ErrorGuaranteed> {
         match (arg, rust_ty.kind()) {
-            (Arg::Ty(ty), _) => self.zip_ty(ty, rust_ty),
+            (Arg::Ty(_, ty), _) => self.zip_ty(ty, rust_ty),
             (Arg::Constr(_, path, _), _) => self.zip_path(path, rust_ty),
             (Arg::StrgRef(_, ty), rustc_ty::TyKind::Ref(rust_ty, Mutability::Mut)) => {
                 self.zip_ty(ty, rust_ty)

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -129,7 +129,7 @@ impl<'sess, 'tcx> Resolver<'sess, 'tcx> {
                 Ok(surface::Arg::Constr(bind, self.resolve_path(path)?, pred))
             }
             surface::Arg::StrgRef(loc, ty) => Ok(surface::Arg::StrgRef(loc, self.resolve_ty(ty)?)),
-            surface::Arg::Ty(ty) => Ok(surface::Arg::Ty(self.resolve_ty(ty)?)),
+            surface::Arg::Ty(bind, ty) => Ok(surface::Arg::Ty(bind, self.resolve_ty(ty)?)),
             surface::Arg::Alias(_, _, _) => panic!("Unexpected 'Alias' in resolve_arg"),
         }
     }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -107,7 +107,8 @@ pub enum Arg<T = Ident> {
     Alias(Ident, Path<T>, Indices),
     /// example `v: &strg i32`
     StrgRef(Ident, Ty<T>),
-    /// A type with an optional bindner, e.g, `i32`, `x: i32` or `x: i32{v : v > 0}`
+    /// A type with an optional binder, e.g, `i32`, `x: i32` or `x: i32{v : v > 0}`.
+    /// The binder has a different meaning depending on the type.
     Ty(Option<Ident>, Ty<T>),
 }
 

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -99,16 +99,14 @@ Ensures = <Comma<(<Ident> ":" <Ty>)>>;
 
 
 Arg: surface::Arg = {
-    <bind:Ident> ":" "&" "strg" <ty:Ty>                    => surface::Arg::StrgRef(bind, ty),
-    <bind:Ident> ":" <path:Path>                           => surface::Arg::Constr(bind, path, None),
-    <bind:Ident> ":" <path:Path> "{" <pred:Level1> "}"     => surface::Arg::Constr(bind, path, Some(pred)),
-    <bind:Ident> ":" <path:Path> "[" <indices:Indices> "]" => surface::Arg::Alias(bind, path, indices),
-    <bind:Ident> ":" <lo:@L> "&" "mut" <ty:Ty> <hi:@R> => {
-        let kind = surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty));
-        let arg_ty = surface::Ty { kind, span: mk_span(lo, hi) };
-        surface::Arg::Ty(arg_ty)
+    <bind:Ident> ":" "&" "strg" <ty:Ty>                    => surface::Arg::StrgRef(<>),
+    <bind:Ident> ":" <path:Path> "{" <pred:Level1> "}"     => surface::Arg::Constr(<>),
+    <bind:Ident> ":" <path:Path> "[" <indices:Indices> "]" => surface::Arg::Alias(<>),
+    <bind:Ident> ":" <lo:@L> <kind:ArgTyKind> <hi:@R> => {
+        let ty = surface::Ty { kind, span: mk_span(lo, hi) };
+        surface::Arg::Ty(Some(bind), ty)
     },
-    <ty:Ty> => surface::Arg::Ty(<>),
+    <ty:Ty> => surface::Arg::Ty(None, <>),
 }
 
 pub Ty: surface::Ty = {
@@ -118,7 +116,8 @@ pub Ty: surface::Ty = {
     }
 }
 
-TyKind: surface::TyKind = {
+// FIXME(nilehmann) We can't parse all types using the `x: T` syntax because it conflicts with aliases.
+ArgTyKind: surface::TyKind = {
     "&"        <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),
     "&" "mut"  <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty)),
 
@@ -126,7 +125,6 @@ TyKind: surface::TyKind = {
 
     <path:Path>                                        => surface::TyKind::Path(<>),
     <path:Path> "{" <bind:Ident> ":" <pred:Level1> "}" => surface::TyKind::Exists { <> },
-    <path:Path> "[" <indices:Indices> "]"              => surface::TyKind::Indexed { <> },
 
     "[" <ty:Ty> ";"  <lo:@L> <ident:Ident> <hi:@R> "]" =>? {
         if ident.name.as_str() == "_" {
@@ -136,9 +134,13 @@ TyKind: surface::TyKind = {
         }
     },
     "[" <ty:Ty> "]" => surface::TyKind::Slice(Box::new(ty)),
-    "[" <ty:Ty> "]""[" <indices:Indices> "]" => surface::TyKind::Slice(Box::new(ty)),
 
     "(" ")"  => surface::TyKind::Unit
+}
+
+TyKind: surface::TyKind = {
+    <ArgTyKind>,
+    <path:Path> "[" <indices:Indices> "]" => surface::TyKind::Indexed { <> },
 }
 
 GenericArgs: Vec<surface::Ty> = {

--- a/flux-tests/tests/neg/surface/arg_syntax.rs
+++ b/flux-tests/tests/neg/surface/arg_syntax.rs
@@ -1,0 +1,27 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x: i32{v : v > 0 && x < 10}) -> i32{v : v > x && v < 10})]
+fn exists(x: i32) -> i32 {
+    x + 1 //~ ERROR postcondition
+}
+
+#[flux::sig(fn(x: &i32[@n]) -> i32[n + 1])]
+fn shr_ref(x: &i32) -> i32 {
+    *x + 2 //~ ERROR postcondition
+}
+
+#[flux::sig(fn(x: i32) -> i32[x + 1])]
+fn path(x: i32) -> i32 {
+    x + 2 //~ ERROR postcondition
+}
+
+#[flux::sig(fn(x: [i32{v : v >= 0}; _]) -> [i32{v : v > 0}; _])]
+fn arr(x: [i32; 1]) -> [i32; 1] {
+    x //~ ERROR postcondition
+}
+
+#[flux::sig(fn(x: &[i32{v : v >= 0}]) -> &[i32{v : v > 0}])]
+fn slice(x: &[i32]) -> &[i32] {
+    x //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/arg_syntax.rs
+++ b/flux-tests/tests/pos/surface/arg_syntax.rs
@@ -1,0 +1,27 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x: i32{v : v > 0 && x < 10}) -> i32{v : v > x && v < 11})]
+fn exists(x: i32) -> i32 {
+    x + 1
+}
+
+#[flux::sig(fn(x: &i32[@n]) -> i32[n + 1])]
+fn shr_ref(x: &i32) -> i32 {
+    *x + 1
+}
+
+#[flux::sig(fn(x: i32) -> i32[x + 1])]
+fn path(x: i32) -> i32 {
+    x + 1
+}
+
+#[flux::sig(fn(x: [i32{v : v > 0}; _]) -> [i32{v : v >= 0}; _])]
+fn arr(x: [i32; 1]) -> [i32; 1] {
+    x
+}
+
+#[flux::sig(fn(x: &[i32{v : v > 0}]) -> &[i32{v : v >= 0}])]
+fn slice(x: &[i32]) -> &[i32] {
+    x
+}


### PR DESCRIPTION
Accept more types using `x: T` syntax. The only type we don't support (which we should eventually fix) are indexed types because it conflicts with aliases.