### PR TITLE
Initial support for refinement parameter predicates aka abstract refinements

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -788,8 +788,11 @@ impl Binders {
         match &ty.kind {
             surface::TyKind::Indexed { path, indices } => {
                 let binder = Binder::from_res(&self.name_gen, map, path.ident);
-                if let Some(bind) = bind {
-                    self.insert_binder(sess, bind, binder.clone())?;
+                if let Some(_) = bind {
+                    // This code is currently not reachable because the parser won't allow it as it conflicts with alias
+                    // applications. If we ever allow this we should think about the meaning of the syntax `x: T[@n]` and
+                    // `x: T[n]`. The second syntax should behave appropriately even when `n` is bound
+                    unreachable!("[sanity check] this code is unreachable but we are leaving a not in case it is not anymore");
                 }
                 if let [surface::Index::Bind(ident, span)] = indices.indices[..] {
                     if !allow_binder {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -788,7 +788,7 @@ impl Binders {
         match &ty.kind {
             surface::TyKind::Indexed { path, indices } => {
                 let binder = Binder::from_res(&self.name_gen, map, path.ident);
-                if let Some(_) = bind {
+                if bind.is_some() {
                     // This code is currently not reachable because the parser won't allow it as it conflicts with alias
                     // applications. If we ever allow this we should think about the meaning of the syntax `x: T[@n]` and
                     // `x: T[n]`. The second syntax should behave appropriately even when `n` is bound explicitly in the

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -791,7 +791,9 @@ impl Binders {
                 if let Some(_) = bind {
                     // This code is currently not reachable because the parser won't allow it as it conflicts with alias
                     // applications. If we ever allow this we should think about the meaning of the syntax `x: T[@n]` and
-                    // `x: T[n]`. The second syntax should behave appropriately even when `n` is bound
+                    // `x: T[n]`. The second syntax should behave appropriately even when `n` is bound explicitly in the
+                    // list of refinement parameters, i.e., what's the meaning of `fn<n: int>(x: i32[n])` or the meaning
+                    // of `fn<n: int>(x: RMat[n, n])`
                     unreachable!("[sanity check] this code is unreachable but we are leaving a not in case it is not anymore");
                 }
                 if let [surface::Index::Bind(ident, span)] = indices.indices[..] {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -135,8 +135,8 @@ pub fn desugar_fn_sig(
     let mut cx = DesugarCtxt::new(tcx, sess, map, binders);
 
     if let Some(e) = fn_sig.requires {
-        let e = cx.as_expr_ctxt().desugar_expr(e)?;
-        cx.requires.push(fhir::Constraint::Pred(e));
+        let pred = cx.as_expr_ctxt().desugar_pred(e)?;
+        cx.requires.push(fhir::Constraint::Pred(pred));
     }
 
     // We bail out if there's an error in the arguments to avoid confusing error messages

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -33,7 +33,7 @@ pub fn resolve_uif_def(
         .into_iter()
         .map(|ident| resolve_sort(sess, ident))
         .try_collect_exhaust()?;
-    let output = resolve_sort(sess, uif_def.output)?.clone();
+    let output = resolve_sort(sess, uif_def.output)?;
     Ok(fhir::UifDef { inputs, output })
 }
 
@@ -310,7 +310,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                                     ExprCtxt::new(self.tcx, self.sess, self.map, binders)
                                         .desugar_expr(pred)
                                 })?;
-                            fhir::Ty::Exists(bty, binder.names(), pred)
+                            fhir::Ty::Exists(bty, binder.names(), fhir::Pred::Expr(pred))
                         }
                     }
                     BtyOrTy::Ty(_) => {
@@ -601,7 +601,7 @@ fn resolve_func_sort(
         .iter()
         .map(|sort| resolve_sort(sess, *sort))
         .try_collect_exhaust()?;
-    inputs_and_output.push(resolve_sort(sess, *output)?.clone());
+    inputs_and_output.push(resolve_sort(sess, *output)?);
     Ok(fhir::FuncSort { inputs_and_output: List::from_vec(inputs_and_output) })
 }
 

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -489,7 +489,7 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
             (Some(Binder::Aggregate(..)), _) => todo!(),
             (Some(Binder::Unrefined), _) => todo!(),
             (None, Some(uif)) => Ok(FuncRes::Uif(uif)),
-            (None, None) => todo!(),
+            (None, None) => Err(self.sess.emit_err(errors::UnresolvedVar::new(func))),
         }
     }
 

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -14,7 +14,7 @@ mod annot_check;
 mod desugar;
 mod table_resolver;
 
-pub use desugar::{desugar_adt_def, desugar_qualifier, resolve_sorts, resolve_uif_def};
+pub use desugar::{desugar_adt_def, desugar_qualifier, resolve_uif_def};
 use flux_errors::FluxSession;
 use flux_middle::fhir;
 use flux_syntax::surface::{self, TyCtxt};

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -115,7 +115,7 @@ impl<'sess, 'tcx> Resolver<'sess, 'tcx> {
         let returns = fn_sig.returns.map(|ty| self.resolve_ty(ty)).transpose();
 
         Ok(surface::FnSig {
-            abstract_params: fn_sig.abstract_params,
+            params: fn_sig.params,
             requires: fn_sig.requires,
             args: args?,
             returns: returns?,

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -115,6 +115,7 @@ impl<'sess, 'tcx> Resolver<'sess, 'tcx> {
         let returns = fn_sig.returns.map(|ty| self.resolve_ty(ty)).transpose();
 
         Ok(surface::FnSig {
+            abstract_params: fn_sig.abstract_params,
             requires: fn_sig.requires,
             args: args?,
             returns: returns?,

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -77,7 +77,7 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
     }
 
     let map = build_fhir_map(tcx, sess, &mut specs)?;
-    check_wf(tcx, sess, &map)?;
+    check_wf(sess, &map)?;
 
     let mut genv = GlobalEnv::new(tcx, sess, map);
     // Assert behavior from Crate config
@@ -311,8 +311,8 @@ fn build_fhir_map(
     }
 }
 
-fn check_wf(tcx: TyCtxt, sess: &FluxSession, map: &fhir::Map) -> Result<(), ErrorGuaranteed> {
-    let wf = Wf::new(tcx, sess, map);
+fn check_wf(sess: &FluxSession, map: &fhir::Map) -> Result<(), ErrorGuaranteed> {
+    let wf = Wf::new(sess, map);
 
     let mut err: Option<ErrorGuaranteed> = None;
 

--- a/flux-errors/locales/en-US/annot_check.ftl
+++ b/flux-errors/locales/en-US/annot_check.ftl
@@ -25,7 +25,7 @@ annot_check_field_count_mismatch =
     }
 
 annot_check_path_mismatch =
-    mismatched types
+    invalid refinement annotation
     .label =  expected `{$rust_type}`, found `{$flux_type}`
 
 annot_check_invalid_refinement =

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -49,3 +49,7 @@ desugar_def_span_note =
         [true] {$def_kind} defined here
         *[false] {$def_kind} defined here with no parameters
     }
+
+desugar_illegal_binder =
+    illegal binder
+    .label = binder not allowed in this position

--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -2,9 +2,9 @@ desugar_unresolved_var =
     cannot find value `{$var}` in this scope
     .label = not found in this scope
 
-desugar_unresolved_dot_var =
+desugar_invalid_aggregate_use =
     invalid use of refinement parameter
-    .label = did you mean one of {$msg}?
+    .label = help: did you mean one of {$msg}?
 
 desugar_duplicate_param =
     the name `{$name}` is already used as a parameter
@@ -37,9 +37,9 @@ desugar_invalid_primitive_dot_access =
     .defined_here = `{$name}` defined here with sort `{$sort}`
 
 desugar_invalid_unrefined_param =
-    invalid use of parameter `{$var}`
+    invalid use of refinement parameter
     .label = parameter `{$var}` refers to a type with no indices
-    .defined_here = declared here
+    .defined_here = `{$var}` bound here
 
 desugar_field_not_found =
     no field `{$fld}` on refinement parameters for {$def_kind} `{$def_name}`

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -13,10 +13,6 @@ wf_illegal_binder =
     illegal binder
     .label = binder not allowed in this position
 
-wf_unresolved_function =
-    unresolved function
-    .label = function is not defined in this scope
-
 wf_duplicated_ensures =
     an ensures clause already exists for `{$loc}`
 

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -21,3 +21,10 @@ wf_missing_ensures =
 
 wf_expected_fun =
     expected function, found `{$found}`
+
+wf_invalid_param_in_func_pos =
+    illegal use of refinement parameter
+    .label = {$is_pred ->
+        [true] abstract refinements are only allowed in a top-level conjunction
+        *[false] parameters of sort `{$sort}` are not supported in this position
+     }

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -18,3 +18,6 @@ wf_duplicated_ensures =
 
 wf_missing_ensures =
     missing ensures clause for `&strg` reference
+
+wf_expected_fun =
+    expected function, found `{$found}`

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -38,11 +38,12 @@ pub enum Expr {
     Var(Name),
     Constant(Constant),
     BinaryOp(BinOp, Box<[Expr; 2]>),
-    App(String, Vec<Expr>),
+    App(Box<Expr>, Vec<Expr>),
     UnaryOp(UnOp, Box<Self>),
     Pair(Box<Expr>, Box<Expr>),
     Proj(Box<Expr>, Proj),
     IfThenElse(Box<[Expr; 3]>),
+    Uif(String),
     Unit,
 }
 
@@ -293,11 +294,11 @@ impl fmt::Display for Expr {
             Expr::Proj(e, Proj::Fst) => write!(f, "(fst {e})"),
             Expr::Proj(e, Proj::Snd) => write!(f, "(snd {e})"),
             Expr::Unit => write!(f, "Unit"),
-            Expr::App(uf, args) => {
+            Expr::App(func, args) => {
                 write!(
                     f,
                     "({} {})",
-                    uf,
+                    func,
                     args.iter()
                         .format_with(" ", |expr, f| { f(&format_args!("{}", FmtParens(expr))) }),
                 )
@@ -305,6 +306,7 @@ impl fmt::Display for Expr {
             Expr::IfThenElse(box [p, e1, e2]) => {
                 write!(f, "if {p} then {e1} else {e2}")
             }
+            Expr::Uif(func) => write!(f, "{func}"),
         }
     }
 }

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -20,6 +20,12 @@ pub enum Sort {
     Bool,
     Unit,
     Pair(Box<Sort>, Box<Sort>),
+    Func(FuncSort),
+}
+
+#[derive(Clone)]
+pub struct FuncSort {
+    pub inputs_and_output: Vec<Sort>,
 }
 
 pub enum Pred {
@@ -31,12 +37,12 @@ pub enum Pred {
 pub enum Expr {
     Var(Name),
     Constant(Constant),
-    BinaryOp(BinOp, Box<Self>, Box<Self>),
+    BinaryOp(BinOp, Box<[Expr; 2]>),
     App(String, Vec<Expr>),
     UnaryOp(UnOp, Box<Self>),
     Pair(Box<Expr>, Box<Expr>),
     Proj(Box<Expr>, Proj),
-    IfThenElse(Box<Expr>, Box<Expr>, Box<Expr>),
+    IfThenElse(Box<[Expr; 3]>),
     Unit,
 }
 
@@ -54,13 +60,12 @@ pub struct Qualifier {
 
 pub struct UifDef {
     pub name: String,
-    pub inputs: Vec<Sort>,
-    pub output: Sort,
+    pub sort: FuncSort,
 }
 
 impl UifDef {
-    pub fn new(name: String, inputs: Vec<Sort>, output: Sort) -> Self {
-        UifDef { name, inputs, output }
+    pub fn new(name: String, sort: FuncSort) -> Self {
+        UifDef { name, sort }
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -127,6 +132,13 @@ impl<Tag> Constraint<Tag> {
 
 impl Pred {
     pub const TRUE: Self = Pred::Expr(Expr::Constant(Constant::Bool(true)));
+}
+
+impl FuncSort {
+    pub fn new(mut inputs: Vec<Sort>, output: Sort) -> FuncSort {
+        inputs.push(output);
+        FuncSort { inputs_and_output: inputs }
+    }
 }
 
 impl<Tag> fmt::Display for Constraint<Tag>
@@ -202,7 +214,14 @@ impl fmt::Display for Sort {
             Sort::Bool => write!(f, "bool"),
             Sort::Unit => write!(f, "Unit"),
             Sort::Pair(s1, s2) => write!(f, "(Pair {s1} {s2})"),
+            Sort::Func(sort) => write!(f, "{sort}"),
         }
+    }
+}
+
+impl fmt::Display for FuncSort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(func(0, [{:?}]))", self.inputs_and_output.iter().format("; "))
     }
 }
 
@@ -234,7 +253,7 @@ impl Expr {
     pub const ZERO: Expr = Expr::Constant(Constant::ZERO);
     pub const ONE: Expr = Expr::Constant(Constant::ONE);
     pub fn eq(self, other: Expr) -> Expr {
-        Expr::BinaryOp(BinOp::Eq, Box::new(self), Box::new(other))
+        Expr::BinaryOp(BinOp::Eq, Box::new([self, other]))
     }
 }
 
@@ -259,7 +278,7 @@ impl fmt::Display for Expr {
         match self {
             Expr::Var(x) => write!(f, "{:?}", x),
             Expr::Constant(c) => write!(f, "{}", c),
-            Expr::BinaryOp(op, e1, e2) => {
+            Expr::BinaryOp(op, box [e1, e2]) => {
                 write!(f, "{} {op} {}", FmtParens(e1), FmtParens(e2))?;
                 Ok(())
             }
@@ -283,7 +302,7 @@ impl fmt::Display for Expr {
                         .format_with(" ", |expr, f| { f(&format_args!("{}", FmtParens(expr))) }),
                 )
             }
-            Expr::IfThenElse(p, e1, e2) => {
+            Expr::IfThenElse(box [p, e1, e2]) => {
                 write!(f, "if {p} then {e1} else {e2}")
             }
         }
@@ -296,35 +315,35 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
     // (qualif EqZero ((v int)) (v == 0))
     let eqzero = Qualifier {
         args: vec![(NAME0, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
+        expr: Expr::BinaryOp(BinOp::Eq, Box::new([Expr::Var(NAME0), Expr::ZERO])),
         name: String::from("EqZero"),
     };
 
     // (qualif GtZero ((v int)) (v > 0))
     let gtzero = Qualifier {
         args: vec![(NAME0, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
+        expr: Expr::BinaryOp(BinOp::Gt, Box::new([Expr::Var(NAME0), Expr::ZERO])),
         name: String::from("GtZero"),
     };
 
     // (qualif GeZero ((v int)) (v >= 0))
     let gezero = Qualifier {
         args: vec![(NAME0, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
+        expr: Expr::BinaryOp(BinOp::Ge, Box::new([Expr::Var(NAME0), Expr::ZERO])),
         name: String::from("GeZero"),
     };
 
     // (qualif LtZero ((v int)) (v < 0))
     let ltzero = Qualifier {
         args: vec![(NAME0, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
+        expr: Expr::BinaryOp(BinOp::Lt, Box::new([Expr::Var(NAME0), Expr::ZERO])),
         name: String::from("LtZero"),
     };
 
     // (qualif LeZero ((v int)) (v <= 0))
     let lezero = Qualifier {
         args: vec![(NAME0, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
+        expr: Expr::BinaryOp(BinOp::Le, Box::new([Expr::Var(NAME0), Expr::ZERO])),
         name: String::from("LeZero"),
     };
 
@@ -333,35 +352,35 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
     // (qualif Eq ((a int) (b int)) (a == b))
     let eq = Qualifier {
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
+        expr: Expr::BinaryOp(BinOp::Eq, Box::new([Expr::Var(NAME0), Expr::Var(NAME1)])),
         name: String::from("Eq"),
     };
 
     // (qualif Gt ((a int) (b int)) (a > b))
     let gt = Qualifier {
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
+        expr: Expr::BinaryOp(BinOp::Gt, Box::new([Expr::Var(NAME0), Expr::Var(NAME1)])),
         name: String::from("Gt"),
     };
 
     // (qualif Lt ((a int) (b int)) (a < b))
     let ge = Qualifier {
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
+        expr: Expr::BinaryOp(BinOp::Ge, Box::new([Expr::Var(NAME0), Expr::Var(NAME1)])),
         name: String::from("Ge"),
     };
 
     // (qualif Ge ((a int) (b int)) (a >= b))
     let lt = Qualifier {
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
+        expr: Expr::BinaryOp(BinOp::Lt, Box::new([Expr::Var(NAME0), Expr::Var(NAME1)])),
         name: String::from("Lt"),
     };
 
     // (qualif Le ((a int) (b int)) (a <= b))
     let le = Qualifier {
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
-        expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
+        expr: Expr::BinaryOp(BinOp::Le, Box::new([Expr::Var(NAME0), Expr::Var(NAME1)])),
         name: String::from("Le"),
     };
 
@@ -370,8 +389,10 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
         expr: Expr::BinaryOp(
             BinOp::Le,
-            Box::new(Expr::Var(NAME0)),
-            Box::new(Expr::BinaryOp(BinOp::Sub, Box::new(Expr::Var(NAME1)), Box::new(Expr::ONE))),
+            Box::new([
+                Expr::Var(NAME0),
+                Expr::BinaryOp(BinOp::Sub, Box::new([Expr::Var(NAME1), Expr::ONE])),
+            ]),
         ),
         name: String::from("Le1"),
     };
@@ -381,12 +402,10 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int), (NAME2, Sort::Int)],
         expr: Expr::BinaryOp(
             BinOp::Eq,
-            Box::new(Expr::Var(NAME0)),
-            Box::new(Expr::BinaryOp(
-                BinOp::Add,
-                Box::new(Expr::Var(NAME1)),
-                Box::new(Expr::Var(NAME2)),
-            )),
+            Box::new([
+                Expr::Var(NAME0),
+                Expr::BinaryOp(BinOp::Add, Box::new([Expr::Var(NAME1), Expr::Var(NAME2)])),
+            ]),
         ),
         name: String::from("Add2"),
     };
@@ -396,12 +415,10 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
         args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int), (NAME2, Sort::Int)],
         expr: Expr::BinaryOp(
             BinOp::Eq,
-            Box::new(Expr::Var(NAME0)),
-            Box::new(Expr::BinaryOp(
-                BinOp::Sub,
-                Box::new(Expr::Var(NAME1)),
-                Box::new(Expr::Var(NAME2)),
-            )),
+            Box::new([
+                Expr::Var(NAME0),
+                Expr::BinaryOp(BinOp::Sub, Box::new([Expr::Var(NAME1), Expr::Var(NAME2)])),
+            ]),
         ),
         name: String::from("Sub2"),
     };

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -38,13 +38,17 @@ pub enum Expr {
     Var(Name),
     Constant(Constant),
     BinaryOp(BinOp, Box<[Expr; 2]>),
-    App(Box<Expr>, Vec<Expr>),
+    App(Func, Vec<Expr>),
     UnaryOp(UnOp, Box<Self>),
-    Pair(Box<Expr>, Box<Expr>),
+    Pair(Box<[Expr; 2]>),
     Proj(Box<Expr>, Proj),
     IfThenElse(Box<[Expr; 3]>),
-    Uif(String),
     Unit,
+}
+
+pub enum Func {
+    Var(Name),
+    Uif(String),
 }
 
 #[derive(Clone, Copy)]
@@ -277,8 +281,8 @@ impl fmt::Display for FmtParens<'_> {
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Expr::Var(x) => write!(f, "{:?}", x),
-            Expr::Constant(c) => write!(f, "{}", c),
+            Expr::Var(x) => write!(f, "{x:?}"),
+            Expr::Constant(c) => write!(f, "{c}"),
             Expr::BinaryOp(op, box [e1, e2]) => {
                 write!(f, "{} {op} {}", FmtParens(e1), FmtParens(e2))?;
                 Ok(())
@@ -290,7 +294,7 @@ impl fmt::Display for Expr {
                     write!(f, "{}({})", op, e)
                 }
             }
-            Expr::Pair(e1, e2) => write!(f, "(Pair ({e1}) ({e2}))"),
+            Expr::Pair(box [e1, e2]) => write!(f, "(Pair ({e1}) ({e2}))"),
             Expr::Proj(e, Proj::Fst) => write!(f, "(fst {e})"),
             Expr::Proj(e, Proj::Snd) => write!(f, "(snd {e})"),
             Expr::Unit => write!(f, "Unit"),
@@ -306,7 +310,15 @@ impl fmt::Display for Expr {
             Expr::IfThenElse(box [p, e1, e2]) => {
                 write!(f, "if {p} then {e1} else {e2}")
             }
-            Expr::Uif(func) => write!(f, "{func}"),
+        }
+    }
+}
+
+impl fmt::Display for Func {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Func::Var(name) => write!(f, "{name:?}"),
+            Func::Uif(uif) => write!(f, "{uif}"),
         }
     }
 }

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -13,8 +13,8 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, Expr, FuncSort, KVid, Name, Pred, Proj, Qualifier, Sign,
-    Sort, UifDef, UnOp,
+    BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, Pred, Proj, Qualifier,
+    Sign, Sort, UifDef, UnOp,
 };
 use flux_common::format::PadAdapter;
 use itertools::Itertools;

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private, min_specialization, once_cell)]
+#![feature(rustc_private, min_specialization, once_cell, box_patterns)]
 
 extern crate rustc_index;
 extern crate rustc_serialize;
@@ -13,8 +13,8 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, Expr, KVid, Name, Pred, Proj, Qualifier, Sign, Sort,
-    UifDef, UnOp,
+    BinOp, Const, Constant, Constraint, Expr, FuncSort, KVid, Name, Pred, Proj, Qualifier, Sign,
+    Sort, UifDef, UnOp,
 };
 use flux_common::format::PadAdapter;
 use itertools::Itertools;
@@ -143,15 +143,7 @@ impl fmt::Display for KVar {
 
 impl fmt::Display for UifDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "(constant {} (func(0, [{}{:?}])))",
-            self.name,
-            self.inputs
-                .iter()
-                .format_with(" ", |sort, f| f(&format_args!("{};", sort))),
-            self.output
-        )
+        write!(f, "(constant {} {})", self.name, self.sort)
     }
 }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -282,8 +282,15 @@ impl AdtDef {
 
 impl RefinedBy {
     pub const DUMMY: &'static RefinedBy = &RefinedBy { params: vec![], span: DUMMY_SP };
+
     pub fn iter(&self) -> impl Iterator<Item = &Param> {
         self.params.iter()
+    }
+}
+
+impl From<FuncSort> for Sort {
+    fn from(v: FuncSort) -> Self {
+        Self::Func(v)
     }
 }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -68,7 +68,6 @@ pub enum StructKind {
 #[derive(Debug)]
 pub struct EnumDef {
     pub def_id: DefId,
-    pub refined_by: Vec<Param>,
     pub variants: Vec<VariantDef>,
 }
 
@@ -169,13 +168,13 @@ pub enum BaseTy {
     Adt(DefId, Vec<Ty>),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct Param {
     pub name: Ident,
     pub sort: Sort,
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum Sort {
     Bool,
     Int,
@@ -266,7 +265,7 @@ pub struct UifDef {
 
 impl AdtDef {
     pub fn new(def_id: DefId, refined_by: RefinedBy, invariants: Vec<Expr>, opaque: bool) -> Self {
-        let sorts = refined_by.iter().map(|param| param.sort).collect();
+        let sorts = refined_by.iter().map(|param| param.sort.clone()).collect();
         AdtDef { def_id, refined_by, invariants, opaque, sorts }
     }
 }
@@ -561,7 +560,7 @@ impl fmt::Debug for Sort {
     }
 }
 
-impl rustc_errors::IntoDiagnosticArg for Sort {
+impl rustc_errors::IntoDiagnosticArg for &Sort {
     fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
         let cow = match self {
             Sort::Bool => Cow::Borrowed("bool"),

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -125,7 +125,7 @@ pub enum Ty {
     Exists(BaseTy, Vec<Name>, Pred),
     /// Constrained types `{T : p}` are like existentials but without binders, and are useful
     /// for specifying constraints on indexed values e.g. `{i32[@a] | 0 <= a}`
-    Constr(Expr, Box<Ty>),
+    Constr(Pred, Box<Ty>),
     Float(FloatTy),
     Str,
     Char,
@@ -141,6 +141,7 @@ pub enum Ty {
 pub enum Pred {
     Expr(Expr),
     And(Vec<Pred>),
+    App(Name, Vec<Expr>),
 }
 
 pub struct ArrayLen;
@@ -225,6 +226,12 @@ pub struct Ident {
 newtype_index! {
     pub struct Name {
         DEBUG_FORMAT = "x{}",
+    }
+}
+
+impl UFun {
+    pub fn new(symbol: Symbol, span: Span) -> Self {
+        Self { symbol, span }
     }
 }
 
@@ -507,6 +514,9 @@ impl fmt::Debug for Pred {
                 } else {
                     write!(f, "{:?}", preds.iter().format(" ∧ "))
                 }
+            }
+            Pred::App(func, args) => {
+                write!(f, "{func:?}({:?})", args.iter().format(", "))
             }
         }
     }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -309,11 +309,16 @@ impl Sort {
     pub fn is_bool(&self) -> bool {
         matches!(self, Self::Bool)
     }
+
+    /// Whether the sort is a function with return sort bool
+    pub fn is_pred(&self) -> bool {
+        matches!(self, Sort::Func(fsort) if fsort.output().is_bool())
+    }
 }
 
 impl From<FuncSort> for Sort {
-    fn from(v: FuncSort) -> Self {
-        Self::Func(v)
+    fn from(sort: FuncSort) -> Self {
+        Self::Func(sort)
     }
 }
 
@@ -652,8 +657,14 @@ impl rustc_errors::IntoDiagnosticArg for &Sort {
             Sort::Bool => Cow::Borrowed("bool"),
             Sort::Int => Cow::Borrowed("int"),
             Sort::Loc => Cow::Borrowed("loc"),
-            _ => Cow::Owned(format!("{}", self)),
+            _ => Cow::Owned(format!("{self}")),
         };
         rustc_errors::DiagnosticArgValue::Str(cow)
+    }
+}
+
+impl rustc_errors::IntoDiagnosticArg for &FuncSort {
+    fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
+        rustc_errors::DiagnosticArgValue::Str(Cow::Owned(format!("{self}")))
     }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -311,6 +311,15 @@ impl Sort {
     }
 }
 
+impl Func {
+    pub fn span(&self) -> Span {
+        match self {
+            Func::Var(var) => var.source_info.0,
+            Func::Uif(_, span) => *span,
+        }
+    }
+}
+
 impl From<FuncSort> for Sort {
     fn from(v: FuncSort) -> Self {
         Self::Func(v)

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -47,7 +47,7 @@ pub struct ConstInfo {
 #[derive(Debug)]
 pub struct Qualifier {
     pub name: String,
-    pub args: Vec<Param>,
+    pub args: Vec<RefineParam>,
     pub expr: Expr,
 }
 
@@ -86,7 +86,7 @@ pub struct EnumDef {
 
 #[derive(Debug)]
 pub struct VariantDef {
-    pub params: Vec<Param>,
+    pub params: Vec<RefineParam>,
     pub fields: Vec<Ty>,
     pub ret: VariantRet,
 }
@@ -99,7 +99,7 @@ pub struct VariantRet {
 
 pub struct FnSig {
     /// example: vec![(n: Int), (l: Loc)]
-    pub params: Vec<Param>,
+    pub params: Vec<RefineParam>,
     /// example: vec![(0 <= n), (l: i32)]
     pub requires: Vec<Constraint>,
     /// example: vec![(x: StrRef(l))]
@@ -170,7 +170,7 @@ pub enum BaseTy {
 }
 
 #[derive(Debug)]
-pub struct Param {
+pub struct RefineParam {
     pub name: Ident,
     pub sort: Sort,
 }
@@ -276,7 +276,7 @@ pub struct AdtDef {
 
 #[derive(Debug)]
 pub struct RefinedBy {
-    pub params: Vec<Param>,
+    pub params: Vec<RefineParam>,
     pub span: Span,
 }
 
@@ -296,7 +296,7 @@ impl AdtDef {
 impl RefinedBy {
     pub const DUMMY: &'static RefinedBy = &RefinedBy { params: vec![], span: DUMMY_SP };
 
-    pub fn iter(&self) -> impl Iterator<Item = &Param> {
+    pub fn iter(&self) -> impl Iterator<Item = &RefineParam> {
         self.params.iter()
     }
 }
@@ -308,15 +308,6 @@ impl Sort {
     #[must_use]
     pub fn is_bool(&self) -> bool {
         matches!(self, Self::Bool)
-    }
-}
-
-impl Func {
-    pub fn span(&self) -> Span {
-        match self {
-            Func::Var(var) => var.source_info.0,
-            Func::Uif(_, span) => *span,
-        }
     }
 }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -40,10 +40,16 @@ pub struct ConstInfo {
     pub val: i128,
 }
 
+#[derive(Debug)]
+pub struct Qualifier {
+    pub name: String,
+    pub args: Vec<Param>,
+    pub expr: Expr,
+}
+
 /// A map between rust definitions and flux annotations in their desugared `fhir` form.
 ///
-/// note: `Map` is a very generic name, so we typically qualify the type as `fhir::Map` when
-/// using it.
+/// note: `Map` is a very generic name, so we typically use the type qualified as `fhir::Map`.
 #[derive(Default, Debug)]
 pub struct Map {
     uifs: FxHashMap<Symbol, UifDef>,
@@ -99,24 +105,12 @@ pub struct FnSig {
     /// example: vec![(l: i32{v:n < v})]
     pub ensures: Vec<Constraint>,
 }
+
 pub enum Constraint {
     /// A type constraint on a location
     Type(Ident, Ty),
     /// A predicate that needs to hold
     Pred(Expr),
-}
-
-#[derive(Debug)]
-pub struct Qualifier {
-    pub name: String,
-    pub args: Vec<Param>,
-    pub expr: Expr,
-}
-
-pub struct ConstSig {
-    pub def_id: DefId,
-    pub val: i128,
-    pub ty: Ty,
 }
 
 pub enum Ty {
@@ -128,7 +122,7 @@ pub enum Ty {
     /// every index of the [`BaseTy`], e.g., `i32{v : v > 0}` for one index and `RMat{v0,v1 : v0 == v1}`.
     /// for two indices. There's currently no equivalent surface syntax and existentials for
     /// types with multiple indices have to use projection syntax.
-    Exists(BaseTy, Vec<Name>, Expr),
+    Exists(BaseTy, Vec<Name>, Pred),
     /// Constrained types `{T : p}` are like existentials but without binders, and are useful
     /// for specifying constraints on indexed values e.g. `{i32[@a] | 0 <= a}`
     Constr(Expr, Box<Ty>),
@@ -142,6 +136,10 @@ pub enum Ty {
     Array(Box<Ty>, ArrayLen),
     Slice(Box<Ty>),
     Never,
+}
+
+pub enum Pred {
+    Expr(Expr),
 }
 
 pub struct ArrayLen;
@@ -494,6 +492,14 @@ impl fmt::Debug for Ty {
             Ty::Slice(ty) => write!(f, "[{ty:?}]"),
             Ty::Str => write!(f, "str"),
             Ty::Char => write!(f, "char"),
+        }
+    }
+}
+
+impl fmt::Debug for Pred {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Pred::Expr(expr) => write!(f, "{expr:?}"),
         }
     }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -110,7 +110,7 @@ pub enum Constraint {
     /// A type constraint on a location
     Type(Ident, Ty),
     /// A predicate that needs to hold
-    Pred(Expr),
+    Pred(Pred),
 }
 
 pub enum Ty {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -578,15 +578,25 @@ impl fmt::Display for Sort {
             Sort::Bool => write!(f, "bool"),
             Sort::Int => write!(f, "int"),
             Sort::Loc => write!(f, "loc"),
-            Sort::Func(sort) => {
-                write!(f, "({}) -> {}", sort.inputs().iter().join(","), sort.output())
-            }
+            Sort::Func(sort) => write!(f, "{sort}"),
             Sort::Tuple(sorts) => write!(f, "({})", sorts.iter().join(", ")),
         }
     }
 }
 
 impl fmt::Debug for Sort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for FuncSort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({}) -> {}", self.inputs().iter().join(","), self.output())
+    }
+}
+
+impl fmt::Debug for FuncSort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -140,6 +140,7 @@ pub enum Ty {
 
 pub enum Pred {
     Expr(Expr),
+    And(Vec<Pred>),
 }
 
 pub struct ArrayLen;
@@ -500,6 +501,13 @@ impl fmt::Debug for Pred {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Pred::Expr(expr) => write!(f, "{expr:?}"),
+            Pred::And(preds) => {
+                if preds.is_empty() {
+                    write!(f, "true")
+                } else {
+                    write!(f, "{:?}", preds.iter().format(" ∧ "))
+                }
+            }
         }
     }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -294,6 +294,16 @@ impl RefinedBy {
     }
 }
 
+impl Sort {
+    /// Returns `true` if the sort is [`Bool`].
+    ///
+    /// [`Bool`]: Sort::Bool
+    #[must_use]
+    pub fn is_bool(&self) -> bool {
+        matches!(self, Self::Bool)
+    }
+}
+
 impl From<FuncSort> for Sort {
     fn from(v: FuncSort) -> Self {
         Self::Func(v)

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -9,7 +9,6 @@ use rustc_hir::{def_id::DefId, LangItem};
 use rustc_middle::ty::TyCtxt;
 pub use rustc_middle::ty::Variance;
 pub use rustc_span::symbol::Ident;
-use rustc_span::Symbol;
 
 pub use crate::rustc::lowering::UnsupportedFnSig;
 use crate::{
@@ -25,7 +24,6 @@ pub struct OpaqueStructErr(pub DefId);
 pub struct GlobalEnv<'genv, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub sess: &'genv FluxSession,
-    pub uif_defs: FxHashMap<Symbol, rty::UifDef>,
     pub qualifiers: Vec<rty::Qualifier>,
     fn_sigs: RefCell<FxHashMap<DefId, rty::PolySig>>,
     map: fhir::Map,
@@ -44,13 +42,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             adt_defs.insert(adt_def.def_id(), adt_def);
         }
 
-        let mut uif_defs = FxHashMap::default();
-        for (name, uif_def) in map.uifs() {
-            let inputs = uif_def.inputs.clone();
-            let output = uif_def.output.clone();
-
-            uif_defs.insert(*name, rty::UifDef { inputs, output });
-        }
         let mut qualifiers = vec![];
         for qualifier in map.qualifiers() {
             qualifiers.push(rty::conv::ConvCtxt::conv_qualifier(qualifier));
@@ -64,7 +55,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             tcx,
             sess,
             check_asserts,
-            uif_defs,
             map,
         };
         genv.register_struct_def_variants();

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -147,7 +147,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         let bty =
             rty::BaseTy::adt(adt_def, vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)]);
-        rty::Ty::indexed(bty, vec![])
+        rty::Ty::indexed(bty, rty::RefineArgs::empty())
     }
 
     pub fn check_asserts(&self) -> &AssertBehavior {
@@ -292,7 +292,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         };
         let sorts = bty.sorts();
         if sorts.is_empty() {
-            rty::Ty::indexed(bty, vec![])
+            rty::Ty::indexed(bty, rty::RefineArgs::empty())
         } else {
             let pred = mk_pred(sorts);
             rty::Ty::exists(bty, pred)

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -46,12 +46,8 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         let mut uif_defs = FxHashMap::default();
         for (name, uif_def) in map.uifs() {
-            let inputs = uif_def
-                .inputs
-                .iter()
-                .map(|sort| rty::conv::conv_sort(*sort))
-                .collect();
-            let output = rty::conv::conv_sort(uif_def.output);
+            let inputs = uif_def.inputs.iter().map(rty::conv::conv_sort).collect();
+            let output = rty::conv::conv_sort(&uif_def.output);
 
             uif_defs.insert(*name, rty::UifDef { inputs, output });
         }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -46,8 +46,8 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         let mut uif_defs = FxHashMap::default();
         for (name, uif_def) in map.uifs() {
-            let inputs = uif_def.inputs.iter().map(rty::conv::conv_sort).collect();
-            let output = rty::conv::conv_sort(&uif_def.output);
+            let inputs = uif_def.inputs.clone();
+            let output = uif_def.output.clone();
 
             uif_defs.insert(*name, rty::UifDef { inputs, output });
         }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -160,7 +160,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         variant_idx: VariantIdx,
     ) -> Result<rty::PolySig, OpaqueStructErr> {
         let poly_variant = self.variant(def_id, variant_idx)?;
-        let variant = poly_variant.skip_binders();
+        let variant = poly_variant.as_ref().skip_binders();
         let sorts = poly_variant.params();
         let sig = rty::FnSig::new(vec![], variant.fields.clone(), variant.ret.to_ty(), vec![]);
         Ok(rty::Binders::new(sig, sorts))

--- a/flux-middle/src/pretty.rs
+++ b/flux-middle/src/pretty.rs
@@ -126,6 +126,7 @@ pub struct PPrintCx<'tcx> {
     pub preds_chain: bool,
     pub full_spans: bool,
     pub hide_uninit: bool,
+    pub show_is_binder: bool,
 }
 
 pub struct WithCx<'a, 'tcx, T> {
@@ -174,6 +175,7 @@ impl PPrintCx<'_> {
             preds_chain: true,
             full_spans: false,
             hide_uninit: true,
+            show_is_binder: false,
         }
     }
 
@@ -200,6 +202,10 @@ impl PPrintCx<'_> {
 
     pub fn fully_qualified_paths(self, b: bool) -> Self {
         Self { fully_qualified_paths: b, ..self }
+    }
+
+    pub fn show_is_binder(self, b: bool) -> Self {
+        Self { show_is_binder: b, ..self }
     }
 }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -387,6 +387,13 @@ impl NameMap {
     fn conv_pred(&self, pred: &fhir::Pred, nbinders: u32) -> rty::Pred {
         match pred {
             fhir::Pred::Expr(expr) => rty::Pred::Expr(self.conv_expr(expr, nbinders)),
+            fhir::Pred::And(preds) => {
+                let preds = preds
+                    .iter()
+                    .map(|pred| self.conv_pred(pred, nbinders))
+                    .collect();
+                rty::Pred::And(List::from_vec(preds))
+            }
         }
     }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -182,7 +182,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .map(|(index, param)| {
                 self.name_map
                     .insert(param.name.name, Entry::Bound { index, level: 0 });
-                conv_sort(&param.sort)
+                param.sort.clone()
             })
             .collect()
     }
@@ -212,7 +212,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .map(|param| {
                 let fresh = name_gen.fresh();
                 name_map.insert(param.name.name, fresh);
-                (fresh, conv_sort(&param.sort))
+                (fresh, param.sort.clone())
             })
             .collect_vec();
 
@@ -379,7 +379,7 @@ impl NameMap {
             .map(|(index, param)| {
                 self.map
                     .insert(param.name.name, Entry::Bound { index, level: 0 });
-                conv_sort(&param.sort)
+                param.sort.clone()
             })
             .collect()
     }
@@ -415,13 +415,5 @@ fn conv_lit(lit: fhir::Lit) -> rty::Constant {
     match lit {
         fhir::Lit::Int(n) => rty::Constant::from(n),
         fhir::Lit::Bool(b) => rty::Constant::from(b),
-    }
-}
-
-pub fn conv_sort(sort: &fhir::Sort) -> rty::Sort {
-    match sort {
-        fhir::Sort::Int => rty::Sort::Int,
-        fhir::Sort::Bool => rty::Sort::Bool,
-        fhir::Sort::Loc => rty::Sort::Loc,
     }
 }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -133,7 +133,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
     pub(crate) fn conv_struct_def_variant(
         genv: &GlobalEnv,
-        refined_by: &[fhir::Param],
+        refined_by: &[fhir::RefineParam],
         struct_def: &fhir::StructDef,
     ) -> Option<rty::PolyVariant> {
         let mut cx = ConvCtxt::new(genv);
@@ -183,7 +183,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         }
     }
 
-    fn conv_params(&mut self, params: &[fhir::Param]) -> Vec<rty::Sort> {
+    fn conv_params(&mut self, params: &[fhir::RefineParam]) -> Vec<rty::Sort> {
         params
             .iter()
             .enumerate()

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -277,7 +277,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             fhir::Ty::Never => rty::Ty::never(),
             fhir::Ty::Constr(pred, ty) => {
-                let pred = self.name_map.conv_expr(pred, nbinders);
+                let pred = self.name_map.conv_pred(pred, nbinders);
                 rty::Ty::constr(pred, self.conv_ty(ty, nbinders))
             }
             fhir::Ty::Array(ty, _) => rty::Ty::array(self.conv_ty(ty, nbinders), rty::Const),
@@ -394,6 +394,7 @@ impl NameMap {
                     .collect();
                 rty::Pred::And(List::from_vec(preds))
             }
+            fhir::Pred::App(_, _) => todo!(),
         }
     }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -182,7 +182,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .map(|(index, param)| {
                 self.name_map
                     .insert(param.name.name, Entry::Bound { index, level: 0 });
-                conv_sort(param.sort)
+                conv_sort(&param.sort)
             })
             .collect()
     }
@@ -212,7 +212,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .map(|param| {
                 let fresh = name_gen.fresh();
                 name_map.insert(param.name.name, fresh);
-                (fresh, conv_sort(param.sort))
+                (fresh, conv_sort(&param.sort))
             })
             .collect_vec();
 
@@ -379,7 +379,7 @@ impl NameMap {
             .map(|(index, param)| {
                 self.map
                     .insert(param.name.name, Entry::Bound { index, level: 0 });
-                conv_sort(param.sort)
+                conv_sort(&param.sort)
             })
             .collect()
     }
@@ -418,7 +418,7 @@ fn conv_lit(lit: fhir::Lit) -> rty::Constant {
     }
 }
 
-pub fn conv_sort(sort: fhir::Sort) -> rty::Sort {
+pub fn conv_sort(sort: &fhir::Sort) -> rty::Sort {
     match sort {
         fhir::Sort::Int => rty::Sort::Int,
         fhir::Sort::Bool => rty::Sort::Bool,

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -198,7 +198,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     self.conv_ty(ty, nbinders),
                 )
             }
-            fhir::Constraint::Pred(e) => rty::Constraint::Pred(self.name_map.conv_expr(e, 1)),
+            fhir::Constraint::Pred(pred) => rty::Constraint::Pred(self.name_map.conv_pred(pred, 1)),
         }
     }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -388,13 +388,17 @@ impl NameMap {
         match pred {
             fhir::Pred::Expr(expr) => rty::Pred::Expr(self.conv_expr(expr, nbinders)),
             fhir::Pred::And(preds) => {
-                let preds = preds
-                    .iter()
-                    .map(|pred| self.conv_pred(pred, nbinders))
-                    .collect();
-                rty::Pred::And(List::from_vec(preds))
+                let preds = preds.iter().map(|pred| self.conv_pred(pred, nbinders));
+                rty::Pred::And(List::from_iter(preds))
             }
-            fhir::Pred::App(_, _) => todo!(),
+            fhir::Pred::App(name, args) => {
+                let args = List::from_iter(args.iter().map(|expr| self.conv_expr(expr, nbinders)));
+                if let rty::ExprKind::BoundVar(bvar) = self.get(*name, nbinders).kind() {
+                    rty::Pred::App(rty::Var::Bound(*bvar), args)
+                } else {
+                    unreachable!()
+                }
+            }
         }
     }
 

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -249,8 +249,8 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 let bty = self.conv_base_ty(bty, nbinders);
                 self.name_map
                     .with_binders(binders, nbinders, |name_map, nbinders| {
-                        let expr = name_map.conv_expr(pred, nbinders);
-                        let pred = rty::Binders::new(rty::Pred::Expr(expr), bty.sorts());
+                        let pred = name_map.conv_pred(pred, nbinders);
+                        let pred = rty::Binders::new(pred, bty.sorts());
                         rty::Ty::exists(bty, pred)
                     })
             }
@@ -382,6 +382,12 @@ impl NameMap {
                 param.sort.clone()
             })
             .collect()
+    }
+
+    fn conv_pred(&self, pred: &fhir::Pred, nbinders: u32) -> rty::Pred {
+        match pred {
+            fhir::Pred::Expr(expr) => rty::Pred::Expr(self.conv_expr(expr, nbinders)),
+        }
     }
 
     fn conv_expr(&self, expr: &fhir::Expr, nbinders: u32) -> rty::Expr {

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -284,11 +284,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     }
 
     fn conv_indices(&self, idxs: &fhir::Indices, nbinders: u32) -> rty::RefineArgs {
-        rty::RefineArgs::new(
-            idxs.indices
-                .iter()
-                .map(|idx| (self.name_map.conv_expr(&idx.expr, nbinders), idx.is_binder)),
-        )
+        rty::RefineArgs::new(idxs.indices.iter().map(|idx| {
+            (rty::RefineArg::Expr(self.name_map.conv_expr(&idx.expr, nbinders)), idx.is_binder)
+        }))
     }
 
     fn conv_ref_kind(rk: fhir::RefKind) -> rty::RefKind {

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -37,6 +37,12 @@ pub enum ExprKind {
     IfThenElse(Expr, Expr, Expr),
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Var {
+    Bound(BoundVar),
+    Free(Name),
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Path {
     pub loc: Loc,
@@ -286,6 +292,14 @@ impl ExprS {
         }
     }
 
+    pub fn to_var(&self) -> Option<Var> {
+        match self.kind() {
+            ExprKind::FreeVar(name) => Some(Var::Free(*name)),
+            ExprKind::BoundVar(bvar) => Some(Var::Bound(*bvar)),
+            _ => None,
+        }
+    }
+
     pub fn to_name(&self) -> Option<Name> {
         match self.kind() {
             ExprKind::FreeVar(name) => Some(*name),
@@ -310,6 +324,15 @@ impl ExprS {
         };
         proj.reverse();
         Some(Path::new(loc, proj))
+    }
+}
+
+impl Var {
+    pub fn to_expr(&self) -> Expr {
+        match self {
+            Var::Bound(bvar) => Expr::bvar(*bvar),
+            Var::Free(name) => Expr::fvar(*name),
+        }
     }
 }
 

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -29,7 +29,7 @@ pub enum ExprKind {
     Local(Local),
     Constant(Constant),
     BinaryOp(BinOp, Expr, Expr),
-    App(Symbol, Vec<Expr>),
+    App(Symbol, List<Expr>),
     UnaryOp(UnOp, Expr),
     TupleProj(Expr, u32),
     Tuple(List<Expr>),
@@ -169,9 +169,8 @@ impl Expr {
         ExprKind::BinaryOp(op, e1.into(), e2.into()).intern()
     }
 
-    pub fn app(f: Symbol, es: Vec<impl Into<Expr>>) -> Expr {
-        let es = es.into_iter().map(|e| e.into()).collect();
-        ExprKind::App(f, es).intern()
+    pub fn app(func: Symbol, args: impl Into<List<Expr>>) -> Expr {
+        ExprKind::App(func, args.into()).intern()
     }
 
     pub fn unary_op(op: UnOp, e: impl Into<Expr>) -> Expr {
@@ -332,6 +331,17 @@ impl Var {
         match self {
             Var::Bound(bvar) => Expr::bvar(*bvar),
             Var::Free(name) => Expr::fvar(*name),
+        }
+    }
+
+    pub fn to_path(&self) -> Path {
+        self.to_loc().into()
+    }
+
+    pub fn to_loc(&self) -> Loc {
+        match self {
+            Var::Bound(bvar) => Loc::Bound(*bvar),
+            Var::Free(name) => Loc::Free(*name),
         }
     }
 }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -468,10 +468,7 @@ impl TypeFoldable for Expr {
                 Expr::tuple(exprs.iter().map(|e| e.fold_with(folder)).collect_vec())
             }
             ExprKind::PathProj(e, field) => Expr::path_proj(e.fold_with(folder), *field),
-            ExprKind::App(f, es) => {
-                let es = es.iter().map(|e| e.fold_with(folder)).collect();
-                Expr::app(*f, es)
-            }
+            ExprKind::App(func, args) => Expr::app(*func, args.fold_with(folder)),
             ExprKind::IfThenElse(p, e1, e2) => {
                 Expr::ite(p.fold_with(folder), e1.fold_with(folder), e2.fold_with(folder))
             }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -340,12 +340,14 @@ impl TypeFoldable for RefineArg {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self {
             RefineArg::Expr(e) => RefineArg::Expr(e.fold_with(folder)),
+            RefineArg::KVar(kvar) => RefineArg::KVar(kvar.fold_with(folder)),
         }
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             RefineArg::Expr(e) => e.visit_with(visitor),
+            RefineArg::KVar(kvar) => kvar.visit_with(visitor),
         }
     }
 }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -340,14 +340,14 @@ impl TypeFoldable for RefineArg {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self {
             RefineArg::Expr(e) => RefineArg::Expr(e.fold_with(folder)),
-            RefineArg::KVar(kvar) => RefineArg::KVar(kvar.fold_with(folder)),
+            RefineArg::Pred(kvar) => RefineArg::Pred(kvar.fold_with(folder)),
         }
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             RefineArg::Expr(e) => e.visit_with(visitor),
-            RefineArg::KVar(kvar) => kvar.visit_with(visitor),
+            RefineArg::Pred(kvar) => kvar.visit_with(visitor),
         }
     }
 }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet;
 
 use super::{
     BaseTy, Binders, Constraint, Expr, ExprKind, FnSig, GenericArg, Index, KVar, Name, Pred,
-    RefineArgs, RefineArgsData, Sort, Ty, TyKind, VariantRet,
+    RefineArg, RefineArgs, RefineArgsData, Sort, Ty, TyKind, VariantRet,
 };
 use crate::{
     intern::{Internable, List},
@@ -333,6 +333,20 @@ impl TypeFoldable for RefineArgs {
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         self.args().iter().for_each(|arg| arg.visit_with(visitor))
+    }
+}
+
+impl TypeFoldable for RefineArg {
+    fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
+        match self {
+            RefineArg::Expr(e) => RefineArg::Expr(e.fold_with(folder)),
+        }
+    }
+
+    fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
+        match self {
+            RefineArg::Expr(e) => e.visit_with(visitor),
+        }
     }
 }
 

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use super::{
-    BaseTy, Binders, Constraint, Expr, ExprKind, FnSig, GenericArg, Index, KVar, Name, Pred,
-    RefineArg, RefineArgs, RefineArgsData, Sort, Ty, TyKind, VariantRet,
+    BaseTy, Binders, Constraint, Expr, ExprKind, FnSig, GenericArg, KVar, Name, Pred, RefineArg,
+    RefineArgs, RefineArgsData, Sort, Ty, TyKind, VariantRet,
 };
 use crate::{
     intern::{Internable, List},
@@ -349,16 +349,6 @@ impl TypeFoldable for RefineArg {
             RefineArg::Expr(e) => e.visit_with(visitor),
             RefineArg::KVar(kvar) => kvar.visit_with(visitor),
         }
-    }
-}
-
-impl TypeFoldable for Index {
-    fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
-        Index { expr: self.expr.fold_with(folder), is_binder: self.is_binder }
-    }
-
-    fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
-        self.expr.visit_with(visitor);
     }
 }
 

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -82,7 +82,7 @@ pub type Constraints = List<Constraint>;
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Constraint {
     Type(Path, Ty),
-    Pred(Expr),
+    Pred(Pred),
 }
 
 #[derive(Debug)]

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -761,7 +761,7 @@ mod pretty {
     where
         T: Pretty,
     {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        default fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             if !self.params.is_empty() {
                 w!("for<{}> ",
@@ -771,6 +771,13 @@ mod pretty {
                 )?;
             }
             w!("{:?}", &self.value)
+        }
+    }
+
+    impl Pretty for Binders<Pred> {
+        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            define_scoped!(cx, f);
+            w!("|{:?}| {:?}", join!(", ", &self.params), &self.value)
         }
     }
 
@@ -990,5 +997,6 @@ mod pretty {
         KVar,
         FnSig,
         GenericArg,
+        RefineArg,
     );
 }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -182,6 +182,12 @@ pub enum Sort {
     Bool,
     Loc,
     Tuple(List<Sort>),
+    Func(FuncSort),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct FuncSort {
+    inputs_and_output: List<Sort>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -193,6 +199,16 @@ pub struct UifDef {
 newtype_index! {
     pub struct KVid {
         DEBUG_FORMAT = "$k{}"
+    }
+}
+
+impl FuncSort {
+    pub fn inputs(&self) -> &[Sort] {
+        &self.inputs_and_output[..self.inputs_and_output.len() - 1]
+    }
+
+    pub fn output(&self) -> &Sort {
+        &self.inputs_and_output[self.inputs_and_output.len() - 1]
     }
 }
 
@@ -907,6 +923,7 @@ mod pretty {
                 Sort::Bool => w!("bool"),
                 Sort::Loc => w!("loc"),
                 Sort::Tuple(sorts) => w!("({:?})", join!(", ", sorts)),
+                Sort::Func(sort) => w!("({:?}) -> {:?}", join!(", ", sort.inputs()), sort.output()),
             }
         }
     }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -69,6 +69,7 @@ pub struct Binders<T> {
 }
 
 pub type PolySig = Binders<FnSig>;
+
 #[derive(Clone)]
 pub struct FnSig {
     requires: List<Constraint>,

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -114,7 +114,7 @@ pub enum TyKind {
     ///    the capability to deallocate the memory stays with the pointer).
     BoxPtr(Name, Ty),
     Ref(RefKind, Ty),
-    Constr(Expr, Ty),
+    Constr(Pred, Ty),
     Param(ParamTy),
     Never,
     /// This is a bit of a hack. We use this type internally to represent the result of
@@ -200,8 +200,12 @@ impl<T> Binders<T> {
         &self.params
     }
 
-    pub fn skip_binders(&self) -> &T {
-        &self.value
+    pub fn as_ref(&self) -> Binders<&T> {
+        Binders { params: self.params.clone(), value: &self.value }
+    }
+
+    pub fn skip_binders(self) -> T {
+        self.value
     }
 }
 
@@ -355,8 +359,8 @@ impl Ty {
         TyKind::Tuple(tys.into()).intern()
     }
 
-    pub fn constr(p: Expr, ty: Ty) -> Ty {
-        TyKind::Constr(p, ty).intern()
+    pub fn constr(p: impl Into<Pred>, ty: Ty) -> Ty {
+        TyKind::Constr(p.into(), ty).intern()
     }
 
     pub fn unconstr(&self) -> &Ty {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -21,7 +21,10 @@ pub use rustc_middle::ty::{AdtFlags, FloatTy, IntTy, ParamTy, ScalarInt, UintTy}
 pub use rustc_target::abi::VariantIdx;
 
 use self::{fold::TypeFoldable, subst::BVarFolder};
-pub use crate::{fhir::RefKind, rustc::ty::Const};
+pub use crate::{
+    fhir::{FuncSort, RefKind, Sort},
+    rustc::ty::Const,
+};
 use crate::{
     intern::{impl_internable, Interned, List},
     rustc::mir::Place,
@@ -176,20 +179,6 @@ pub struct KVar {
     pub scope: List<Expr>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Sort {
-    Int,
-    Bool,
-    Loc,
-    Tuple(List<Sort>),
-    Func(FuncSort),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct FuncSort {
-    inputs_and_output: List<Sort>,
-}
-
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct UifDef {
     pub inputs: Vec<Sort>,
@@ -199,16 +188,6 @@ pub struct UifDef {
 newtype_index! {
     pub struct KVid {
         DEBUG_FORMAT = "$k{}"
-    }
-}
-
-impl FuncSort {
-    pub fn inputs(&self) -> &[Sort] {
-        &self.inputs_and_output[..self.inputs_and_output.len() - 1]
-    }
-
-    pub fn output(&self) -> &Sort {
-        &self.inputs_and_output[self.inputs_and_output.len() - 1]
     }
 }
 
@@ -696,7 +675,6 @@ impl_internable!(
     [KVar],
     [Constraint],
     [Index],
-    [Sort]
 );
 
 #[macro_export]
@@ -928,18 +906,11 @@ mod pretty {
         }
     }
 
-    impl fmt::Display for Sort {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            fmt::Debug::fmt(self, f)
-        }
-    }
-
     impl_debug_with_default_cx!(
         Constraint,
         TyS => "ty",
         BaseTy,
         Pred,
-        Sort,
         KVar,
         FnSig,
         Index,

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -140,7 +140,7 @@ struct RefineArgsData {
 #[derive(Eq, Hash, PartialEq)]
 pub enum RefineArg {
     Expr(Expr),
-    KVar(Binders<KVar>),
+    Pred(Binders<Pred>),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -291,7 +291,7 @@ impl RefineArg {
     pub fn as_expr(&self) -> &Expr {
         match self {
             RefineArg::Expr(e) => e,
-            RefineArg::KVar(_) => panic!("expected an [`RefineArg::Expr`]"),
+            RefineArg::Pred(_) => panic!("expected an [`RefineArg::Expr`]"),
         }
     }
 }
@@ -887,7 +887,7 @@ mod pretty {
             define_scoped!(cx, f);
             match self {
                 RefineArg::Expr(e) => w!("{:?}", e),
-                RefineArg::KVar(kvar) => w!("{:?}", kvar),
+                RefineArg::Pred(kvar) => w!("{:?}", kvar),
             }
         }
     }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -138,6 +138,7 @@ struct RefineArgsData {
 #[derive(Eq, Hash, PartialEq)]
 pub enum RefineArg {
     Expr(Expr),
+    KVar(Binders<KVar>),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -298,6 +299,7 @@ impl RefineArg {
     pub fn as_expr(&self) -> &Expr {
         match self {
             RefineArg::Expr(e) => e,
+            RefineArg::KVar(_) => panic!("expected an [`RefineArg::Expr`]"),
         }
     }
 }
@@ -931,6 +933,7 @@ mod pretty {
             define_scoped!(cx, f);
             match self {
                 RefineArg::Expr(e) => w!("{:?}", e),
+                RefineArg::KVar(kvar) => w!("{:?}", kvar),
             }
         }
     }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -187,12 +187,6 @@ pub struct KVar {
     pub scope: List<Expr>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct UifDef {
-    pub inputs: Vec<Sort>,
-    pub output: Sort,
-}
-
 newtype_index! {
     pub struct KVid {
         DEBUG_FORMAT = "$k{}"

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -80,13 +80,13 @@ impl TypeFolder for FVarFolder<'_> {
     }
 }
 
-pub(crate) struct BVarFolder<'a> {
+pub(super) struct BVarFolder<'a> {
     outer_binder: DebruijnIndex,
     exprs: &'a [Expr],
 }
 
 impl<'a> BVarFolder<'a> {
-    pub(crate) fn new(exprs: &'a [Expr]) -> BVarFolder<'a> {
+    pub(super) fn new(exprs: &'a [Expr]) -> BVarFolder<'a> {
         BVarFolder { exprs, outer_binder: INNERMOST }
     }
 }

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -131,7 +131,7 @@ impl TypeFolder for BVarFolder<'_> {
             if let RefineArg::Expr(e) = &self.args[bvar.index] {
                 e.clone()
             } else {
-                panic!("invalid substitution")
+                panic!("expected expr for `{bvar:?}` but found `{:?}` when substituting", self.args[bvar.index])
             }
         } else {
             e.super_fold_with(self)

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -115,9 +115,9 @@ impl TypeFolder for BVarFolder<'_> {
     fn fold_pred(&mut self, pred: &Pred) -> Pred {
         if let Pred::App(Var::Bound(bvar), args) = pred && bvar.debruijn == self.outer_binder {
             match &self.args[bvar.index] {
-                RefineArg::KVar(kvar) => {
+                RefineArg::Pred(pred_abs) => {
                     let args = args.iter().map(|arg| RefineArg::Expr(arg.fold_with(self))).collect_vec();
-                    Pred::Kvar(kvar.replace_bound_vars(&args))
+                    pred_abs.replace_bound_vars(&args)
                 },
                 RefineArg::Expr(_) => pred.super_fold_with(self),
             }

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private)]
+#![feature(rustc_private, box_patterns)]
 
 extern crate flux_errors;
 extern crate rustc_ast;

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -80,6 +80,14 @@ pub struct Param {
     pub sort: Ident,
 }
 
+/// An abstract refinement predicate
+#[derive(Debug)]
+pub struct AbstractPred {
+    pub name: Ident,
+    pub inputs: Vec<Ident>,
+    pub output: Ident,
+}
+
 #[derive(Debug)]
 pub struct ConstSig {
     pub span: Span,
@@ -87,6 +95,8 @@ pub struct ConstSig {
 
 #[derive(Debug)]
 pub struct FnSig<T = Ident> {
+    pub abstract_params: Vec<AbstractPred>,
+    // pub abstract: Vec<AbstractRefine>,
     /// example: `requires n > 0`
     pub requires: Option<Expr>,
     /// example: `i32<@n>`
@@ -305,6 +315,7 @@ pub mod expand {
         fn_sig: FnSig,
     ) -> Result<FnSig, ErrorGuaranteed> {
         Ok(FnSig {
+            abstract_params: fn_sig.abstract_params,
             args: expand_args(sess, aliases, fn_sig.args)?,
             returns: fn_sig.returns.as_ref().map(|ty| expand_ty(aliases, ty)),
             ensures: expand_locs(aliases, fn_sig.ensures),

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -164,8 +164,8 @@ pub struct Indices {
 
 #[derive(Debug, Clone)]
 pub enum Index {
-    /// @n
-    Bind(Ident),
+    /// @n, the span correspond to the span of @ plus the identifier
+    Bind(Ident, Span),
     Expr(Expr),
 }
 
@@ -444,11 +444,7 @@ pub mod expand {
                 Index::Expr(e) => {
                     res.insert(*src_id, e.clone());
                 }
-                Index::Bind(_) => panic!("cannot use binder in type alias"),
-                // TyKind::Path(p) if p.args.is_empty() => {
-                //     res.insert(*src_id, p.ident);
-                // }
-                // _ => panic!("mk_sub: invalid arg"),
+                Index::Bind(..) => panic!("cannot use binder in type alias"),
             }
         }
         res
@@ -512,10 +508,10 @@ pub mod expand {
         Indices { indices, span: i_indices.span }
     }
 
-    fn subst_index(subst: &Subst, i: &Index) -> Index {
-        match i {
+    fn subst_index(subst: &Subst, idx: &Index) -> Index {
+        match idx {
             super::Index::Expr(e) => Index::Expr(subst_expr(subst, e)),
-            super::Index::Bind(_) => i.clone(),
+            super::Index::Bind(..) => idx.clone(),
         }
     }
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -82,7 +82,10 @@ pub struct RefineParam {
 
 #[derive(Debug)]
 pub enum Sort {
+    /// A _base_ sort, e.g., `int` or `bool`.
     Base(Ident),
+    /// A _function_ sort of the form `(bi,...) -> bo` where `bi..` and `bo`
+    /// are all base sorts.
     Func { inputs: Vec<Ident>, output: Ident },
 }
 
@@ -93,7 +96,7 @@ pub struct ConstSig {
 
 #[derive(Debug)]
 pub struct FnSig<T = Ident> {
-    /// note: the parser only accepts params with a function sort
+    /// List of explicit refinement parameters
     pub params: Vec<RefineParam>,
     /// example: `requires n > 0`
     pub requires: Option<Expr>,

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -192,7 +192,7 @@ Level7 = LeftAssoc<BinOp7, Level8>; // *, %
 Level8: surface::Expr = {
     <lo:@L> "if" <p:Level1> "{" <e1:Level1> "}" "else" "{" <e2:Level1> "}" <hi:@R> => {
         surface::Expr {
-            kind: surface::ExprKind::IfThenElse(Box::new(p), Box::new(e1), Box::new(e2)),
+            kind: surface::ExprKind::IfThenElse(Box::new([p, e1, e2])),
             span: mk_span(lo, hi),
         }
     },
@@ -227,7 +227,7 @@ Level8: surface::Expr = {
 
 NonAssoc<Op, NextLevel>: surface::Expr = {
     <lo:@L> <e1:NextLevel> <op:Op> <e2:NextLevel> <hi:@R> => surface::Expr {
-        kind: surface::ExprKind::BinaryOp(op, Box::new(e1), Box::new(e2)),
+        kind: surface::ExprKind::BinaryOp(op, Box::new([e1, e2])),
         span: mk_span(lo, hi)
     },
     NextLevel
@@ -237,8 +237,7 @@ LeftAssoc<Op, NextLevel>: surface::Expr = {
         surface::Expr {
             kind: surface::ExprKind::BinaryOp(
                 op,
-                Box::new(e1),
-                Box::new(e2)
+                Box::new([e1, e2])
             ),
             span: mk_span(lo, hi),
         },

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -57,6 +57,7 @@ Param: surface::Param = <name: Ident> ":" <sort: Ident> => surface::Param { <> }
 pub FnSig: surface::FnSig = {
     <lo:@L>
     "fn"
+    <abstract_params:("<" <Comma<AbstractPred>> ">")?>
     "(" <args:Args> ")"
     <returns:("->" <Ty>)?>
     <requires:("requires" <Level1>)?>
@@ -64,8 +65,13 @@ pub FnSig: surface::FnSig = {
     <hi:@R>
     => {
         let ensures = ensures.unwrap_or_default();
-        surface::FnSig { args, returns, ensures, requires, span: mk_span(lo, hi) }
+        let abstract_params = abstract_params.unwrap_or_default();
+        surface::FnSig { abstract_params, args, returns, ensures, requires, span: mk_span(lo, hi) }
     }
+}
+
+AbstractPred: surface::AbstractPred = {
+    <name:Ident> ":" "(" <inputs:Comma<Ident>> ")" "->" <output:Ident> => surface::AbstractPred { <> }
 }
 
 pub Variant: surface::VariantDef = {

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -176,8 +176,8 @@ Indices: surface::Indices = {
 };
 
 Index: surface::Index = {
-    "@" <Ident> => surface::Index::Bind(<>),
-    <Level1>    => surface::Index::Expr(<>),
+    <lo:@L> "@" <bind:Ident> <hi:@R> => surface::Index::Bind(bind, mk_span(lo, hi)),
+    <Level1>                         => surface::Index::Expr(<>),
 };
 
 pub Expr = Level1;

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -56,7 +56,8 @@ RefineParam: surface::RefineParam = <name:Ident> ":" <sort:Sort> => surface::Ref
 
 Sort: surface::Sort = {
     <sort: Ident> => surface::Sort::Base(sort),
-    "(" <inputs:Comma<Ident>> ")" "->" <output:Ident> => surface::Sort::Func { <> }
+    "(" <inputs:Comma<Ident>> ")" "->" <output:Ident> => surface::Sort::Func { <> },
+    <input:Ident> "->" <output:Ident>                 => surface::Sort::Func { inputs: vec![input], output }
 }
 
 pub FnSig: surface::FnSig = {

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -25,7 +25,7 @@ pub Alias: surface::Alias = {
 }
 
 pub RefinedBy: surface::RefinedBy = {
-    <lo:@L> <params:Comma<Param>> <hi:@R> => surface::RefinedBy { params, span: mk_span(lo, hi) }
+    <lo:@L> <params:Comma<RefineParam>> <hi:@R> => surface::RefinedBy { params, span: mk_span(lo, hi) }
 }
 
 pub UifDef: surface::UifDef = {
@@ -44,7 +44,7 @@ pub UifDef: surface::UifDef = {
 pub Qualifier: surface::Qualifier = {
     <lo:@L>
     <name:Ident>
-    "(" <args:Comma<Param>> ")"
+    "(" <args:Comma<RefineParam>> ")"
     ":"
     <expr:Level1>
     <hi:@R> => {
@@ -52,12 +52,17 @@ pub Qualifier: surface::Qualifier = {
     }
 }
 
-Param: surface::Param = <name: Ident> ":" <sort: Ident> => surface::Param { <> };
+RefineParam: surface::RefineParam = <name:Ident> ":" <sort:Sort> => surface::RefineParam { <> };
+
+Sort: surface::Sort = {
+    <sort: Ident> => surface::Sort::Base(sort),
+    "(" <inputs:Comma<Ident>> ")" "->" <output:Ident> => surface::Sort::Func { <> }
+}
 
 pub FnSig: surface::FnSig = {
     <lo:@L>
     "fn"
-    <abstract_params:("<" <Comma<AbstractPred>> ">")?>
+    <params:("<" <Comma<RefineParam>> ">")?>
     "(" <args:Args> ")"
     <returns:("->" <Ty>)?>
     <requires:("requires" <Level1>)?>
@@ -65,13 +70,9 @@ pub FnSig: surface::FnSig = {
     <hi:@R>
     => {
         let ensures = ensures.unwrap_or_default();
-        let abstract_params = abstract_params.unwrap_or_default();
-        surface::FnSig { abstract_params, args, returns, ensures, requires, span: mk_span(lo, hi) }
+        let params = params.unwrap_or_default();
+        surface::FnSig { params, args, returns, ensures, requires, span: mk_span(lo, hi) }
     }
-}
-
-AbstractPred: surface::AbstractPred = {
-    <name:Ident> ":" "(" <inputs:Comma<Ident>> ")" "->" <output:Ident> => surface::AbstractPred { <> }
 }
 
 pub Variant: surface::VariantDef = {

--- a/flux-tests/tests/neg/abstract_refinements/test00.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test00.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(
+    fn<p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    requires p(x) && p(y)
+)]
+fn max(x: i32, y: i32) -> i32 {
+    if x > y {
+        x
+    } else {
+        y
+    }
+}
+
+#[flux::sig(fn() -> i32{v: v % 2 == 0})]
+fn test00() -> i32 {
+    max(4, 5) //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> i32[10])]
+fn test01() -> i32 {
+    max(4, 1) //~ ERROR postcondition
+}

--- a/flux-tests/tests/neg/error_messages/abstract_refinements.rs
+++ b/flux-tests/tests/neg/error_messages/abstract_refinements.rs
@@ -1,0 +1,19 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(
+    fn<p: int -> bool>(x: i32) -> i32{v: p(v)}
+    requires x > 0 || p(x) //~ ERROR illegal use of refinement parameter
+)]
+fn test00(x: i32) -> i32 {
+    0
+}
+
+#[flux::sig(
+    fn<p: int -> bool>(x: i32) -> i32{v: p(v)}
+    requires p == p //~ ERROR illegal use of refinement parameter
+    //~^ ERROR illegal use of refinement parameter
+)]
+fn test01(x: i32) -> i32 {
+    0
+}

--- a/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
@@ -13,8 +13,3 @@ pub fn foo(x: i32, y: i32) -> i32 {
 pub fn bar(a: i32) -> i32 {
     return a;
 }
-
-#[flux::sig(fn (i32[fog(10, 20)]) -> i32)] //~ ERROR unresolved function
-pub fn baz(a: i32) -> i32 {
-    return a;
-}

--- a/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
@@ -1,0 +1,9 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+#![feature(custom_inner_attributes)]
+#![flux::uf(fn foo(int, int) -> int)]
+
+#[flux::sig(fn (i32[fog(10, 20)]) -> i32)] //~ ERROR cannot find value `fog`
+pub fn baz(a: i32) -> i32 {
+    return a;
+}

--- a/flux-tests/tests/neg/error_messages/fun_sig_error.rs
+++ b/flux-tests/tests/neg/error_messages/fun_sig_error.rs
@@ -7,12 +7,12 @@ pub fn say_strng(x: &mut i32) {
     return;
 }
 
-#[flux::sig(fn(x:i32) -> i32)] //~ ERROR mismatched types
+#[flux::sig(fn(x:i32) -> i32)] //~ ERROR invalid refinement annotation
 pub fn sob(x: i32) {
     return;
 }
 
-#[flux::sig(fn(x:i32) -> i32)] //~ ERROR mismatched types
+#[flux::sig(fn(x:i32) -> i32)] //~ ERROR invalid refinement annotation
 pub fn foo(x: bool) -> i32 {
     if x {
         1
@@ -21,7 +21,7 @@ pub fn foo(x: bool) -> i32 {
     }
 }
 
-#[flux::sig(fn(x:i32) -> i32)] //~ ERROR mismatched types
+#[flux::sig(fn(x:i32) -> i32)] //~ ERROR invalid refinement annotation
 pub fn bar(x: i32) -> bool {
     x > 0
 }
@@ -31,7 +31,7 @@ pub fn boo(x: i32) -> bool {
     x > 0
 }
 
-#[flux::sig(fn(x:Option<i32>) -> i32)] //~ ERROR mismatched types
+#[flux::sig(fn(x:Option<i32>) -> i32)] //~ ERROR invalid refinement annotation
 pub fn goo(x: i32) -> Option<i32> {
     Some(x)
 }
@@ -56,7 +56,7 @@ type A<'a> = &'a [i32];
 #[flux::sig(fn())]
 fn dipa(x: A) {} //~ ERROR unsupported function signature
 
-#[flux::sig(fn(x: f32))] //~ ERROR mismatched types
+#[flux::sig(fn(x: f32))] //~ ERROR invalid refinement annotation
 fn hefe(f: &mut f32) {}
 
 #[flux::sig(fn(x: &mut f32))] //~ ERROR invalid refinement annotation

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -40,12 +40,12 @@ pub fn myint2(x: i32) -> i32 {
     x
 }
 
-#[flux::sig(fn(f: f32) -> i32[f])] //~ ERROR invalid use of parameter
+#[flux::sig(fn(f: f32) -> i32[f])] //~ ERROR invalid use of refinement parameter
 fn ipa(f: f32) -> i32 {
     0
 }
 
-#[flux::sig(fn(f: f32) -> i32[f.x])] //~ ERROR invalid use of parameter
+#[flux::sig(fn(f: f32) -> i32[f.x])] //~ ERROR invalid use of refinement parameter
 fn ris(f: f32) -> i32 {
     0
 }

--- a/flux-tests/tests/neg/error_messages/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/index_errors.rs
@@ -35,7 +35,7 @@ pub fn myint1(x: i32) -> i32 {
     x
 }
 
-#[flux::sig(fn(i32) -> i32[@n])] //~ ERROR cannot find
+#[flux::sig(fn(i32) -> i32[@n])] //~ ERROR illegal binder
 pub fn myint2(x: i32) -> i32 {
     x
 }

--- a/flux-tests/tests/neg/error_messages/struct_error.rs
+++ b/flux-tests/tests/neg/error_messages/struct_error.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 struct S {
-    #[flux::field(i64)] //~ ERROR mismatched types
+    #[flux::field(i64)] //~ ERROR invalid refinement annotation
     x: i32,
     y: i64,
 }

--- a/flux-tests/tests/neg/error_messages/variant_sig_desugar_err.rs
+++ b/flux-tests/tests/neg/error_messages/variant_sig_desugar_err.rs
@@ -1,0 +1,8 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(b: int)]
+pub enum E2 {
+    #[flux::variant((i32[@n]) -> E2[@n])] //~ ERROR illegal binder
+    A(i32),
+}

--- a/flux-tests/tests/neg/error_messages/variant_sig_wf_errors.rs
+++ b/flux-tests/tests/neg/error_messages/variant_sig_wf_errors.rs
@@ -7,6 +7,4 @@ pub enum E2 {
     A(i32),
     #[flux::variant(E2[true])] //~ ERROR mismatched sorts
     B,
-    #[flux::variant((i32[@n]) -> E2[@n])] //~ ERROR illegal binder
-    C(i32),
 }

--- a/flux-tests/tests/pos/abstract_refinements/test00.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test00.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(
+    fn<p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    requires p(x) && p(y)
+)]
+fn max(x: i32, y: i32) -> i32 {
+    if x > y {
+        x
+    } else {
+        y
+    }
+}
+
+#[flux::sig(fn() -> i32{v: v % 2 == 0})]
+fn test00() -> i32 {
+    max(4, 10)
+}
+
+#[flux::sig(fn() -> i32[10])]
+fn test01() -> i32 {
+    max(4, 10)
+}

--- a/flux-tests/tests/pos/enums/list00.rs
+++ b/flux-tests/tests/pos/enums/list00.rs
@@ -15,54 +15,54 @@ pub enum List {
     Cons(i32, Box<List>),
 }
 
-#[flux::sig(fn(&List[@n]) -> bool[n == 0])]
-pub fn empty(l: &List) -> bool {
-    match l {
-        List::Nil => true,
-        List::Cons(_, _) => false,
-    }
-}
+// #[flux::sig(fn(&List[@n]) -> bool[n == 0])]
+// pub fn empty(l: &List) -> bool {
+//     match l {
+//         List::Nil => true,
+//         List::Cons(_, _) => false,
+//     }
+// }
 
-#[flux::sig(fn(&List[@n]) -> i32[n])]
-pub fn len(l: &List) -> i32 {
-    match l {
-        List::Nil => 0,
-        List::Cons(_, tl) => 1 + len(tl),
-    }
-}
+// #[flux::sig(fn(&List[@n]) -> i32[n])]
+// pub fn len(l: &List) -> i32 {
+//     match l {
+//         List::Nil => 0,
+//         List::Cons(_, tl) => 1 + len(tl),
+//     }
+// }
 
-#[flux::sig(fn({&List[@n] : 0 < n}) -> i32)]
-pub fn head(l: &List) -> i32 {
-    match l {
-        List::Nil => never(0),
-        List::Cons(h, _) => *h,
-    }
-}
+// #[flux::sig(fn({&List[@n] : 0 < n}) -> i32)]
+// pub fn head(l: &List) -> i32 {
+//     match l {
+//         List::Nil => never(0),
+//         List::Cons(h, _) => *h,
+//     }
+// }
 
-#[flux::sig(fn({&List[@n] : 0 < n}) -> &List)]
-pub fn tail(l: &List) -> &List {
-    match l {
-        List::Nil => never(0),
-        List::Cons(_, t) => t,
-    }
-}
+// #[flux::sig(fn({&List[@n] : 0 < n}) -> &List)]
+// pub fn tail(l: &List) -> &List {
+//     match l {
+//         List::Nil => never(0),
+//         List::Cons(_, t) => t,
+//     }
+// }
 
-#[flux::sig(fn(i32, n:usize) -> List[n])]
-pub fn clone(val: i32, n: usize) -> List {
-    if n == 0 {
-        List::Nil
-    } else {
-        List::Cons(val, Box::new(clone(val, n - 1)))
-    }
-}
+// #[flux::sig(fn(i32, n:usize) -> List[n])]
+// pub fn clone(val: i32, n: usize) -> List {
+//     if n == 0 {
+//         List::Nil
+//     } else {
+//         List::Cons(val, Box::new(clone(val, n - 1)))
+//     }
+// }
 
-#[flux::sig(fn(List[@n1], List[@n2]) -> List[n1+n2])]
-pub fn append(l1: List, l2: List) -> List {
-    match l1 {
-        List::Nil => l2,
-        List::Cons(h1, t1) => List::Cons(h1, Box::new(append(*t1, l2))),
-    }
-}
+// #[flux::sig(fn(List[@n1], List[@n2]) -> List[n1+n2])]
+// pub fn append(l1: List, l2: List) -> List {
+//     match l1 {
+//         List::Nil => l2,
+//         List::Cons(h1, t1) => List::Cons(h1, Box::new(append(*t1, l2))),
+//     }
+// }
 
 #[flux::sig(fn(&List[@n], k:usize{k < n} ) -> i32)]
 pub fn get_nth(l: &List, k: usize) -> i32 {

--- a/flux-tests/tests/pos/enums/list00.rs
+++ b/flux-tests/tests/pos/enums/list00.rs
@@ -15,54 +15,54 @@ pub enum List {
     Cons(i32, Box<List>),
 }
 
-// #[flux::sig(fn(&List[@n]) -> bool[n == 0])]
-// pub fn empty(l: &List) -> bool {
-//     match l {
-//         List::Nil => true,
-//         List::Cons(_, _) => false,
-//     }
-// }
+#[flux::sig(fn(&List[@n]) -> bool[n == 0])]
+pub fn empty(l: &List) -> bool {
+    match l {
+        List::Nil => true,
+        List::Cons(_, _) => false,
+    }
+}
 
-// #[flux::sig(fn(&List[@n]) -> i32[n])]
-// pub fn len(l: &List) -> i32 {
-//     match l {
-//         List::Nil => 0,
-//         List::Cons(_, tl) => 1 + len(tl),
-//     }
-// }
+#[flux::sig(fn(&List[@n]) -> i32[n])]
+pub fn len(l: &List) -> i32 {
+    match l {
+        List::Nil => 0,
+        List::Cons(_, tl) => 1 + len(tl),
+    }
+}
 
-// #[flux::sig(fn({&List[@n] : 0 < n}) -> i32)]
-// pub fn head(l: &List) -> i32 {
-//     match l {
-//         List::Nil => never(0),
-//         List::Cons(h, _) => *h,
-//     }
-// }
+#[flux::sig(fn({&List[@n] : 0 < n}) -> i32)]
+pub fn head(l: &List) -> i32 {
+    match l {
+        List::Nil => never(0),
+        List::Cons(h, _) => *h,
+    }
+}
 
-// #[flux::sig(fn({&List[@n] : 0 < n}) -> &List)]
-// pub fn tail(l: &List) -> &List {
-//     match l {
-//         List::Nil => never(0),
-//         List::Cons(_, t) => t,
-//     }
-// }
+#[flux::sig(fn({&List[@n] : 0 < n}) -> &List)]
+pub fn tail(l: &List) -> &List {
+    match l {
+        List::Nil => never(0),
+        List::Cons(_, t) => t,
+    }
+}
 
-// #[flux::sig(fn(i32, n:usize) -> List[n])]
-// pub fn clone(val: i32, n: usize) -> List {
-//     if n == 0 {
-//         List::Nil
-//     } else {
-//         List::Cons(val, Box::new(clone(val, n - 1)))
-//     }
-// }
+#[flux::sig(fn(i32, n:usize) -> List[n])]
+pub fn clone(val: i32, n: usize) -> List {
+    if n == 0 {
+        List::Nil
+    } else {
+        List::Cons(val, Box::new(clone(val, n - 1)))
+    }
+}
 
-// #[flux::sig(fn(List[@n1], List[@n2]) -> List[n1+n2])]
-// pub fn append(l1: List, l2: List) -> List {
-//     match l1 {
-//         List::Nil => l2,
-//         List::Cons(h1, t1) => List::Cons(h1, Box::new(append(*t1, l2))),
-//     }
-// }
+#[flux::sig(fn(List[@n1], List[@n2]) -> List[n1+n2])]
+pub fn append(l1: List, l2: List) -> List {
+    match l1 {
+        List::Nil => l2,
+        List::Cons(h1, t1) => List::Cons(h1, Box::new(append(*t1, l2))),
+    }
+}
 
 #[flux::sig(fn(&List[@n], k:usize{k < n} ) -> i32)]
 pub fn get_nth(l: &List, k: usize) -> i32 {

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -490,9 +490,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         let ty = self.check_operand(rcx, env, source_info, cond)?;
         let pred = if let TyKind::Indexed(BaseTy::Bool, idxs) = ty.kind() {
             if expected {
-                idxs.nth(0).clone()
+                idxs.nth(0).as_expr().clone()
             } else {
-                idxs.nth(0).not()
+                idxs.nth(0).as_expr().not()
             }
         } else {
             unreachable!("unexpected ty `{ty:?}`")
@@ -516,13 +516,17 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             match discr_ty.kind() {
                 TyKind::Indexed(BaseTy::Bool, idxs) => {
                     if bits == 0 {
-                        idxs.nth(0).not()
+                        idxs.nth(0).as_expr().not()
                     } else {
-                        idxs.nth(0).clone()
+                        idxs.nth(0).as_expr().clone()
                     }
                 }
                 TyKind::Indexed(bty @ (BaseTy::Int(_) | BaseTy::Uint(_)), idxs) => {
-                    Expr::binary_op(BinOp::Eq, idxs.nth(0).clone(), Expr::from_bits(bty, bits))
+                    Expr::binary_op(
+                        BinOp::Eq,
+                        idxs.nth(0).as_expr().clone(),
+                        Expr::from_bits(bty, bits),
+                    )
                 }
                 _ => unreachable!("unexpected discr_ty {:?}", discr_ty),
             }
@@ -711,7 +715,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             }
             _ => unreachable!("incompatible types: `{:?}` `{:?}`", ty1, ty2),
         };
-        let (e1, e2) = (idx1.clone(), idx2.clone());
+        let (e1, e2) = (idx1.as_expr().clone(), idx2.as_expr().clone());
         if let sigs::Pre::Some(tag, constr) = sig.pre {
             self.phase
                 .constr_gen(self.genv, rcx, tag(source_info.span))
@@ -747,7 +751,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             (Bool!(idxs1), Bool!(idxs2)) => (idxs1.nth(0), idxs2.nth(0), sigs::bool_bin_ops(op)),
             _ => return Ty::bool(),
         };
-        let (e1, e2) = (idx1.clone(), idx2.clone());
+        let (e1, e2) = (idx1.as_expr().clone(), idx2.as_expr().clone());
         if let sigs::Pre::Some(tag, constr) = sig.pre {
             self.phase
                 .constr_gen(self.genv, rcx, tag(source_info.span))
@@ -776,7 +780,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         let ty = match un_op {
             mir::UnOp::Not => {
                 if let Bool!(idxs) = ty.kind() {
-                    Ty::indexed(BaseTy::Bool, RefineArgs::one(idxs.nth(0).not()))
+                    Ty::indexed(BaseTy::Bool, RefineArgs::one(idxs.nth(0).as_expr().not()))
                 } else {
                     unreachable!("incompatible type: `{:?}`", ty)
                 }
@@ -784,7 +788,10 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             mir::UnOp::Neg => {
                 match ty.kind() {
                     Int!(int_ty, idxs) => {
-                        Ty::indexed(BaseTy::Int(*int_ty), RefineArgs::one(idxs.nth(0).neg()))
+                        Ty::indexed(
+                            BaseTy::Int(*int_ty),
+                            RefineArgs::one(idxs.nth(0).as_expr().neg()),
+                        )
                     }
                     Float!(float_ty, _) => Ty::float(*float_ty),
                     _ => unreachable!("incompatible type: `{:?}`", ty),
@@ -799,16 +806,20 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         match kind {
             CastKind::IntToInt => {
                 match (from.kind(), to.kind()) {
-                    (Bool!(idxs), RustTy::Int(int_ty)) => bool_int_cast(idxs.nth(0), *int_ty),
-                    (Bool!(idxs), RustTy::Uint(uint_ty)) => bool_uint_cast(idxs.nth(0), *uint_ty),
+                    (Bool!(idxs), RustTy::Int(int_ty)) => {
+                        bool_int_cast(idxs.nth(0).as_expr(), *int_ty)
+                    }
+                    (Bool!(idxs), RustTy::Uint(uint_ty)) => {
+                        bool_uint_cast(idxs.nth(0).as_expr(), *uint_ty)
+                    }
                     (Int!(int_ty1, idxs), RustTy::Int(int_ty2)) => {
-                        int_int_cast(idxs.nth(0), *int_ty1, *int_ty2)
+                        int_int_cast(idxs.nth(0).as_expr(), *int_ty1, *int_ty2)
                     }
                     (Uint!(uint_ty1, idxs), RustTy::Uint(uint_ty2)) => {
-                        uint_uint_cast(idxs.nth(0), *uint_ty1, *uint_ty2)
+                        uint_uint_cast(idxs.nth(0).as_expr(), *uint_ty1, *uint_ty2)
                     }
                     (Uint!(uint_ty, idxs), RustTy::Int(int_ty)) => {
-                        uint_int_cast(idxs.nth(0), *uint_ty, *int_ty)
+                        uint_int_cast(idxs.nth(0).as_expr(), *uint_ty, *int_ty)
                     }
                     (Int!(_, _), RustTy::Uint(uint_ty)) => Ty::uint(*uint_ty),
                     _ => {

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -129,7 +129,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
             .collect_vec();
 
         // Infer refinement parameters
-        let exprs = param_infer::infer_from_fn_call(env, &actuals, fn_sig)?;
+        let exprs = param_infer::infer_from_fn_call(env, &actuals, fn_sig, &mut self.fresh_kvar)?;
         let fn_sig = fn_sig
             .replace_generic_args(&substs)
             .replace_bound_vars(&exprs);
@@ -184,7 +184,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
             .collect_vec();
 
         // Infer refinement parameters
-        let exprs = param_infer::infer_from_constructor(fields, variant)?;
+        let exprs = param_infer::infer_from_constructor(fields, variant, &mut self.fresh_kvar)?;
         let variant = variant
             .replace_generic_args(&substs)
             .replace_bound_vars(&exprs);

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -111,7 +111,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         // where the formal argument is of the form `&mut B[@n]`, e.g., the type of the first argument
         // to `RVec::get_mut` is `&mut RVec<T>[@n]`. We should remove this after we implement opening of
         // mutable references.
-        let actuals = iter::zip(actuals, fn_sig.skip_binders().args())
+        let actuals = iter::zip(actuals, fn_sig.as_ref().skip_binders().args())
             .map(|(actual, formal)| {
                 if let (TyKind::Ref(RefKind::Mut, _), TyKind::Ref(RefKind::Mut, ty)) = (actual.kind(), formal.kind())
                 && let TyKind::Indexed(..) = ty.kind() {

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -221,7 +221,10 @@ fn subtyping(genv: &GlobalEnv, constr: &mut ConstrBuilder, ty1: &Ty, ty2: &Ty, t
             bty_subtyping(genv, constr, bty1, bty2, tag);
             for (idx1, idx2) in iter::zip(idxs1.args(), idx2.args()) {
                 if idx1 != idx2 {
-                    constr.push_head(Expr::binary_op(BinOp::Eq, idx1.clone(), idx2.clone()), tag);
+                    constr.push_head(
+                        Expr::binary_op(BinOp::Eq, idx1.as_expr().clone(), idx2.as_expr().clone()),
+                        tag,
+                    );
                 }
             }
         }

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -379,7 +379,7 @@ impl std::str::FromStr for TagIdx {
 
 pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
     match sort {
-        rty::Sort::Int | rty::Sort::Loc => fixpoint::Sort::Int,
+        rty::Sort::Int => fixpoint::Sort::Int,
         rty::Sort::Bool => fixpoint::Sort::Bool,
         rty::Sort::Tuple(sorts) => {
             match &sorts[..] {
@@ -398,6 +398,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
                 }
             }
         }
+        rty::Sort::Func(_) | rty::Sort::Loc => unreachable!("unexpected sort {sort:?}"),
     }
 }
 
@@ -472,7 +473,7 @@ fn expr_to_fixpoint(expr: &rty::Expr, name_map: &NameMap, const_map: &ConstMap) 
         rty::ExprKind::App(f, exprs) => {
             let args = exprs
                 .iter()
-                .map(|e| expr_to_fixpoint(e, name_map, const_map))
+                .map(|e| (expr_to_fixpoint(e, name_map, const_map)))
                 .collect();
             fixpoint::Expr::App(f.to_string(), args)
         }

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -210,6 +210,7 @@ where
             }
             rty::Pred::Kvar(kvar) => self.kvar_to_fixpoint(kvar, bindings),
             rty::Pred::Hole => panic!("unexpected hole"),
+            rty::Pred::App(_, _) => todo!(),
         }
     }
 

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -214,9 +214,9 @@ where
                     .name_map
                     .get(name)
                     .unwrap_or_else(|| panic!("no entry found for key: `{name:?}`"));
-                let func = fixpoint::Expr::Var(*name);
+                let func = fixpoint::Func::Var(*name);
                 let args = exprs_to_fixpoint(args, &self.name_map, &self.const_map);
-                fixpoint::Pred::Expr(fixpoint::Expr::App(Box::new(func), args))
+                fixpoint::Pred::Expr(fixpoint::Expr::App(func, args))
             }
             rty::Pred::App(rty::Var::Bound(_), _) => {
                 panic!("unexpected bound var in pred application")
@@ -499,8 +499,8 @@ fn expr_to_fixpoint(expr: &rty::Expr, name_map: &NameMap, const_map: &ConstMap) 
         rty::ExprKind::ConstDefId(did) => fixpoint::Expr::Var(const_map[did].name),
         rty::ExprKind::App(func, args) => {
             let args = exprs_to_fixpoint(args, name_map, const_map);
-            let uif = fixpoint::Expr::Uif(func.to_string());
-            fixpoint::Expr::App(Box::new(uif), args)
+            let uif = fixpoint::Func::Uif(func.to_string());
+            fixpoint::Expr::App(uif, args)
         }
         rty::ExprKind::IfThenElse(p, e1, e2) => {
             fixpoint::Expr::IfThenElse(Box::new([
@@ -531,10 +531,10 @@ fn tuple_to_fixpoint(
     match exprs {
         [] => fixpoint::Expr::Unit,
         [e, exprs @ ..] => {
-            fixpoint::Expr::Pair(
-                Box::new(expr_to_fixpoint(e, name_map, const_map)),
-                Box::new(tuple_to_fixpoint(exprs, name_map, const_map)),
-            )
+            fixpoint::Expr::Pair(Box::new([
+                expr_to_fixpoint(e, name_map, const_map),
+                tuple_to_fixpoint(exprs, name_map, const_map),
+            ]))
         }
     }
 }

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -4,8 +4,8 @@
     once_cell,
     if_let_guard,
     let_chains,
-    never_type,
-    type_alias_impl_trait
+    type_alias_impl_trait,
+    box_patterns
 )]
 
 extern crate rustc_data_structures;

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -17,10 +17,10 @@ pub fn infer_from_constructor(
     fields: &[Ty],
     variant: &PolyVariant,
 ) -> Result<Vec<Expr>, InferenceError> {
-    debug_assert_eq!(fields.len(), variant.skip_binders().fields().len());
+    debug_assert_eq!(fields.len(), variant.as_ref().skip_binders().fields().len());
     let mut exprs = Exprs::default();
 
-    for (actual, formal) in iter::zip(fields, variant.skip_binders().fields()) {
+    for (actual, formal) in iter::zip(fields, variant.as_ref().skip_binders().fields()) {
         infer_from_tys(&mut exprs, &FxHashMap::default(), actual, &FxHashMap::default(), formal);
     }
 
@@ -32,10 +32,11 @@ pub fn infer_from_fn_call<M: PathMap>(
     actuals: &[Ty],
     fn_sig: &PolySig,
 ) -> Result<Vec<Expr>, InferenceError> {
-    debug_assert_eq!(actuals.len(), fn_sig.skip_binders().args().len());
+    debug_assert_eq!(actuals.len(), fn_sig.as_ref().skip_binders().args().len());
 
     let mut exprs = Exprs::default();
     let requires: FxHashMap<Path, Ty> = fn_sig
+        .as_ref()
         .skip_binders()
         .requires()
         .iter()
@@ -48,7 +49,7 @@ pub fn infer_from_fn_call<M: PathMap>(
         })
         .collect();
 
-    for (actual, formal) in iter::zip(actuals, fn_sig.skip_binders().args()) {
+    for (actual, formal) in iter::zip(actuals, fn_sig.as_ref().skip_binders().args()) {
         infer_from_tys(&mut exprs, env, actual, &requires, formal);
     }
 

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -82,10 +82,10 @@ pub fn check_inference(
 
 fn infer_from_tys(exprs: &mut Exprs, env1: &impl PathMap, ty1: &Ty, env2: &impl PathMap, ty2: &Ty) {
     match (ty1.unconstr().kind(), ty2.unconstr().kind()) {
-        (TyKind::Indexed(_, indices1), TyKind::Indexed(_, indices2)) => {
-            for (idx1, idx2) in iter::zip(indices1, indices2) {
-                if idx2.is_binder {
-                    infer_from_exprs(exprs, &idx1.expr, &idx2.expr);
+        (TyKind::Indexed(_, idxs1), TyKind::Indexed(_, idxs2)) => {
+            for (i, (idx1, idx2)) in iter::zip(idxs1.args(), idxs2.args()).enumerate() {
+                if idxs2.is_binder(i) {
+                    infer_from_exprs(exprs, idx1, idx2);
                 }
             }
         }

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -139,8 +139,8 @@ fn infer_from_generic_args(
 }
 
 fn infer_from_refine_args(exprs: &mut Exprs, arg1: &RefineArg, arg2: &RefineArg) {
-    match (arg1, arg2) {
-        (RefineArg::Expr(e1), RefineArg::Expr(e2)) => infer_from_exprs(exprs, e1, e2),
+    if let (RefineArg::Expr(e1), RefineArg::Expr(e2)) = (arg1, arg2) {
+        infer_from_exprs(exprs, e1, e2)
     }
 }
 

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -9,7 +9,7 @@ use flux_common::index::{IndexGen, IndexVec};
 use flux_fixpoint as fixpoint;
 use flux_middle::rty::{
     box_args, fold::TypeFoldable, BaseTy, Binders, Expr, GenericArg, Name, Pred, RefKind,
-    RefineArgs, Sort, Ty, TyKind,
+    RefineArg, RefineArgs, Sort, Ty, TyKind,
 };
 use itertools::Itertools;
 
@@ -282,7 +282,7 @@ impl ConstrBuilder<'_> {
         self.ptr.push_guard(p.into());
     }
 
-    pub fn push_bound_guard(&mut self, pred: &Binders<Pred>) -> Vec<Expr> {
+    pub fn push_bound_guard(&mut self, pred: &Binders<Pred>) -> Vec<RefineArg> {
         self.ptr.push_bound_guard(pred)
     }
 
@@ -306,14 +306,14 @@ impl NodePtr {
         }
     }
 
-    fn push_bound_guard(&mut self, pred: &Binders<Pred>) -> Vec<Expr> {
-        let exprs = self
+    fn push_bound_guard(&mut self, pred: &Binders<Pred>) -> Vec<RefineArg> {
+        let args = self
             .push_foralls(pred.params())
             .into_iter()
-            .map(Expr::fvar)
+            .map(|name| RefineArg::Expr(Expr::fvar(name)))
             .collect_vec();
-        self.push_guard(pred.replace_bound_vars(&exprs));
-        exprs
+        self.push_guard(pred.replace_bound_vars(&args));
+        args
     }
 
     fn push_foralls(&mut self, sorts: &[Sort]) -> Vec<Name> {

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -284,8 +284,8 @@ impl ConstrBuilder<'_> {
         ConstrBuilder { tree: self.tree, ptr: NodePtr::clone(&self.ptr) }
     }
 
-    pub fn push_guard(&mut self, p: Expr) {
-        self.ptr.push_guard(p);
+    pub fn push_guard(&mut self, p: impl Into<Pred>) {
+        self.ptr.push_guard(p.into());
     }
 
     pub fn push_bound_guard(&mut self, pred: &Binders<Pred>) -> Vec<Expr> {

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -7,8 +7,8 @@ use flux_middle::{
     global_env::{GlobalEnv, OpaqueStructErr},
     intern::List,
     rty::{
-        box_args, fold::TypeFoldable, subst::FVarSubst, BaseTy, Binders, Expr, GenericArg, Index,
-        Path, RefKind, Ty, TyKind,
+        box_args, fold::TypeFoldable, subst::FVarSubst, BaseTy, Binders, Expr, GenericArg, Path,
+        RefKind, RefineArgs, Ty, TyKind,
     },
     rustc::mir::{Local, Place, PlaceElem},
 };
@@ -221,10 +221,10 @@ impl TypeEnv {
         subst: &mut FVarSubst,
     ) {
         match (ty1.kind(), ty2.kind()) {
-            (TyKind::Indexed(bty1, indices1), TyKind::Indexed(bty2, indices2)) => {
+            (TyKind::Indexed(bty1, idxs1), TyKind::Indexed(bty2, idxs2)) => {
                 self.infer_subst_for_bb_env_bty(bb_env, params, bty1, bty2, subst);
-                for (idx1, idx2) in iter::zip(indices1, indices2) {
-                    subst.infer_from_exprs(params, &idx1.expr, &idx2.expr);
+                for (idx1, idx2) in iter::zip(idxs1.args(), idxs2.args()) {
+                    subst.infer_from_exprs(params, idx1, idx2);
                 }
             }
             (TyKind::Ptr(rk1, path1), TyKind::Ptr(rk2, path2)) => {
@@ -565,7 +565,7 @@ impl TypeEnvInfer {
             }
             (TyKind::Indexed(bty1, idxs1), TyKind::Indexed(bty2, idxs2)) => {
                 let bty = self.join_bty(bty1, bty2);
-                if self.scope.has_free_vars(idxs2) || !Index::exprs_eq(idxs1, idxs2) {
+                if self.scope.has_free_vars(idxs2) || idxs1.args() != idxs2.args() {
                     let pred = Binders::new(Pred::Hole, bty.sorts());
                     Ty::exists(bty, pred)
                 } else {
@@ -678,12 +678,12 @@ fn generalize(
                 let fresh = name_gen.fresh();
                 names.push(fresh);
                 sorts.push(sort.clone());
-                idxs.push(Expr::fvar(fresh).into());
+                idxs.push(Expr::fvar(fresh));
                 fresh
             });
             preds.push(pred);
 
-            Ty::indexed(bty, idxs)
+            Ty::indexed(bty, RefineArgs::multi(idxs))
         }
         TyKind::Ref(RefKind::Shr, ty) => {
             let ty = generalize(name_gen, ty, names, sorts, preds);

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -301,19 +301,13 @@ impl PathsTree {
                         adt.def_id(),
                         VariantIdx::from_u32(0),
                         substs,
-                        &idxs.to_exprs(),
+                        idxs.args(),
                     )?;
                     ty = fields[field.as_usize()].clone();
                 }
                 (Downcast(variant_idx), TyKind::Indexed(BaseTy::Adt(adt_def, substs), idxs)) => {
-                    let tys = downcast(
-                        genv,
-                        rcx,
-                        adt_def.def_id(),
-                        variant_idx,
-                        substs,
-                        &idxs.to_exprs(),
-                    )?;
+                    let tys =
+                        downcast(genv, rcx, adt_def.def_id(), variant_idx, substs, idxs.args())?;
                     ty = rcx.unpack_with(&Ty::tuple(tys), UnpackFlags::INVARIANTS);
                 }
                 _ => todo!("{elem:?} {ty:?}"),
@@ -501,7 +495,7 @@ impl Node {
                             adt_def.def_id(),
                             variant_idx,
                             substs,
-                            &idxs.to_exprs(),
+                            idxs.args(),
                         )?
                         .into_iter()
                         .map(|ty| {

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -763,7 +763,7 @@ fn downcast_enum(
     let constr = Expr::and(iter::zip(&variant_def.ret.indices, args).map(|(idx, arg)| {
         match arg {
             RefineArg::Expr(e) => Expr::eq(idx, e),
-            RefineArg::KVar(_) => todo!(),
+            RefineArg::Pred(_) => todo!(),
         }
     }));
     rcx.assume_pred(constr);

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -763,6 +763,7 @@ fn downcast_enum(
     let constr = Expr::and(iter::zip(&variant_def.ret.indices, args).map(|(idx, arg)| {
         match arg {
             RefineArg::Expr(e) => Expr::eq(idx, e),
+            RefineArg::KVar(_) => todo!(),
         }
     }));
     rcx.assume_pred(constr);

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -5,7 +5,8 @@ use flux_middle::{
     rty::{
         box_args,
         fold::{TypeFoldable, TypeFolder, TypeVisitor},
-        AdtDef, BaseTy, Expr, GenericArg, Loc, Path, RefKind, Sort, Substs, Ty, TyKind, VariantIdx,
+        AdtDef, BaseTy, Expr, GenericArg, Loc, Path, RefKind, RefineArg, Sort, Substs, Ty, TyKind,
+        VariantIdx,
     },
     rustc::mir::{Field, Place, PlaceElem},
 };
@@ -703,12 +704,12 @@ fn downcast(
     def_id: DefId,
     variant_idx: VariantIdx,
     substs: &[GenericArg],
-    exprs: &[Expr],
+    args: &[RefineArg],
 ) -> Result<Vec<Ty>, OpaqueStructErr> {
     if genv.tcx.adt_def(def_id).is_struct() {
-        downcast_struct(genv, def_id, variant_idx, substs, exprs)
+        downcast_struct(genv, def_id, variant_idx, substs, args)
     } else if genv.tcx.adt_def(def_id).is_enum() {
-        downcast_enum(genv, rcx, def_id, variant_idx, substs, exprs)
+        downcast_enum(genv, rcx, def_id, variant_idx, substs, args)
     } else {
         panic!("Downcast without struct or enum!")
     }
@@ -727,11 +728,11 @@ fn downcast_struct(
     def_id: DefId,
     variant_idx: VariantIdx,
     substs: &[GenericArg],
-    exprs: &[Expr],
+    args: &[RefineArg],
 ) -> Result<Vec<Ty>, OpaqueStructErr> {
     Ok(genv
         .variant(def_id, variant_idx)?
-        .replace_bound_vars(exprs)
+        .replace_bound_vars(args)
         .replace_generic_args(substs)
         .fields
         .to_vec())
@@ -751,16 +752,19 @@ fn downcast_enum(
     def_id: DefId,
     variant_idx: VariantIdx,
     substs: &[GenericArg],
-    exprs: &[Expr],
+    args: &[RefineArg],
 ) -> Result<Vec<Ty>, OpaqueStructErr> {
     let variant_def = genv
         .variant(def_id, variant_idx)?
         .replace_bvars_with_fresh_fvars(|sort| rcx.define_var(sort))
         .replace_generic_args(substs);
 
-    debug_assert_eq!(variant_def.ret.indices.len(), exprs.len());
-    let constr =
-        Expr::and(iter::zip(&variant_def.ret.indices, exprs).map(|(idx, e)| Expr::eq(idx, e)));
+    debug_assert_eq!(variant_def.ret.indices.len(), args.len());
+    let constr = Expr::and(iter::zip(&variant_def.ret.indices, args).map(|(idx, arg)| {
+        match arg {
+            RefineArg::Expr(e) => Expr::eq(idx, e),
+        }
+    }));
     rcx.assume_pred(constr);
 
     Ok(variant_def.fields.to_vec())

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -424,7 +424,7 @@ impl<'a> Wf<'a> {
                 if !is_top_level_conj && let fhir::Func::Var(var) = func {
                     return self.emit_err(errors::InvalidParamPos::new(var.source_info.0, env[var.name]));
                 }
-                args.into_iter()
+                args.iter()
                     .try_for_each_exhaust(|arg| self.check_param_uses(env, arg, false))
             }
             fhir::ExprKind::Var(name, _, span) => {

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -208,9 +208,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                     ));
                 }
                 self.check_base_ty(env, bty, allow_binder)?;
-                env.with_binders(binders, sorts, |env| {
-                    self.check_expr(env, pred, &fhir::Sort::Bool)
-                })
+                env.with_binders(binders, sorts, |env| self.check_pred(env, pred))
             }
             fhir::Ty::Ptr(loc) => self.check_loc(env, *loc),
             fhir::Ty::Ref(_, ty) => self.check_type(env, ty, allow_binder),
@@ -281,6 +279,12 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 }
             })
             .try_collect_exhaust()
+    }
+
+    fn check_pred(&self, env: &Env, pred: &fhir::Pred) -> Result<(), ErrorGuaranteed> {
+        match pred {
+            fhir::Pred::Expr(e) => self.check_expr(env, e, &fhir::Sort::Bool),
+        }
     }
 
     fn check_expr(

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -21,7 +21,7 @@ struct Env<'a> {
 }
 
 impl<'a> Env<'a> {
-    fn new(params: &'a [fhir::Param]) -> Env {
+    fn new(params: &'a [fhir::RefineParam]) -> Env {
         let sorts = params
             .iter()
             .map(|param| (param.name.name, &param.sort))

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -284,6 +284,11 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
     fn check_pred(&self, env: &Env, pred: &fhir::Pred) -> Result<(), ErrorGuaranteed> {
         match pred {
             fhir::Pred::Expr(e) => self.check_expr(env, e, &fhir::Sort::Bool),
+            fhir::Pred::And(preds) => {
+                preds
+                    .iter()
+                    .try_for_each_exhaust(|pred| self.check_pred(env, pred))
+            }
         }
     }
 
@@ -386,6 +391,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         }
     }
 
+    #[track_caller]
     fn emit_err<'b, R>(&'b self, err: impl IntoDiagnostic<'b>) -> Result<R, ErrorGuaranteed> {
         Err(self.sess.emit_err(err))
     }

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -182,7 +182,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                     .into_iter()
                     .try_collect_exhaust()
             }
-            fhir::Constraint::Pred(e) => self.check_expr(env, e, &fhir::Sort::Bool),
+            fhir::Constraint::Pred(pred) => self.check_pred(env, pred),
         }
     }
 


### PR DESCRIPTION
Going from the lowest level up the implementation required the following changes

At the fixpoint interface level I added function sorts.  A constraint containing a `Forall` with a binder to a function sort will be correctly treated as an uninterpreted function by fixpoint allowing to type check function with abstract refinement without any extra changes. Function sorts are propagated all the way up to the surface syntax.

In `rty`, I added a new variant for predicates `rty::Pred::App(Var, List<Expr>)`. When substituting bound variables we can now substitute by a `RefineArg::Expr(Expr)` or a `RefineArg::Pred(Binder<Pred>)`. Substituting by an `Expr` proceeds as normal. Substitution by a `Binnder<Pred>` can only be applied to an application in a `rty::Pred`. This restrict syntactically that kvars will only show up in a conjunction at the top level. When instantiating parameters in a function call we treat predicate parameters especially by generating a kvar.

In `fhir` expressions are modified to accept a variable in function position (in addition to uifs). `fhir` does not put any syntactic restriction to where application with a variable can appear, but checked in well-formedness, which guarantees that during `conv` 
application with a variable in function position will only appear in an `rty::pred::App`.

The surface adds support for parsing a list of explicit refinement parameters in function signatures.

There are still some unresolved questions and I'm sure I've missed some edge cases, in particular in the interaction with data types with abstract refinements.