### PR TITLE
Optimize away trivial equalities

### DIFF
--- a/flux-middle/src/pretty.rs
+++ b/flux-middle/src/pretty.rs
@@ -85,6 +85,14 @@ macro_rules! _join {
 pub use crate::_join as join;
 
 #[macro_export]
+macro_rules! _parens {
+    ($val:expr, $parenthesize:expr) => {
+        $crate::pretty::Parens::new(&$val, $parenthesize)
+    };
+}
+pub use crate::_parens as parens;
+
+#[macro_export]
 macro_rules! _impl_debug_with_default_cx {
     ($($ty:ty $(=> $key:literal)?),* $(,)?) => {$(
         impl std::fmt::Debug for $ty  {
@@ -139,6 +147,11 @@ pub struct Join<'a, I> {
     iter: RefCell<Option<I>>,
 }
 
+pub struct Parens<'a, T> {
+    val: &'a T,
+    parenthesize: bool,
+}
+
 pub trait Pretty {
     fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
@@ -150,6 +163,12 @@ pub trait Pretty {
 impl<'a, I> Join<'a, I> {
     pub fn new<T: IntoIterator<IntoIter = I>>(sep: &'a str, iter: T) -> Self {
         Self { sep, iter: RefCell::new(Some(iter.into_iter())) }
+    }
+}
+
+impl<'a, T> Parens<'a, T> {
+    pub fn new(val: &'a T, parenthesize: bool) -> Self {
+        Self { val, parenthesize }
     }
 }
 
@@ -262,6 +281,21 @@ where
                 write!(f, "{}", self.sep)?;
             }
             <T as Pretty>::fmt(&item, cx, f)?;
+        }
+        Ok(())
+    }
+}
+impl<'a, T> Pretty for Parens<'a, T>
+where
+    T: Pretty,
+{
+    fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.parenthesize {
+            write!(f, "(")?;
+        }
+        <T as Pretty>::fmt(&self.val, cx, f)?;
+        if self.parenthesize {
+            write!(f, ")")?;
         }
         Ok(())
     }

--- a/flux-middle/src/pretty.rs
+++ b/flux-middle/src/pretty.rs
@@ -293,7 +293,7 @@ where
         if self.parenthesize {
             write!(f, "(")?;
         }
-        <T as Pretty>::fmt(&self.val, cx, f)?;
+        <T as Pretty>::fmt(self.val, cx, f)?;
         if self.parenthesize {
             write!(f, ")")?;
         }

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -225,9 +225,7 @@ impl Expr {
     pub fn neg(&self) -> Expr {
         ExprKind::UnaryOp(UnOp::Neg, self.clone()).intern()
     }
-}
 
-impl Expr {
     pub fn kind(&self) -> &ExprKind {
         &self.kind
     }
@@ -239,6 +237,10 @@ impl Expr {
 
     pub fn is_binary_op(&self) -> bool {
         !matches!(self.kind, ExprKind::BinaryOp(..))
+    }
+
+    pub fn is_trivial_equality(&self) -> bool {
+        matches!(self.kind(), ExprKind::BinaryOp(BinOp::Eq, e1, e2) if e1 == e2)
     }
 
     /// Simplify expression applying some simple rules like removing double negation. This is

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -5,7 +5,8 @@
     if_let_guard,
     let_chains,
     type_alias_impl_trait,
-    box_patterns
+    box_patterns,
+    drain_filter
 )]
 
 extern crate rustc_data_structures;

--- a/flux-typeck/src/refine_tree.rs
+++ b/flux-typeck/src/refine_tree.rs
@@ -77,6 +77,8 @@ enum NodeKind {
     ForAll(Name, Sort),
     Guard(Pred),
     Head(Pred, Tag),
+    Impl(Pred, Pred, Tag),
+    True,
 }
 
 impl RefineTree {
@@ -147,10 +149,9 @@ impl RefineCtxt<'_> {
         }
     }
 
-    pub fn check_impl(&mut self, ped1: impl Into<Pred>, pred2: impl Into<Pred>, tag: Tag) {
+    pub fn check_impl(&mut self, pred1: impl Into<Pred>, pred2: impl Into<Pred>, tag: Tag) {
         self.ptr
-            .push_node(NodeKind::Guard(ped1.into()))
-            .push_node(NodeKind::Head(pred2.into(), tag));
+            .push_node(NodeKind::Impl(pred1.into(), pred2.into(), tag));
     }
 
     fn unpack_bty(&mut self, bty: &BaseTy, inside_mut_ref: bool, flags: UnpackFlags) -> BaseTy {
@@ -367,13 +368,31 @@ impl std::ops::Deref for NodePtr {
 
 impl Node {
     fn replace_evars(&mut self, evars: &EVarSol) {
+        self.children.drain_filter(|child| {
+            let mut node = child.borrow_mut();
+            node.replace_evars(evars);
+            matches!(node.kind, NodeKind::True)
+        });
         match &mut self.kind {
             NodeKind::Guard(pred) => *pred = pred.replace_evars(evars),
-            NodeKind::Head(pred, _) => *pred = pred.replace_evars(evars),
-            NodeKind::Conj | NodeKind::ForAll(_, _) => {}
-        }
-        for child in &self.children {
-            child.borrow_mut().replace_evars(evars)
+            NodeKind::Impl(pred1, pred2, tag) => {
+                let pred1 = pred1.replace_evars(evars);
+                let pred2 = pred2.replace_evars(evars);
+                if pred1 == pred2 {
+                    self.kind = NodeKind::True;
+                } else {
+                    self.kind = NodeKind::Impl(pred1, pred2, *tag)
+                }
+            }
+            NodeKind::Head(pred, _) => {
+                match pred.replace_evars(evars) {
+                    Pred::Expr(e) if e.is_trivial_equality() => {
+                        self.kind = NodeKind::True;
+                    }
+                    new_pred => *pred = new_pred,
+                }
+            }
+            NodeKind::Conj | NodeKind::ForAll(_, _) | NodeKind::True => {}
         }
     }
 
@@ -403,10 +422,25 @@ impl Node {
                     ),
                 ))
             }
+            NodeKind::Impl(pred1, pred2, tag) => {
+                let (bindings1, pred1) = cx.pred_to_fixpoint(pred1);
+                let (bindings2, pred2) = cx.pred_to_fixpoint(pred2);
+                Some(stitch(
+                    bindings1,
+                    fixpoint::Constraint::Guard(
+                        pred1,
+                        Box::new(stitch(
+                            bindings2,
+                            fixpoint::Constraint::Pred(pred2, Some(cx.tag_idx(*tag))),
+                        )),
+                    ),
+                ))
+            }
             NodeKind::Head(pred, tag) => {
                 let (bindings, pred) = cx.pred_to_fixpoint(pred);
                 Some(stitch(bindings, fixpoint::Constraint::Pred(pred, Some(cx.tag_idx(*tag)))))
             }
+            NodeKind::True => None,
         }
     }
 
@@ -576,23 +610,26 @@ mod pretty {
                         (vec![pred.clone()], node.children.clone())
                     };
                     let guard = Pred::And(List::from_vec(preds)).simplify();
-                    if guard.is_atom() {
-                        w!("{:?} ⇒", guard)?;
-                    } else {
-                        w!("({:?}) ⇒", guard)?;
-                    }
+                    w!("{:?} =>", parens!(guard, !guard.is_atom()))?;
                     fmt_children(&children, cx, f)
                 }
                 NodeKind::Head(pred, tag) => {
-                    if pred.is_atom() {
-                        w!("{:?}", pred)?;
-                    } else {
-                        w!("({:?})", pred)?;
-                    }
+                    w!("{:?}", parens!(pred, !pred.is_atom()))?;
                     if cx.tags {
                         w!(" ~ {:?}", tag)?;
                     }
                     Ok(())
+                }
+                NodeKind::Impl(pred1, pred2, tag) => {
+                    w!("{:?} => ", parens!(pred1, !pred1.is_atom()))?;
+                    w!("{:?}", parens!(pred2, !pred2.is_atom()))?;
+                    if cx.tags {
+                        w!(" ~ {:?}", tag)?;
+                    }
+                    Ok(())
+                }
+                NodeKind::True => {
+                    w!("true")
                 }
             }
         }
@@ -645,7 +682,7 @@ mod pretty {
                                 f(&format_args_cx!("{:?}: {:?}", ^name, sort))
                             }
                             NodeKind::Guard(pred) => f(&format_args_cx!("{:?}", pred)),
-                            NodeKind::Conj | NodeKind::Head(..) => unreachable!(),
+                            _ => unreachable!(),
                         }
                     })
             )


### PR DESCRIPTION
After https://github.com/liquid-rust/flux/pull/249 constraints contain a lot of trivial equalities. This happens because we replace evars after generating the constraint. This means that before replacing evars the constraint contains a lot of equalities of the form `?e0 = n`, which will later become `n = n`. This PR finds these trivial equalities when replacing evars and optimizes them away. It also optimizes aways trivial implications of the form `p => p` in anticipation of syntactic unification of abstract refinements.