### PR TITLE
Skip annot check for opaque structs

### DIFF
--- a/flux-desugar/src/annot_check.rs
+++ b/flux-desugar/src/annot_check.rs
@@ -19,6 +19,10 @@ pub fn check_struct_def(
     struct_def: &StructDef<Res>,
 ) -> Result<(), ErrorGuaranteed> {
     let def_id = struct_def.def_id.to_def_id();
+    // Opaque struct can't have field annotations so skip them
+    if struct_def.opaque {
+        return Ok(());
+    }
     let rust_adt_def = lowering::lower_adt_def(tcx, sess, tcx.adt_def(def_id))?;
     let rust_variant_def = &rust_adt_def.variants[0];
     iter::zip(&struct_def.fields, rust_variant_def.fields()).try_for_each_exhaust(

--- a/flux-driver/src/lib.rs
+++ b/flux-driver/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private, box_patterns, once_cell)]
+#![feature(rustc_private, box_patterns, once_cell, let_chains)]
 
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;

--- a/flux-errors/locales/en-US/parse.ftl
+++ b/flux-errors/locales/en-US/parse.ftl
@@ -15,3 +15,7 @@ parse_invalid_constant =
 
 parse_invalid_alias_application =
     invalid alias application
+
+parse_attr_on_opaque =
+    opaque struct can't have field annotations
+    .label = this field has a refinement annotation

--- a/flux-tests/tests/neg/error_messages/invalid_annot.rs
+++ b/flux-tests/tests/neg/error_messages/invalid_annot.rs
@@ -1,0 +1,8 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::opaque]
+struct S {
+    #[flux::field(i32[0])] //~ ERROR opaque struct can't have field annotations
+    x: i32,
+}

--- a/flux-tests/tests/pos/structs/opaque-struct02.rs
+++ b/flux-tests/tests/pos/structs/opaque-struct02.rs
@@ -1,0 +1,7 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::opaque]
+struct Ptr<T> {
+    data: *mut T,
+}


### PR DESCRIPTION
* Report an error if an opaque struct has a field annotation
* Skip annotation checking for opaque structs such that they can contain unsupported types.