### PR TITLE
Honor #[flux::assumed] even when there's no #[flux::sig] annotation

### DIFF
--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -291,10 +291,13 @@ fn build_fhir_map(
     err = std::mem::take(&mut specs.fns)
         .into_iter()
         .try_for_each_exhaust(|(def_id, spec)| {
+            if spec.assume {
+                map.add_assumed(def_id);
+            }
             if let Some(fn_sig) = spec.fn_sig {
                 let fn_sig = surface::expand::expand_sig(sess, &aliases, fn_sig)?;
                 let fn_sig = desugar::desugar_fn_sig(tcx, sess, &map, def_id, fn_sig)?;
-                map.insert_fn_sig(def_id, fn_sig, spec.assume);
+                map.insert_fn_sig(def_id, fn_sig);
             }
             Ok(())
         })

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -592,7 +592,7 @@ mod pretty {
                     }
                 }
                 ExprKind::App(f, exprs) => {
-                    w!("{f:?}({:?})", join!(", ", exprs))
+                    w!("{}({:?})", ^f, join!(", ", exprs))
                 }
                 ExprKind::IfThenElse(p, e1, e2) => {
                     w!("if {:?} {{ {:?} }} else {{ {:?} }}", p, e1, e2)

--- a/flux-tests/tests/pos/surface/issue-220.rs
+++ b/flux-tests/tests/pos/surface/issue-220.rs
@@ -1,0 +1,11 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(bool[true]))]
+fn assert(_: bool) {}
+
+// We should not check the body of the function
+#[flux::assume]
+fn foo() {
+    assert(0 > 1);
+}


### PR DESCRIPTION
cc #220 