### PR TITLE
Allow binders for non-alias types

### DIFF
--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -295,7 +295,7 @@ fn build_fhir_map(
                 map.add_assumed(def_id);
             }
             if let Some(fn_sig) = spec.fn_sig {
-                let fn_sig = surface::expand::expand_sig(sess, &aliases, fn_sig)?;
+                let fn_sig = surface::expand::expand_sig(&aliases, fn_sig)?;
                 let fn_sig = desugar::desugar_fn_sig(tcx, sess, &map, def_id, fn_sig)?;
                 map.insert_fn_sig(def_id, fn_sig);
             }

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -3,7 +3,7 @@ wf_sort_mismatch =
     .label = expected `{$expected}`, found `{$found}`
 
 wf_param_count_mismatch =
-    this type takes {$expected} refinement parameters but {$found ->
+    this {$thing} takes {$expected} refinement parameters but {$found ->
         [one] {$found} was found
         *[other] {$found} were found
     }

--- a/flux-tests/tests/neg/error_messages/bad_alias00.rs
+++ b/flux-tests/tests/neg/error_messages/bad_alias00.rs
@@ -9,7 +9,7 @@ fn foo(x: i32, y: i32) -> i32 {
     x + y
 }
 
-#[flux::sig(fn(a:i32[foo(10, 20)]))] //~ ERROR invalid alias
+#[flux::sig(fn(i32[foo(10,20,30)]))] //~ ERROR this function
 fn bar(a: i32) {
     return;
 }

--- a/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
@@ -4,12 +4,12 @@
 #![flux::uf(fn foo(int, int) -> int)]
 
 #[flux::assume]
-#[flux::sig(fn(x: i32, y:i32) -> i32[foo(x)])] //~ ERROR this type takes 2 refinement parameters but 1 was found
+#[flux::sig(fn(x: i32, y:i32) -> i32[foo(x)])] //~ ERROR this function takes 2 refinement parameters but 1 was found
 pub fn foo(x: i32, y: i32) -> i32 {
     x + y
 }
 
-#[flux::sig(fn (i32[foo(10, 20, 30)]) -> i32)] //~ ERROR this type takes 2 refinement parameters but 3 were found
+#[flux::sig(fn (i32[foo(10, 20, 30)]) -> i32)] //~ ERROR this function takes 2 refinement parameters but 3 were found
 pub fn bar(a: i32) -> i32 {
     return a;
 }

--- a/flux-tests/tests/pos/surface/issue-231.rs
+++ b/flux-tests/tests/pos/surface/issue-231.rs
@@ -2,9 +2,8 @@
 #![register_tool(flux)]
 
 #[flux::sig(fn(b:bool[true]))]
-fn assert(_: bool) {}
+pub fn assert(_: bool) {}
 
-// We should not check the body of the function
-fn foo() {
+pub fn foo() {
     assert(0 < 1);
 }

--- a/flux-tests/tests/pos/surface/issue-231.rs
+++ b/flux-tests/tests/pos/surface/issue-231.rs
@@ -1,0 +1,10 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(b:bool[true]))]
+fn assert(_: bool) {}
+
+// We should not check the body of the function
+fn foo() {
+    assert(0 < 1);
+}

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -198,6 +198,7 @@ impl<'a> Wf<'a> {
                 if binders.len() != sorts.len() {
                     return self.emit_err(errors::ParamCountMismatch::new(
                         None,
+                        String::from("type"),
                         sorts.len(),
                         binders.len(),
                     ));
@@ -246,6 +247,7 @@ impl<'a> Wf<'a> {
         if expected.len() != indices.indices.len() {
             return self.emit_err(errors::ParamCountMismatch::new(
                 Some(indices.span),
+                String::from("type"),
                 expected.len(),
                 indices.indices.len(),
             ));
@@ -386,6 +388,7 @@ impl<'a> Wf<'a> {
         if args.len() != fsort.inputs().len() {
             return self.emit_err(errors::ParamCountMismatch::new(
                 Some(span),
+                String::from("function"),
                 fsort.inputs().len(),
                 args.len(),
             ));
@@ -496,11 +499,17 @@ mod errors {
         span: Option<Span>,
         expected: usize,
         found: usize,
+        thing: String,
     }
 
     impl ParamCountMismatch {
-        pub(super) fn new(span: Option<Span>, expected: usize, found: usize) -> Self {
-            Self { span, expected, found }
+        pub(super) fn new(
+            span: Option<Span>,
+            thing: String,
+            expected: usize,
+            found: usize,
+        ) -> Self {
+            Self { span, expected, found, thing }
         }
     }
 


### PR DESCRIPTION
fixes #231 -- in particular allows signatures like

```rust
fn(b:bool[true])
```