### PR TITLE
No span in rty

### DIFF
--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -80,7 +80,7 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
     let map = build_fhir_map(tcx, sess, &mut specs)?;
     check_wf(sess, &map)?;
 
-    let mut genv = GlobalEnv::new(tcx, sess, map);
+    let mut genv = GlobalEnv::new(tcx, sess, map)?;
     // Assert behavior from Crate config
     // TODO(atgeller) rest of settings from crate config
     if let Some(crate_config) = specs.crate_config {

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, collections::hash_map};
 
 use flux_common::config::{AssertBehavior, CONFIG};
-use flux_errors::FluxSession;
+use flux_errors::{ErrorGuaranteed, FluxSession};
 use itertools::Itertools;
 use rustc_errors::FatalError;
 use rustc_hash::FxHashMap;
@@ -10,6 +10,7 @@ use rustc_middle::ty::TyCtxt;
 pub use rustc_middle::ty::Variance;
 pub use rustc_span::{symbol::Ident, Symbol};
 
+use self::errors::DefinitionCycle;
 pub use crate::rustc::lowering::UnsupportedFnSig;
 use crate::{
     fhir::{self, VariantIdx},
@@ -34,7 +35,11 @@ pub struct GlobalEnv<'genv, 'tcx> {
 }
 
 impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, sess: &'genv FluxSession, map: fhir::Map) -> Self {
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        sess: &'genv FluxSession,
+        map: fhir::Map,
+    ) -> Result<Self, ErrorGuaranteed> {
         let check_asserts = CONFIG.check_asserts;
 
         let mut defns: FxHashMap<Symbol, rty::Defn> = FxHashMap::default();
@@ -42,10 +47,10 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             let defn = rty::conv::conv_defn(defn);
             defns.insert(defn.name, defn);
         }
-        let defns = match Defns::new(defns) {
-            Ok(defns) => defns,
-            Err(_) => panic!("cyclic defns"), // TODO: fix with proper emit_err (funny missing ftl problem)
-        };
+        let defns = Defns::new(defns).map_err(|cycle| {
+            let span = map.defn(cycle[0]).unwrap().expr.span;
+            sess.emit_err(DefinitionCycle::new(span, cycle))
+        })?;
 
         let mut adt_defs = FxHashMap::default();
         for adt_def in map.adts() {
@@ -74,7 +79,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         genv.register_enum_def_variants();
         genv.register_fn_sigs();
 
-        genv
+        Ok(genv)
     }
 
     fn register_struct_def_variants(&mut self) {
@@ -315,6 +320,28 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         match ty {
             rustc::ty::GenericArg::Ty(ty) => rty::GenericArg::Ty(self.refine_ty(ty, mk_pred)),
             rustc::ty::GenericArg::Lifetime(_) => rty::GenericArg::Lifetime,
+        }
+    }
+}
+
+mod errors {
+    use flux_macros::Diagnostic;
+    use rustc_span::{Span, Symbol};
+
+    #[derive(Diagnostic)]
+    #[diag(expand::definition_cycle, code = "FLUX")]
+    pub struct DefinitionCycle {
+        #[primary_span]
+        #[label]
+        span: Span,
+        msg: String,
+    }
+
+    impl DefinitionCycle {
+        pub(super) fn new(span: Span, cycle: Vec<Symbol>) -> Self {
+            // let msg = format!("{} -> {}", cycle.join(" -> "), cycle[0]);
+            let msg = format!("{:?}", cycle);
+            Self { span, msg }
         }
     }
 }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -63,7 +63,7 @@ pub(crate) fn conv_defn(defn: &fhir::Defn) -> rty::Defn {
     let mut name_map = NameMap::default();
     let sorts = name_map.conv_refined_by(&defn.args);
     let expr = Binders::new(name_map.conv_expr(&defn.expr, 1), sorts);
-    rty::Defn { name: defn.name, expr, span: defn.expr.span }
+    rty::Defn { name: defn.name, expr }
 }
 
 impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -1075,7 +1075,8 @@ impl Defns {
                 let cycle = scc.pop().unwrap();
                 let cycle: Vec<Symbol> = cycle.iter().map(|i| i2s[*i]).collect();
                 if 1 + 1 < 0 {
-                    // 'failed to find fluent bundle'
+                    // TODO: failed to find message in primary or fallback fluent bundles
+                    // flux --crate-type=rlib flux-tests/tests/todo/dfn_cycle.rs
                     Err(cycle)
                 } else {
                     panic!("DefinitionCycle at {:?}", cycle);


### PR DESCRIPTION
Cleanup from #238 -- in particular remove the `Span` from `rty::Defn` and use `Map` instead.

Sadly, I still can't get the fluent-bundle thing to work :-( 

To reproduce:

1. Toggle the `1 + 1 < 0` in `sorted_defns` and
2. Run `flux --crate-type=rlib flux-tests/tests/todo/dfn_cycle.rs` 