### PR TITLE
Make kvar encoding configurable

### DIFF
--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -192,10 +192,8 @@ pub enum Pred {
 
 /// In theory a kvar is just an unknown predicate that can use some variables in scope. In practice,
 /// fixpoint makes a diference between the first and the rest of the variables, the first one being
-/// the kvar's *self argument*. Fixpoint will only instantiate qualifiers using this first argument.
-/// Flux generalizes the self argument to be a list in order to deal with multiple indices. When
-/// generating the fixpoint constraint, the kvar will be split into multiple kvars, one for each
-/// argument in the list.
+/// the kvar's *self argument*. Fixpoint will only instantiate qualifiers that use the self argument.
+/// Flux generalizes the self argument to be a list.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KVar {
     pub kvid: KVid,

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -708,6 +708,10 @@ impl KVar {
     pub fn new(kvid: KVid, args: Vec<Expr>, scope: Vec<Expr>) -> Self {
         KVar { kvid, args: List::from_vec(args), scope: List::from_vec(scope) }
     }
+
+    pub fn all_args(&self) -> impl Iterator<Item = &Expr> {
+        self.args.iter().chain(&self.scope)
+    }
 }
 
 #[track_caller]

--- a/flux-tests/tests/pos/structs/dot01.rs
+++ b/flux-tests/tests/pos/structs/dot01.rs
@@ -19,9 +19,9 @@ pub fn mk_pairs_with_bound(a: i32) -> RVec<Pair> {
     let mut i = 0;
     let mut res = RVec::new();
     while i < a {
-        let p = Pair { x: i , y: a - i };
+        let p = Pair { x: i, y: a - i };
         res.push(p);
         i += 1;
     }
-    return res;
+    res
 }

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -956,7 +956,7 @@ impl Phase for Inference<'_> {
         _rcx: &RefineCtxt,
         tag: Tag,
     ) -> ConstrGen<'a, 'tcx> {
-        ConstrGen::new(genv, |sorts, _| Binders::new(Pred::Hole, sorts), tag)
+        ConstrGen::new(genv, |sorts: &[Sort], _| Binders::new(Pred::Hole, sorts), tag)
     }
 
     fn enter_basic_block(&mut self, _rcx: &mut RefineCtxt, bb: BasicBlock) -> TypeEnv {
@@ -974,8 +974,11 @@ impl Phase for Inference<'_> {
         let scope = ck.snapshot_at_dominator(target).scope().unwrap();
 
         dbg::infer_goto_enter!(target, env, ck.phase.bb_envs.get(&target));
-        let mut gen =
-            ConstrGen::new(ck.genv, |sorts, _| Binders::new(Pred::Hole, sorts), Tag::Other);
+        let mut gen = ConstrGen::new(
+            ck.genv,
+            |sorts: &[Sort], _| Binders::new(Pred::Hole, sorts),
+            Tag::Other,
+        );
         let modified = match ck.phase.bb_envs.entry(target) {
             Entry::Occupied(mut entry) => entry.get_mut().join(&mut rcx, &mut gen, env),
             Entry::Vacant(entry) => {

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -1008,9 +1008,9 @@ impl Phase for Check<'_> {
         tag: Tag,
     ) -> ConstrGen<'a, 'tcx> {
         let scope = rcx.scope();
-        let fresh_kvar =
+        let kvar_gen =
             move |sorts: &[Sort], encoding| self.kvars.fresh(sorts, scope.iter(), encoding);
-        ConstrGen::new(genv, fresh_kvar, tag)
+        ConstrGen::new(genv, kvar_gen, tag)
     }
 
     fn enter_basic_block(&mut self, rcx: &mut RefineCtxt, bb: BasicBlock) -> TypeEnv {
@@ -1029,10 +1029,10 @@ impl Phase for Check<'_> {
 
         dbg::check_goto!(target, rcx, env, bb_env);
 
-        let fresh_kvar =
+        let kvar_gen =
             |sorts: &[Sort], encoding| ck.phase.kvars.fresh(sorts, bb_env.scope().iter(), encoding);
         let tag = Tag::Goto(src_info.map(|s| s.span), target);
-        let gen = &mut ConstrGen::new(ck.genv, fresh_kvar, tag);
+        let gen = &mut ConstrGen::new(ck.genv, kvar_gen, tag);
         env.check_goto(&mut rcx, gen, bb_env)
             .map_err(|err| CheckerError::from(err).with_src_info_opt(src_info))?;
 

--- a/flux-typeck/src/constraint_gen.rs
+++ b/flux-typeck/src/constraint_gen.rs
@@ -63,11 +63,11 @@ impl Tag {
 }
 
 impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
-    pub fn new<F>(genv: &'a GlobalEnv<'a, 'tcx>, fresh_kvar: F, tag: Tag) -> Self
+    pub fn new<G>(genv: &'a GlobalEnv<'a, 'tcx>, kvar_gen: G, tag: Tag) -> Self
     where
-        F: KVarGen + 'a,
+        G: KVarGen + 'a,
     {
-        ConstrGen { genv, kvar_gen: Box::new(fresh_kvar), tag }
+        ConstrGen { genv, kvar_gen: Box::new(kvar_gen), tag }
     }
 
     pub fn check_constraint(

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -318,7 +318,7 @@ where
 
 impl<'a> KVarGen for Box<dyn KVarGen + 'a> {
     fn fresh(&mut self, sorts: &[rty::Sort], kind: KVarEncoding) -> Binders<rty::Pred> {
-        <dyn KVarGen>::fresh(self, sorts, kind)
+        (**self).fresh(sorts, kind)
     }
 }
 

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -35,9 +35,15 @@ struct KVarDecl {
     encoding: KVarEncoding,
 }
 
+/// How an [rty::KVar] is encoded in the fixpoint constraint
 #[derive(Clone, Copy)]
 pub enum KVarEncoding {
+    /// Generate a single kvar appending the self arguments and the scope, i.e.,
+    /// a kvar `$k(a0, ...)[b0, ...]` becomes `$k(a0, ..., b0, ...)` in the fixpoint constraint.
     Single,
+    /// Generate a conjunction of kvars, one per argument in [rty::KVar::args].
+    /// Concretely, a kvar `$k(a0, a1, ..., an)[b0, ...]` becomes
+    /// `$k0(a0, a1, ..., an, b0, ...) ∧ $k1(a1, ..., an, b0, ...) ∧ ... ∧ $kn(an, b0, ...)`
     Conj,
 }
 

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -19,7 +19,7 @@ pub struct InferenceError(String);
 pub fn infer_from_constructor(
     fields: &[Ty],
     variant: &PolyVariant,
-    fresh_kvar: &mut impl KVarGen,
+    kvar_gen: &mut impl KVarGen,
 ) -> Result<Vec<RefineArg>, InferenceError> {
     debug_assert_eq!(fields.len(), variant.as_ref().skip_binders().fields().len());
     let mut exprs = Exprs::default();
@@ -28,14 +28,14 @@ pub fn infer_from_constructor(
         infer_from_tys(&mut exprs, &FxHashMap::default(), actual, &FxHashMap::default(), formal);
     }
 
-    collect(variant, exprs, fresh_kvar)
+    collect(variant, exprs, kvar_gen)
 }
 
 pub fn infer_from_fn_call<M: PathMap>(
     env: &M,
     actuals: &[Ty],
     fn_sig: &PolySig,
-    fresh_kvar: &mut impl KVarGen,
+    kvar_gen: &mut impl KVarGen,
 ) -> Result<Vec<RefineArg>, InferenceError> {
     debug_assert_eq!(actuals.len(), fn_sig.as_ref().skip_binders().args().len());
 
@@ -58,7 +58,7 @@ pub fn infer_from_fn_call<M: PathMap>(
         infer_from_tys(&mut exprs, env, actual, &requires, formal);
     }
 
-    collect(fn_sig, exprs, fresh_kvar)
+    collect(fn_sig, exprs, kvar_gen)
 }
 
 fn collect<T>(

--- a/flux-typeck/src/param_infer.rs
+++ b/flux-typeck/src/param_infer.rs
@@ -2,11 +2,14 @@ use std::iter;
 
 use flux_middle::rty::{
     subst::FVarSubst, BaseTy, Binders, Constraint, Expr, ExprKind, GenericArg, Name, Path, PolySig,
-    PolyVariant, Pred, RefineArg, Sort, Ty, TyKind, INNERMOST,
+    PolyVariant, RefineArg, Sort, Ty, TyKind, INNERMOST,
 };
 use rustc_hash::FxHashMap;
 
-use crate::type_env::PathMap;
+use crate::{
+    fixpoint::{KVarEncoding, KVarGen},
+    type_env::PathMap,
+};
 
 type Exprs = FxHashMap<usize, Expr>;
 
@@ -16,7 +19,7 @@ pub struct InferenceError(String);
 pub fn infer_from_constructor(
     fields: &[Ty],
     variant: &PolyVariant,
-    fresh_kvar: &mut impl FnMut(&[Sort]) -> Binders<Pred>,
+    fresh_kvar: &mut impl KVarGen,
 ) -> Result<Vec<RefineArg>, InferenceError> {
     debug_assert_eq!(fields.len(), variant.as_ref().skip_binders().fields().len());
     let mut exprs = Exprs::default();
@@ -32,7 +35,7 @@ pub fn infer_from_fn_call<M: PathMap>(
     env: &M,
     actuals: &[Ty],
     fn_sig: &PolySig,
-    fresh_kvar: &mut impl FnMut(&[Sort]) -> Binders<Pred>,
+    fresh_kvar: &mut impl KVarGen,
 ) -> Result<Vec<RefineArg>, InferenceError> {
     debug_assert_eq!(actuals.len(), fn_sig.as_ref().skip_binders().args().len());
 
@@ -61,14 +64,14 @@ pub fn infer_from_fn_call<M: PathMap>(
 fn collect<T>(
     t: &Binders<T>,
     mut exprs: Exprs,
-    fresh_kvar: &mut impl FnMut(&[Sort]) -> Binders<Pred>,
+    kvar_gen: &mut impl KVarGen,
 ) -> Result<Vec<RefineArg>, InferenceError> {
     t.params()
         .iter()
         .enumerate()
         .map(|(idx, sort)| {
             if let Sort::Func(fsort) = sort && fsort.output().is_bool() {
-                Ok(RefineArg::Abs(fresh_kvar(fsort.inputs())))
+                Ok(RefineArg::Abs(kvar_gen.fresh(fsort.inputs(), KVarEncoding::Single)))
             } else {
                 let e = exprs
                     .remove(&idx)

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -21,7 +21,7 @@ use self::paths_tree::{Binding, FoldResult, LocKind, PathsTree};
 use super::rty::{Loc, Name, Pred, Sort};
 use crate::{
     constraint_gen::ConstrGen,
-    fixpoint::{KVarEncoding, KVarGen},
+    fixpoint::{KVarEncoding, KVarStore},
     param_infer,
     refine_tree::{RefineCtxt, Scope},
     rty::VariantIdx,
@@ -619,7 +619,7 @@ impl TypeEnvInfer {
         }
     }
 
-    pub fn into_bb_env(self, kvar_gen: &mut impl KVarGen) -> BasicBlockEnv {
+    pub fn into_bb_env(self, kvar_gen: &mut KVarStore) -> BasicBlockEnv {
         let mut bindings = self.bindings;
 
         let mut names = vec![];
@@ -652,9 +652,13 @@ impl TypeEnvInfer {
         let params = iter::zip(names, sorts).collect_vec();
 
         // Replace holes that weren't generalized by fresh kvars
-        let mut kvar_gen = kvar_gen.chaining(&self.scope);
-        let fresh_kvar =
-            &mut |sorts: &[Sort]| kvar_gen.fresh(sorts, params.iter().cloned(), KVarEncoding::Conj);
+        let fresh_kvar = &mut |sorts: &[Sort]| {
+            kvar_gen.fresh(
+                sorts,
+                self.scope.iter().chain(params.iter().cloned()),
+                KVarEncoding::Conj,
+            )
+        };
         bindings.fmap_mut(|binding| binding.replace_holes(fresh_kvar));
 
         BasicBlockEnv { params, constrs, bindings, scope: self.scope }

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -619,7 +619,7 @@ impl TypeEnvInfer {
         }
     }
 
-    pub fn into_bb_env(self, kvar_gen: &mut KVarStore) -> BasicBlockEnv {
+    pub fn into_bb_env(self, kvar_store: &mut KVarStore) -> BasicBlockEnv {
         let mut bindings = self.bindings;
 
         let mut names = vec![];
@@ -644,7 +644,7 @@ impl TypeEnvInfer {
             .iter()
             .map(|name| RefineArg::Expr(Expr::fvar(*name)))
             .collect_vec();
-        let kvar = kvar_gen
+        let kvar = kvar_store
             .fresh(&sorts, self.scope.iter(), KVarEncoding::Conj)
             .replace_bound_vars(&exprs);
         constrs.push(kvar);
@@ -652,14 +652,14 @@ impl TypeEnvInfer {
         let params = iter::zip(names, sorts).collect_vec();
 
         // Replace holes that weren't generalized by fresh kvars
-        let fresh_kvar = &mut |sorts: &[Sort]| {
-            kvar_gen.fresh(
+        let kvar_gen = &mut |sorts: &[Sort]| {
+            kvar_store.fresh(
                 sorts,
                 self.scope.iter().chain(params.iter().cloned()),
                 KVarEncoding::Conj,
             )
         };
-        bindings.fmap_mut(|binding| binding.replace_holes(fresh_kvar));
+        bindings.fmap_mut(|binding| binding.replace_holes(kvar_gen));
 
         BasicBlockEnv { params, constrs, bindings, scope: self.scope }
     }


### PR DESCRIPTION
Make the encoding of flux kvars into fixpoint kvars configurable. The `Single` encoding will maps a flux kvar to a single kvar in fixpoint maintaining all the arguments. The `Conj` encoding creates a conjunction of kvars one for each self argument.