### PR TITLE
Naive join for tuples (?)

### DIFF
--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -631,7 +631,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, U
             Ok(Ty::mk_array(lower_ty(tcx, *ty)?, Const { val }))
         }
         rustc_ty::Slice(ty) => Ok(Ty::mk_slice(lower_ty(tcx, *ty)?)),
-        _ => Err(UnsupportedType { reason: format!("unsupported type `{ty:?}`") }),
+        _ => Err(UnsupportedType { reason: format!("TRACE unsupported type `{ty:?}`") }),
     }
 }
 

--- a/flux-tests/tests/pos/surface/join02.rs
+++ b/flux-tests/tests/pos/surface/join02.rs
@@ -1,0 +1,8 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(bool) -> i32{v: v >= 0})]
+pub fn test00(b: bool) -> i32 {
+    let p = if b { (0, 0) } else { (0, 1) };
+    p.0 + p.1
+}

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -609,9 +609,9 @@ impl TypeEnvInfer {
                 Ty::param(*param_ty1)
             }
             (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
-                let tys: Vec<Ty> = iter::zip(tys1, tys2)
+                let tys = iter::zip(tys1, tys2)
                     .map(|(ty1, ty2)| self.join_ty(ty1, ty2, src_info))
-                    .collect();
+                    .collect_vec();
                 Ty::tuple(tys)
             }
             _ => unreachable!("`{ty1:?}` -- `{ty2:?}`"),

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -609,11 +609,10 @@ impl TypeEnvInfer {
                 Ty::param(*param_ty1)
             }
             (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
-                assert!(
-                    tys1.is_empty() && tys2.is_empty(),
-                    "join of non-empty tuples is not supported yet {src_info:?}"
-                );
-                Ty::tuple(vec![])
+                let tys: Vec<Ty> = iter::zip(tys1, tys2)
+                    .map(|(ty1, ty2)| self.join_ty(ty1, ty2, src_info))
+                    .collect();
+                Ty::tuple(tys)
             }
             _ => unreachable!("`{ty1:?}` -- `{ty2:?}`"),
         }


### PR DESCRIPTION
I was getting an odd `panic!` in the `flux-wave` code that seems to come from here 

https://github.com/liquid-rust/examples/blob/main/wave/flux/src/iov.rs#L9-L11

I'm not 100% sure as the `SourcePos` is from inside the `unwrap_result` macro but changing it to use a custom `Pair` type made the error go away. 

So I implemented this "naive" fix which seems to pass the tests and make this example work, but I don't know if there are some more subtle invariants lurking that I'm unaware of?

LMK!