### PR TITLE
Add rslice example

### DIFF
--- a/flux-tests/tests/lib/rslice.rs
+++ b/flux-tests/tests/lib/rslice.rs
@@ -1,0 +1,30 @@
+use std::marker::PhantomData;
+
+use super::RVec;
+
+#[flux::opaque]
+#[flux::refined_by(len: int, valid: (int, int) -> bool)]
+pub struct RSlice<'a, T> {
+    data: *mut T,
+    len: usize,
+    _marker: PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> RSlice<'a, T> {
+    #[flux::assume]
+    #[flux::sig(fn(vec: &mut RVec<T>[@n]) -> RSlice<T>[n, |i,j| true])]
+    pub fn from_vec(vec: &'a mut RVec<T>) -> RSlice<T> {
+        let inner = &mut vec.inner;
+        RSlice { data: inner.as_mut_ptr(), len: inner.len(), _marker: PhantomData }
+    }
+
+    #[flux::assume]
+    #[flux::sig(
+        fn(self: &strg RSlice<T>[@len, @valid], left: usize, right: usize) -> RSlice<T>[right - left + 1, |i,j| true]
+        requires left <= right && right < len && valid(left, right)
+        ensures self: RSlice<T>[len, |i, j| valid(i, j) && (right < i || j < left)]
+    )]
+    pub fn subslice(&mut self, left: usize, right: usize) -> RSlice<'a, T> {
+        unsafe { RSlice { data: self.data.add(left), len: right - left + 1, _marker: PhantomData } }
+    }
+}

--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+pub mod rslice;
+
 #[macro_export]
 macro_rules! rvec {
     () => { RVec::new() };

--- a/flux-tests/tests/neg/surface/rslice00.rs
+++ b/flux-tests/tests/neg/surface/rslice00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+use rvec::{rslice::RSlice, RVec};
+
+#[flux::sig(fn(&mut RVec<T>[10]))]
+fn test00<T>(vec: &mut RVec<T>) {
+    let mut s = RSlice::from_vec(vec);
+    let s1 = s.subslice(0, 3);
+    let s2 = s.subslice(2, 5); //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/rslice00.rs
+++ b/flux-tests/tests/pos/surface/rslice00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+use rvec::{rslice::RSlice, RVec};
+
+#[flux::sig(fn(&mut RVec<T>[10]))]
+fn test00<T>(vec: &mut RVec<T>) {
+    let mut s = RSlice::from_vec(vec);
+    let s1 = s.subslice(0, 3);
+    let s2 = s.subslice(4, 5);
+}


### PR DESCRIPTION
An attempt at creating an API for "refined slices" that can be borrowed mutably multiple times at non-overlapping subslices. The generated constraints are not very inference friendly so the api can only be used in straightforward cases. I think this could be improved if we implement variance for abstract refinements as that would eliminate cycles. This also makes me wonder if one could possibly opt out of "constrained-based" inference for abstract refinement and unify them syntactically as normal refinement parameters.

I believe a similar API could be used for a memory buffer with maybe uninitialized memory, i.e., `RawVec`.