### PR TITLE
Track some control flow information for catchall patterns

### DIFF
--- a/flux-tests/tests/neg/enums/issue-234.rs
+++ b/flux-tests/tests/neg/enums/issue-234.rs
@@ -1,0 +1,60 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(len: int)]
+pub enum List {
+    #[flux::variant(List[0])]
+    Nil,
+    #[flux::variant((i32, Box<List[@n]>) -> List[n+1])]
+    Cons(i32, Box<List>),
+}
+
+impl List {
+    #[flux::sig(fn(&List[@n]) -> usize[n])]
+    fn len_const_memory(&self) -> usize {
+        let mut len = 1;
+        let mut cur = self;
+        while let List::Cons(_, tl) = cur {
+            len += 1;
+            cur = tl;
+        }
+        len //~ ERROR postcondition
+    }
+}
+
+#[flux::refined_by(x: int)]
+pub enum Thing {
+    #[flux::variant(Thing[1])]
+    One,
+    #[flux::variant(Thing[2])]
+    Two,
+    #[flux::variant(Thing[3])]
+    Three,
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test1(l: &Thing) -> i32 {
+    match l {
+        Thing::Two => 2,
+        Thing::Three => 3,
+        _ => 42, //~ ERROR postcondition
+    }
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test2(l: &Thing) -> i32 {
+    match l {
+        Thing::One => 1,
+        Thing::Three => 3,
+        _ => 42, //~ ERROR postcondition
+    }
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test3(l: &Thing) -> i32 {
+    match l {
+        Thing::One => 1,
+        Thing::Two => 2,
+        _ => 42, //~ ERROR postcondition
+    }
+}

--- a/flux-tests/tests/pos/enums/issue-234.rs
+++ b/flux-tests/tests/pos/enums/issue-234.rs
@@ -1,0 +1,60 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::refined_by(len: int)]
+pub enum List {
+    #[flux::variant(List[0])]
+    Nil,
+    #[flux::variant((i32, Box<List[@n]>) -> List[n+1])]
+    Cons(i32, Box<List>),
+}
+
+impl List {
+    #[flux::sig(fn(&List[@n]) -> usize[n])]
+    fn len_const_memory(&self) -> usize {
+        let mut len = 0;
+        let mut cur = self;
+        while let List::Cons(_, tl) = cur {
+            len += 1;
+            cur = tl;
+        }
+        len
+    }
+}
+
+#[flux::refined_by(x: int)]
+pub enum Thing {
+    #[flux::variant(Thing[1])]
+    One,
+    #[flux::variant(Thing[2])]
+    Two,
+    #[flux::variant(Thing[3])]
+    Three,
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test1(l: &Thing) -> i32 {
+    match l {
+        Thing::Two => 2,
+        Thing::Three => 3,
+        _ => 1,
+    }
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test2(l: &Thing) -> i32 {
+    match l {
+        Thing::One => 1,
+        Thing::Three => 3,
+        _ => 2,
+    }
+}
+
+#[flux::sig(fn(&Thing[@x]) -> i32[x])]
+pub fn test3(l: &Thing) -> i32 {
+    match l {
+        Thing::One => 1,
+        Thing::Two => 2,
+        _ => 3,
+    }
+}

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -729,7 +729,7 @@ fn downcast(
     if genv.tcx.adt_def(def_id).is_struct() {
         downcast_struct(genv, def_id, variant_idx, substs, args)
     } else if genv.tcx.adt_def(def_id).is_enum() {
-        downcast_enum(genv, rcx, def_id, variant_idx, substs, args)
+        Ok(downcast_enum(genv, rcx, def_id, variant_idx, substs, args))
     } else {
         panic!("Downcast without struct or enum!")
     }
@@ -773,9 +773,10 @@ fn downcast_enum(
     variant_idx: VariantIdx,
     substs: &[GenericArg],
     args: &[RefineArg],
-) -> Result<Vec<Ty>, OpaqueStructErr> {
+) -> Vec<Ty> {
     let variant_def = genv
-        .variant(def_id, variant_idx)?
+        .variant(def_id, variant_idx)
+        .unwrap()
         .replace_bvars_with_fresh_fvars(|sort| rcx.define_var(sort))
         .replace_generic_args(substs);
 
@@ -789,7 +790,7 @@ fn downcast_enum(
     }));
     rcx.assume_pred(constr);
 
-    Ok(variant_def.fields.to_vec())
+    variant_def.fields.to_vec()
 }
 
 mod pretty {


### PR DESCRIPTION
Track control flow information in the _otherwise_ case when this can only refer to a single variant.

ping https://github.com/liquid-rust/flux/issues/234