### PR TITLE
Abstract refinements in data types

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -225,7 +225,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
     }
 
     fn expr_ctxt_with<'b>(&'b self, binders: &'b Binders) -> ExprCtxt<'b, 'tcx> {
-        ExprCtxt::new(self.tcx, self.sess, self.map, &binders)
+        ExprCtxt::new(self.tcx, self.sess, self.map, binders)
     }
 
     fn as_expr_ctxt(&self) -> ExprCtxt<'_, 'tcx> {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -400,7 +400,12 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             surface::RefineArg::Abs(params, body, span) => {
                 let binders = Binders::from_abs(self.sess, &params)?;
                 let body = self.expr_ctxt_with(&binders).desugar_expr(body)?;
-                Ok(vec![fhir::RefineArg::Abs(binders.into_params(), body, span)])
+                let params = binders
+                    .into_params()
+                    .into_iter()
+                    .map(|param| param.name.name)
+                    .collect_vec();
+                Ok(vec![fhir::RefineArg::Abs(params, body, span)])
             }
         }
     }

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -28,3 +28,7 @@ wf_invalid_param_in_func_pos =
         [true] abstract refinements are only allowed in a top-level conjunction
         *[false] parameters of sort `{$sort}` are not supported in this position
      }
+
+wf_unexpected_fun =
+    mismatched sorts
+    .label = expected `{$sort}`, found function

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -167,15 +167,18 @@ impl From<RefKind> for WeakKind {
 }
 
 pub struct Indices {
-    pub indices: Vec<Index>,
+    pub indices: Vec<RefineArg>,
     pub span: Span,
 }
 
-pub struct Index {
-    pub expr: Expr,
-    /// Whether this index was used as a binder in the surface syntax. Used as a hint for inferring
-    /// parameters at function calls.
-    pub is_binder: bool,
+pub enum RefineArg {
+    Expr {
+        expr: Expr,
+        /// Whether this index was used as a binder in the surface syntax. Used as a hint for inferring
+        /// parameters at function calls.
+        is_binder: bool,
+    },
+    Abs(Vec<RefineParam>, Expr),
 }
 
 pub enum BaseTy {
@@ -198,6 +201,7 @@ pub enum Sort {
     Loc,
     Tuple(List<Sort>),
     Func(FuncSort),
+    Infer,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -268,9 +272,9 @@ impl BaseTy {
 }
 
 impl<'a> IntoIterator for &'a Indices {
-    type Item = &'a Index;
+    type Item = &'a RefineArg;
 
-    type IntoIter = std::slice::Iter<'a, Index>;
+    type IntoIter = std::slice::Iter<'a, RefineArg>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.indices.iter()
@@ -329,6 +333,15 @@ impl Sort {
     /// Whether the sort is a function with return sort bool
     pub fn is_pred(&self) -> bool {
         matches!(self, Sort::Func(fsort) if fsort.output().is_bool())
+    }
+
+    #[track_caller]
+    pub fn as_func(&self) -> &FuncSort {
+        if let Sort::Func(sort) = self {
+            sort
+        } else {
+            panic!("expected `Sort::Func`")
+        }
     }
 }
 
@@ -442,7 +455,7 @@ impl Map {
         self.adts.insert(def_id, sort_info);
     }
 
-    pub fn sorts(&self, def_id: DefId) -> Option<&[Sort]> {
+    pub fn sorts_of(&self, def_id: DefId) -> Option<&[Sort]> {
         let info = self.adts.get(&def_id.as_local()?)?;
         Some(&info.sorts)
     }
@@ -574,12 +587,17 @@ impl fmt::Debug for Indices {
     }
 }
 
-impl fmt::Debug for Index {
+impl fmt::Debug for RefineArg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_binder {
-            write!(f, "@")?;
+        match self {
+            RefineArg::Expr { expr, is_binder } => {
+                if *is_binder {
+                    write!(f, "@")?;
+                }
+                write!(f, "{expr:?}")
+            }
+            RefineArg::Abs(params, body) => write!(f, "|{:?}| {body:?}", params.iter().format(",")),
         }
-        write!(f, "{:?}", self.expr)
     }
 }
 
@@ -645,6 +663,7 @@ impl fmt::Display for Sort {
             Sort::Loc => write!(f, "loc"),
             Sort::Func(sort) => write!(f, "{sort}"),
             Sort::Tuple(sorts) => write!(f, "({})", sorts.iter().join(", ")),
+            Sort::Infer => write!(f, "_"),
         }
     }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -178,7 +178,7 @@ pub enum RefineArg {
         /// inferring parameters at function calls.
         is_binder: bool,
     },
-    Abs(Vec<RefineParam>, Expr, Span),
+    Abs(Vec<Name>, Expr, Span),
 }
 
 pub enum BaseTy {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -174,11 +174,11 @@ pub struct Indices {
 pub enum RefineArg {
     Expr {
         expr: Expr,
-        /// Whether this index was used as a binder in the surface syntax. Used as a hint for inferring
-        /// parameters at function calls.
+        /// Whether this arg was used as a binder in the surface syntax. Used as a hint for
+        /// inferring parameters at function calls.
         is_binder: bool,
     },
-    Abs(Vec<RefineParam>, Expr),
+    Abs(Vec<RefineParam>, Expr, Span),
 }
 
 pub enum BaseTy {
@@ -253,12 +253,6 @@ pub struct Ident {
 newtype_index! {
     pub struct Name {
         DEBUG_FORMAT = "x{}",
-    }
-}
-
-impl UFun {
-    pub fn new(symbol: Symbol, span: Span) -> Self {
-        Self { symbol, span }
     }
 }
 
@@ -596,7 +590,9 @@ impl fmt::Debug for RefineArg {
                 }
                 write!(f, "{expr:?}")
             }
-            RefineArg::Abs(params, body) => write!(f, "|{:?}| {body:?}", params.iter().format(",")),
+            RefineArg::Abs(params, body, _) => {
+                write!(f, "|{:?}| {body:?}", params.iter().format(","))
+            }
         }
     }
 }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -303,7 +303,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 let fsort = sort.as_func();
                 let abs = self
                     .name_map
-                    .with_binders(&params, nbinders, |name_map, nbinders| {
+                    .with_binders(params, nbinders, |name_map, nbinders| {
                         let body = name_map.conv_expr(body, nbinders);
                         rty::Binders::new(rty::Pred::Expr(body), fsort.inputs())
                     });

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -301,10 +301,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             fhir::RefineArg::Abs(params, body, _) => {
                 let fsort = sort.as_func();
-                let names = params.iter().map(|param| param.name.name).collect_vec();
                 let abs = self
                     .name_map
-                    .with_binders(&names, nbinders, |name_map, nbinders| {
+                    .with_binders(&params, nbinders, |name_map, nbinders| {
                         let body = name_map.conv_expr(body, nbinders);
                         rty::Binders::new(rty::Pred::Expr(body), fsort.inputs())
                     });

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -122,13 +122,12 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     }
 
     fn conv_variant_ret(&mut self, ret: &fhir::VariantRet) -> VariantRet {
+        let bty = self.conv_base_ty(&ret.bty, 1);
         let args = List::from_iter(
-            ret.indices
-                .indices
-                .iter()
-                .map(|idx| rty::RefineArg::Expr(self.conv_expr(&idx.expr))),
+            iter::zip(&ret.indices.indices, bty.sorts())
+                .map(|(arg, sort)| self.conv_arg(arg, sort, 1)),
         );
-        VariantRet { bty: self.conv_base_ty(&ret.bty, 1), args }
+        VariantRet { bty, args }
     }
 
     pub(crate) fn conv_struct_def_variant(
@@ -225,10 +224,6 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         rty::Qualifier { name: qualifier.name.clone(), args, expr }
     }
 
-    fn conv_expr(&self, expr: &fhir::Expr) -> rty::Expr {
-        self.name_map.conv_expr(expr, 1)
-    }
-
     fn conv_ty(&mut self, ty: &fhir::Ty, nbinders: u32) -> rty::Ty {
         match ty {
             fhir::Ty::BaseTy(bty) => {
@@ -242,8 +237,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 }
             }
             fhir::Ty::Indexed(bty, idxs) => {
-                let idxs = self.conv_indices(idxs, nbinders);
-                rty::Ty::indexed(self.conv_base_ty(bty, nbinders), idxs)
+                let bty = self.conv_base_ty(bty, nbinders);
+                let idxs = self.conv_indices(idxs, bty.sorts(), nbinders);
+                rty::Ty::indexed(bty, idxs)
             }
             fhir::Ty::Exists(bty, binders, pred) => {
                 let bty = self.conv_base_ty(bty, nbinders);
@@ -281,10 +277,40 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         }
     }
 
-    fn conv_indices(&self, idxs: &fhir::Indices, nbinders: u32) -> rty::RefineArgs {
-        rty::RefineArgs::new(idxs.indices.iter().map(|idx| {
-            (rty::RefineArg::Expr(self.name_map.conv_expr(&idx.expr, nbinders)), idx.is_binder)
+    fn conv_indices(
+        &mut self,
+        idxs: &fhir::Indices,
+        sorts: &[fhir::Sort],
+        nbinders: u32,
+    ) -> rty::RefineArgs {
+        rty::RefineArgs::new(iter::zip(&idxs.indices, sorts).map(|(arg, sort)| {
+            let is_binder = matches!(arg, fhir::RefineArg::Expr { is_binder: true, .. });
+            (self.conv_arg(arg, sort, nbinders), is_binder)
         }))
+    }
+
+    fn conv_arg(
+        &mut self,
+        arg: &fhir::RefineArg,
+        sort: &fhir::Sort,
+        nbinders: u32,
+    ) -> rty::RefineArg {
+        match arg {
+            fhir::RefineArg::Expr { expr, .. } => {
+                rty::RefineArg::Expr(self.name_map.conv_expr(expr, nbinders))
+            }
+            fhir::RefineArg::Abs(params, body) => {
+                let fsort = sort.as_func();
+                let names = params.iter().map(|param| param.name.name).collect_vec();
+                let abs = self
+                    .name_map
+                    .with_binders(&names, nbinders, |name_map, nbinders| {
+                        let body = name_map.conv_expr(body, nbinders);
+                        rty::Binders::new(rty::Pred::Expr(body), fsort.inputs())
+                    });
+                rty::RefineArg::Abs(abs)
+            }
+        }
     }
 
     fn conv_ref_kind(rk: fhir::RefKind) -> rty::RefKind {
@@ -380,24 +406,6 @@ impl NameMap {
             .collect()
     }
 
-    // fn conv_pred(&self, pred: &fhir::Pred, nbinders: u32) -> rty::Pred {
-    //     match pred {
-    //         fhir::Pred::Expr(expr) => rty::Pred::Expr(self.conv_expr(expr, nbinders)),
-    //         fhir::Pred::And(preds) => {
-    //             let preds = preds.iter().map(|pred| self.conv_pred(pred, nbinders));
-    //             rty::Pred::And(List::from_iter(preds))
-    //         }
-    //         fhir::Pred::App(name, args) => {
-    //             let args = List::from_iter(args.iter().map(|expr| self.conv_expr(expr, nbinders)));
-    //             if let rty::ExprKind::BoundVar(bvar) = self.get(*name, nbinders).kind() {
-    //                 rty::Pred::App(rty::Var::Bound(*bvar), args)
-    //             } else {
-    //                 unreachable!()
-    //             }
-    //         }
-    //     }
-    // }
-
     fn conv_pred(&self, expr: &fhir::Expr, nbinders: u32) -> rty::Pred {
         fn go(this: &NameMap, expr: &fhir::Expr, nbinders: u32, preds: &mut Vec<rty::Pred>) {
             match &expr.kind {
@@ -410,7 +418,6 @@ impl NameMap {
                     let args = this.conv_exprs(args, nbinders);
                     preds.push(rty::Pred::App(func, args));
                 }
-                fhir::ExprKind::Const(_, _) => todo!(),
                 _ => {
                     preds.push(rty::Pred::Expr(this.conv_expr(expr, nbinders)));
                 }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -299,7 +299,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             fhir::RefineArg::Expr { expr, .. } => {
                 rty::RefineArg::Expr(self.name_map.conv_expr(expr, nbinders))
             }
-            fhir::RefineArg::Abs(params, body) => {
+            fhir::RefineArg::Abs(params, body, _) => {
                 let fsort = sort.as_func();
                 let names = params.iter().map(|param| param.name.name).collect_vec();
                 let abs = self

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -696,5 +696,5 @@ mod pretty {
         }
     }
 
-    impl_debug_with_default_cx!(ExprS, Loc, Path, BoundVar,);
+    impl_debug_with_default_cx!(ExprS, Loc, Path, BoundVar, Var);
 }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -35,6 +35,10 @@ pub trait TypeFolder: Sized {
     fn fold_pred(&mut self, pred: &Pred) -> Pred {
         pred.super_fold_with(self)
     }
+
+    fn fold_refine_arg(&mut self, arg: &RefineArg) -> RefineArg {
+        arg.super_fold_with(self)
+    }
 }
 
 pub trait TypeFoldable: Sized {
@@ -335,15 +339,19 @@ impl TypeFoldable for RefineArg {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self {
             RefineArg::Expr(e) => RefineArg::Expr(e.fold_with(folder)),
-            RefineArg::Pred(kvar) => RefineArg::Pred(kvar.fold_with(folder)),
+            RefineArg::Abs(abs) => RefineArg::Abs(abs.fold_with(folder)),
         }
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
         match self {
             RefineArg::Expr(e) => e.visit_with(visitor),
-            RefineArg::Pred(kvar) => kvar.visit_with(visitor),
+            RefineArg::Abs(kvar) => kvar.visit_with(visitor),
         }
+    }
+
+    fn fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
+        folder.fold_refine_arg(self)
     }
 }
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -171,7 +171,7 @@ pub enum RefineArg {
     /// @n, the span correspond to the span of @ plus the identifier
     Bind(Ident, Span),
     Expr(Expr),
-    Abs(Vec<Ident>, Expr),
+    Abs(Vec<Ident>, Expr, Span),
 }
 
 #[derive(Debug)]

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -180,9 +180,11 @@ Indices: surface::Indices = {
 };
 
 RefineArg: surface::RefineArg = {
-    <lo:@L> "@" <bind:Ident> <hi:@R> => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
-    <Level1>                         => surface::RefineArg::Expr(<>),
-    "|"<Comma<Ident>> "|" <Level1>   => surface::RefineArg::Abs(<>)
+    <lo:@L> "@" <bind:Ident> <hi:@R>               => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
+    <Level1>                                       => surface::RefineArg::Expr(<>),
+    <lo:@L> "|"<params: Comma<Ident>> "|" <body:Level1> <hi:@R> => {
+        surface::RefineArg::Abs(params, body, mk_span(lo, hi))
+    }
 };
 
 pub Expr = Level1;

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -129,8 +129,8 @@ ArgTyKind: surface::TyKind = {
 
     "(" <tys:Comma<Ty>> ")"  => surface::TyKind::Tuple(tys),
 
-    "&"        <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),
-    "&" "mut"  <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty)),
+    "&"       <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),
+    "&" "mut" <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty)),
 
     "{" <ty:Ty> ":" <pred:Level1> "}" => surface::TyKind::Constr(pred, Box::new(ty)),
 
@@ -176,12 +176,13 @@ Refinement: surface::Expr = {
 };
 
 Indices: surface::Indices = {
-    <lo:@L> <indices:Comma<Index>> <hi:@R> => surface::Indices { indices, span: mk_span(lo, hi) }
+    <lo:@L> <indices:Comma<RefineArg>> <hi:@R> => surface::Indices { indices, span: mk_span(lo, hi) }
 };
 
-Index: surface::Index = {
-    <lo:@L> "@" <bind:Ident> <hi:@R> => surface::Index::Bind(bind, mk_span(lo, hi)),
-    <Level1>                         => surface::Index::Expr(<>),
+RefineArg: surface::RefineArg = {
+    <lo:@L> "@" <bind:Ident> <hi:@R> => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
+    <Level1>                         => surface::RefineArg::Expr(<>),
+    "|"<Comma<Ident>> "|" <Level1>   => surface::RefineArg::Abs(<>)
 };
 
 pub Expr = Level1;

--- a/flux-tests/tests/neg/abstract_refinements/test01.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test01.rs
@@ -23,3 +23,8 @@ fn test01() {
 fn test02(x: i32, pair: Pair) -> i32 {
     pair.fst //~ ERROR postcondition
 }
+
+fn test03() {
+    let pair = Pair { fst: 0, snd: 0 };
+    test02(10, pair); //~ ERROR precondition
+}

--- a/flux-tests/tests/neg/abstract_refinements/test01.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test01.rs
@@ -1,0 +1,20 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int, b: int, p: (int, int) -> bool)]
+struct Pair {
+    #[flux::field(i32[@a])]
+    fst: i32,
+    #[flux::field({i32[@b] : p(a, b)})]
+    snd: i32,
+}
+
+#[flux::sig(fn(Pair[@a, @b, |a, b| a <= b]) -> i32{v: v > 0})]
+fn test00(pair: Pair) -> i32 {
+    pair.snd - pair.fst //~ ERROR postcondition
+}
+
+fn test01() {
+    let pair = Pair { fst: 1, snd: 0 };
+    let x = test00(pair); //~ ERROR precondition
+}

--- a/flux-tests/tests/neg/abstract_refinements/test01.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test01.rs
@@ -18,3 +18,8 @@ fn test01() {
     let pair = Pair { fst: 1, snd: 0 };
     let x = test00(pair); //~ ERROR precondition
 }
+
+#[flux::sig(fn(x: i32, Pair[@a, @b, |a, b| a >= x]) -> i32{v: v > x})]
+fn test02(x: i32, pair: Pair) -> i32 {
+    pair.fst //~ ERROR postcondition
+}

--- a/flux-tests/tests/neg/error_messages/abstract_refinements.rs
+++ b/flux-tests/tests/neg/error_messages/abstract_refinements.rs
@@ -17,3 +17,15 @@ fn test00(x: i32) -> i32 {
 fn test01(x: i32) -> i32 {
     0
 }
+
+#[flux::sig(fn(i32[|a| a > 0]))] //~ ERROR mismatched sorts
+fn test02(x: i32) {}
+
+#[flux::refined_by(p: int -> bool)]
+struct S {}
+
+#[flux::sig(fn(S[|a| a + 1]))] //~ ERROR mismatched sorts
+fn test03(x: S) {}
+
+#[flux::sig(fn(S[|a| a]))] //~ ERROR mismatched sorts
+fn test04(x: S) {}

--- a/flux-tests/tests/pos/abstract_refinements/test01.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test01.rs
@@ -23,3 +23,8 @@ fn test02() {
     let pair = Pair { fst: 0, snd: 1 };
     let x = test01(pair);
 }
+
+#[flux::sig(fn(x: i32, Pair[@a, @b, |a, b| a > x]) -> i32{v: v > x})]
+fn test03(x: i32, pair: Pair) -> i32 {
+    pair.fst
+}

--- a/flux-tests/tests/pos/abstract_refinements/test01.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test01.rs
@@ -1,0 +1,25 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int, b: int, p: (int, int) -> bool)]
+struct Pair {
+    #[flux::field(i32[@a])]
+    fst: i32,
+    #[flux::field({i32[@b] : p(a, b)})]
+    snd: i32,
+}
+
+#[flux::sig(fn() -> Pair)]
+fn test00() -> Pair {
+    Pair { fst: 0, snd: 1 }
+}
+
+#[flux::sig(fn(Pair[@a, @b, |a, b| a < b]) -> i32{v: v > 0})]
+fn test01(pair: Pair) -> i32 {
+    pair.snd - pair.fst
+}
+
+fn test02() {
+    let pair = Pair { fst: 0, snd: 1 };
+    let x = test01(pair);
+}

--- a/flux-tests/tests/pos/abstract_refinements/test01.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test01.rs
@@ -28,3 +28,8 @@ fn test02() {
 fn test03(x: i32, pair: Pair) -> i32 {
     pair.fst
 }
+
+fn test04() {
+    let pair = Pair { fst: 10, snd: 0 };
+    test03(0, pair);
+}

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -220,7 +220,6 @@ fn subtyping(genv: &GlobalEnv, constr: &mut ConstrBuilder, ty1: &Ty, ty2: &Ty, t
 
     match (ty1.kind(), ty2.kind()) {
         (TyKind::Indexed(bty1, idxs1), TyKind::Indexed(bty2, idx2)) => {
-            println!("{ty1:?} <: {ty2:?}");
             bty_subtyping(genv, constr, bty1, bty2, tag);
             for (arg1, arg2) in iter::zip(idxs1.args(), idx2.args()) {
                 arg_subtyping(constr, arg1, arg2, tag);

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -413,7 +413,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
             }
         }
         rty::Sort::Func(sort) => fixpoint::Sort::Func(func_sort_to_fixpoint(sort)),
-        rty::Sort::Loc => unreachable!("unexpected sort {sort:?}"),
+        rty::Sort::Infer | rty::Sort::Loc => unreachable!("unexpected sort {sort:?}"),
     }
 }
 

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -68,7 +68,7 @@ fn collect<T>(
         .enumerate()
         .map(|(idx, sort)| {
             if let Sort::Func(fsort) = sort && fsort.output().is_bool() {
-                Ok(RefineArg::Pred(fresh_kvar(fsort.inputs())))
+                Ok(RefineArg::Abs(fresh_kvar(fsort.inputs())))
             } else {
                 let e = exprs
                     .remove(&idx)

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -278,6 +278,10 @@ impl ConstrBuilder<'_> {
         ConstrBuilder { tree: self.tree, ptr: NodePtr::clone(&self.ptr) }
     }
 
+    pub fn define_vars(&mut self, sorts: &[Sort]) -> Vec<Name> {
+        self.ptr.push_foralls(sorts)
+    }
+
     pub fn push_guard(&mut self, p: impl Into<Pred>) {
         self.ptr.push_guard(p.into());
     }
@@ -291,6 +295,12 @@ impl ConstrBuilder<'_> {
         if !pred.is_trivially_true() {
             self.ptr.push_node(NodeKind::Head(pred, tag));
         }
+    }
+
+    pub fn push_horn_clause(&mut self, body: impl Into<Pred>, head: impl Into<Pred>, tag: Tag) {
+        let mut constr = self.breadcrumb();
+        constr.push_guard(body);
+        constr.push_head(head, tag);
     }
 }
 

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -270,7 +270,7 @@ impl<'a> Wf<'a> {
             }
             fhir::RefineArg::Abs(params, body, span) => {
                 if let fhir::Sort::Func(fsort) = expected {
-                    env.with_binders(&params, fsort.inputs(), |env| {
+                    env.with_binders(params, fsort.inputs(), |env| {
                         self.check_expr(env, body, fsort.output())
                     })
                 } else {

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -6,7 +6,7 @@ use std::{borrow::Borrow, iter};
 use flux_common::iter::IterExt;
 use flux_errors::FluxSession;
 use flux_middle::fhir;
-use itertools::{izip, Itertools};
+use itertools::izip;
 use rustc_errors::{ErrorGuaranteed, IntoDiagnostic};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_span::Span;
@@ -270,8 +270,7 @@ impl<'a> Wf<'a> {
             }
             fhir::RefineArg::Abs(params, body, span) => {
                 if let fhir::Sort::Func(fsort) = expected {
-                    let binders = params.iter().map(|param| param.name.name).collect_vec();
-                    env.with_binders(&binders, fsort.inputs(), |env| {
+                    env.with_binders(&params, fsort.inputs(), |env| {
                         self.check_expr(env, body, fsort.output())
                     })
                 } else {


### PR DESCRIPTION
This mostly just adds syntax for _predicate abstractions_ (as in `|a| a > 0`) to be used as refinement arguments. Most of the machinery to support abstract refinements in data types was implemented in the previous pr.
