### PR TITLE
Macro for `from_elem_n`

### DIFF
--- a/flux-tests/tests/lib/rvec.rs
+++ b/flux-tests/tests/lib/rvec.rs
@@ -9,6 +9,9 @@ macro_rules! rvec {
         let mut res = RVec::new();
         $( res.push($e); )*
         res
+    }};
+    ($elem:expr; $n:expr) => {{
+        RVec::from_elem_n($elem, $n)
     }}
 }
 

--- a/flux-tests/tests/pos/surface/rvec00.rs
+++ b/flux-tests/tests/pos/surface/rvec00.rs
@@ -5,20 +5,25 @@
 mod rvec;
 use rvec::RVec;
 
-#[flux::sig(fn() -> RVec<i32>[5])]
-pub fn test1() -> RVec<i32> {
-    rvec![ 12; 55 ] //~ ERROR postcondition
+#[flux::sig(fn() -> RVec<i32>[0])]
+pub fn test0() -> RVec<i32> {
+    let mv = rvec![];
+    mv
 }
 
-#[flux::sig(fn(n:usize) -> RVec<i32>[n + 1])]
+#[flux::sig(fn() -> RVec<i32>[5])]
+pub fn test1() -> RVec<i32> {
+    rvec![ 12; 5 ]
+}
+
+#[flux::sig(fn(n:usize) -> RVec<i32>[n])]
 pub fn test2(n: usize) -> RVec<i32> {
-    rvec![ 12; n ] //~ ERROR postcondition
+    rvec![ 12; n ]
 }
 
 pub fn test3() -> usize {
     let v = rvec![0, 1];
     let r = v[0];
     let r = r + v[1];
-    let r = r + v[2]; //~ ERROR precondition might not hold
     r
 }


### PR DESCRIPTION
So we can write stuff like `rvec![ 100; 4 ]`