### PR TITLE
Change qualifier syntax to use curly braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ![Flux](logo.png)
 
-`flux` is a refinement type checker for Rust. 
+`flux` is a refinement type checker for Rust.
 
 See the [blog](https://liquid-rust.github.io/) for details on refinement types and rust.
 
@@ -65,7 +65,7 @@ not yet supported.
 To run `flux` on code outside the repo, use script in `tools/flux.sh`
 
 - copy it to some place on your `$PATH`
-- edit the variable `FLUX` to point to the root of your local `flux` repo. 
+- edit the variable `FLUX` to point to the root of your local `flux` repo.
 
 
 ### A tiny example
@@ -133,10 +133,10 @@ This is a prototype! Use at your own risk. Everything could break and it will br
 
 ## Rust-Analyzer in VSCode
 
-Add this to the workspace settings i.e. `.vscode/settings.json` using in the appropriate paths for 
+Add this to the workspace settings i.e. `.vscode/settings.json` using in the appropriate paths for
 
 * `DYLD_FALLBACK_LIBRARY_PATH` (on `macos`) or `LD_LIBRARY_PATH` (on `linux`)
-* `RUSTC_WRAPPER` 
+* `RUSTC_WRAPPER`
 * `RUSTUP_TOOLCHAIN` (should be the same as the contents of `/path/to/flux/rust-toolchain.toml`)
 
 ```json
@@ -151,7 +151,7 @@ Add this to the workspace settings i.e. `.vscode/settings.json` using in the app
 
 ## Cargo Wrapper
 
-If the plugin doesn't work it is useful to write a small shell script e.g. `cargo-flux` 
+If the plugin doesn't work it is useful to write a small shell script e.g. `cargo-flux`
 that simulates how `vscode` invokes `flux` via `rust-analyzer`
 
 ```bash

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -309,7 +309,7 @@ pub mod expand {
         AliasMap, Arg, BinOp, Expr, ExprKind, FnSig, Indices, Path, RefineArg, Ty, TyKind,
     };
 
-    /// `expand_bare_sig(aliases, b_sig)` replaces all the alias-applications in `b_sig`
+    /// `expand_sig(aliases, sig)` replaces all the alias-applications in `sig`
     /// with the corresponding type definitions from `aliases` (if any).
     pub fn expand_sig(aliases: &AliasMap, fn_sig: FnSig) -> Result<FnSig, ErrorGuaranteed> {
         Ok(FnSig {

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -45,8 +45,9 @@ pub Qualifier: surface::Qualifier = {
     <lo:@L>
     <name:Ident>
     "(" <args:Comma<RefineParam>> ")"
-    ":"
+    "{"
     <expr:Level1>
+    "}"
     <hi:@R> => {
         surface::Qualifier { name: name, args: args, expr: expr, span: mk_span(lo, hi) }
     }

--- a/flux-tests/tests/neg/error_messages/badqual00.rs
+++ b/flux-tests/tests/neg/error_messages/badqual00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 // Test definition and checking of const and qualifiers
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ1(x: int, a: int) : x == a + FORTY_TOO)] //~ ERROR cannot find
+#![flux::qualifier(MyQ1(x: int, a: int) { x == a + FORTY_TOO })] //~ ERROR cannot find
 
 #[flux::constant]
 const FORTY_TWO: usize = 21 + 21;

--- a/flux-tests/tests/neg/error_messages/const00.rs
+++ b/flux-tests/tests/neg/error_messages/const00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 // Test definition and checking of const and qualifiers
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ1(x: int, a: int): x == a + FORTY_TOO)] //~ ERROR cannot find
+#![flux::qualifier(MyQ1(x: int, a: int) { x == a + FORTY_TOO })] //~ ERROR cannot find
 
 #[flux::constant]
 const FORTY_TWO: usize = 21 + 21;

--- a/flux-tests/tests/neg/error_messages/ill-formed-qualifier00.rs
+++ b/flux-tests/tests/neg/error_messages/ill-formed-qualifier00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ(x: int): x == a)] //~ ERROR cannot find value `a` in this scope
+#![flux::qualifier(MyQ(x: int) { x == a })] //~ ERROR cannot find value `a` in this scope
 
 #[flux::sig(fn(i32[@n]) -> i32[n])]
 pub fn dummy(x: i32) -> i32 {

--- a/flux-tests/tests/neg/error_messages/ill-formed-qualifier01.rs
+++ b/flux-tests/tests/neg/error_messages/ill-formed-qualifier01.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ(x: int): x + 1)] //~ ERROR mismatched sorts
+#![flux::qualifier(MyQ(x: int) { x + 1 })] //~ ERROR mismatched sorts
 
 #[flux::sig(fn(i32[@n]) -> i32[n])]
 pub fn dummy(x: i32) -> i32 {

--- a/flux-tests/tests/pos/user_qualifiers/const00.rs
+++ b/flux-tests/tests/pos/user_qualifiers/const00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 // Test definition and checking of const and qualifiers
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ1(x: int, a: int) : x == a + FORTY_TWO)]
+#![flux::qualifier(MyQ1(x: int, a: int) { x == a + FORTY_TWO })]
 
 #[flux::constant]
 const FORTY_TWO: usize = 21 + 21;

--- a/flux-tests/tests/pos/user_qualifiers/well_formed.rs
+++ b/flux-tests/tests/pos/user_qualifiers/well_formed.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::qualifier(MyQ1(x: int, a: int): x == a)]
-#![flux::qualifier(MyQ2(x: int): x > 1)]
+#![flux::qualifier(MyQ1(x: int, a: int) { x == a })]
+#![flux::qualifier(MyQ2(x: int) { x > 1 })]
 
 #[flux::sig(fn(i32[@n]) -> i32[n])]
 pub fn dummy(x: i32) -> i32 {


### PR DESCRIPTION
Seems more in the spirit of `rust`. So 

```rust
#![flux::qualifier(MyQ(x: int) : x + 1 )]
```

becomes 

```rust
#![flux::qualifier(MyQ(x: int) { x + 1 })]
```