### PR TITLE
RVec Macro

### DIFF
--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -1,14 +1,13 @@
 #![allow(dead_code)]
-#![allow(unused_mut)]
 
 #[macro_export]
 macro_rules! rvec {
-    () => { RVec::new() };
-    ($($e:expr),+) => {
-       { let mut res = RVec::new();
-         $( res.push($e); )*
-         res }
-    }
+    ($($e:expr),*$(,)?) => {{
+        #[allow(unused_mut)]
+        let mut res = RVec::new();
+        $( res.push($e); )*
+        res
+    }}
 }
 
 #[flux::opaque]

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -2,12 +2,11 @@
 
 #[macro_export]
 macro_rules! rvec {
-    ($($e:expr),+) => {
+    ($($e:expr),*) => {
        { let mut res = RVec::new();
-         $( res.push($e); )+
+         $( res.push($e); )*
          res }
     }
-
 }
 
 #[flux::opaque]

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -1,5 +1,15 @@
 #![allow(dead_code)]
 
+#[macro_export]
+macro_rules! rvec {
+    ($($e:expr),+) => {
+       { let mut res = RVec::new();
+         $( res.push($e); )+
+         res }
+    }
+
+}
+
 #[flux::opaque]
 #[flux::refined_by(len: int)]
 pub struct RVec<T> {

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -2,8 +2,8 @@
 
 #[macro_export]
 macro_rules! rvec {
-    ($($e:expr),*$(,)?) => {{
-        #[allow(unused_mut)]
+    () => { RVec::new() };
+    ($($e:expr),+$(,)?) => {{
         let mut res = RVec::new();
         $( res.push($e); )*
         res

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -3,7 +3,8 @@
 
 #[macro_export]
 macro_rules! rvec {
-    ($($e:expr),*) => {
+    () => { RVec::new() };
+    ($($e:expr),+) => {
        { let mut res = RVec::new();
          $( res.push($e); )*
          res }

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(unused_mut)]
 
 #[macro_export]
 macro_rules! rvec {

--- a/flux-tests/tests/neg/surface/rvec00.rs
+++ b/flux-tests/tests/neg/surface/rvec00.rs
@@ -7,7 +7,6 @@ use rvec::RVec;
 
 #[flux::sig(fn() -> RVec<i32>[0])]
 pub fn vec_empty() -> RVec<i32> {
-    #[allow(unused_mut)]
     let mv = rvec![];
     mv
 }

--- a/flux-tests/tests/neg/surface/rvec00.rs
+++ b/flux-tests/tests/neg/surface/rvec00.rs
@@ -5,6 +5,13 @@
 mod rvec;
 use rvec::RVec;
 
+#[flux::sig(fn() -> RVec<i32>[1])]
+pub fn vec_empty() -> RVec<i32> {
+    let mut mv = rvec![];
+    mv.push(1);
+    mv
+}
+
 pub fn vec_push() -> usize {
     let v = rvec![0, 1];
     let r = v[0];

--- a/flux-tests/tests/neg/surface/rvec00.rs
+++ b/flux-tests/tests/neg/surface/rvec00.rs
@@ -1,0 +1,14 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+use rvec::RVec;
+
+pub fn vec_push() -> usize {
+    let v = rvec![0, 1];
+    let r = v[0];
+    let r = r + v[1];
+    let r = r + v[2]; //~ ERROR precondition might not hold
+    r
+}

--- a/flux-tests/tests/neg/surface/rvec00.rs
+++ b/flux-tests/tests/neg/surface/rvec00.rs
@@ -5,10 +5,10 @@
 mod rvec;
 use rvec::RVec;
 
-#[flux::sig(fn() -> RVec<i32>[1])]
+#[flux::sig(fn() -> RVec<i32>[0])]
 pub fn vec_empty() -> RVec<i32> {
-    let mut mv = rvec![];
-    mv.push(1);
+    #[allow(unused_mut)]
+    let mv = rvec![];
     mv
 }
 


### PR DESCRIPTION
A small macro to create `rvec` literals (without the tedious `push`-ing)"

```rust
pub fn vec_push() -> usize {
    let v = rvec![0, 1];
    let r = v[0];
    let r = r + v[1];
    let r = r + v[2]; //~ ERROR precondition might not hold
    r
}
```