### PR TITLE
Support for unary operators in surface

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -510,6 +510,9 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                 let e2 = self.desugar_expr(e2);
                 fhir::ExprKind::BinaryOp(desugar_bin_op(op), Box::new([e1?, e2?]))
             }
+            surface::ExprKind::UnaryOp(op, box e) => {
+                fhir::ExprKind::UnaryOp(desugar_un_op(op), Box::new(self.desugar_expr(e)?))
+            }
             surface::ExprKind::Dot(e, fld) => return self.desugar_dot(*e, fld),
             surface::ExprKind::App(func, args) => {
                 let args = self.desugar_exprs(args)?;
@@ -1073,6 +1076,13 @@ fn desugar_bin_op(op: surface::BinOp) -> fhir::BinOp {
         surface::BinOp::Sub => fhir::BinOp::Sub,
         surface::BinOp::Mod => fhir::BinOp::Mod,
         surface::BinOp::Mul => fhir::BinOp::Mul,
+    }
+}
+
+fn desugar_un_op(op: surface::UnOp) -> fhir::UnOp {
+    match op {
+        surface::UnOp::Not => fhir::UnOp::Not,
+        surface::UnOp::Neg => fhir::UnOp::Neg,
     }
 }
 

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -485,6 +485,12 @@ impl fmt::Display for UnOp {
     }
 }
 
+impl fmt::Debug for UnOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
 impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use flux_common::format::PadAdapter;
-pub use flux_fixpoint::BinOp;
+pub use flux_fixpoint::{BinOp, UnOp};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -247,6 +247,7 @@ pub enum ExprKind {
     Var(Name, Symbol, Span),
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),
+    UnaryOp(UnOp, Box<Expr>),
     App(Func, Vec<Expr>),
     IfThenElse(Box<[Expr; 3]>),
 }
@@ -672,6 +673,7 @@ impl fmt::Debug for Expr {
         match &self.kind {
             ExprKind::Var(x, ..) => write!(f, "{x:?}"),
             ExprKind::BinaryOp(op, box [e1, e2]) => write!(f, "({e1:?} {op:?} {e2:?})"),
+            ExprKind::UnaryOp(op, e) => write!(f, "{op:?}{e:?}"),
             ExprKind::Literal(lit) => write!(f, "{lit:?}"),
             ExprKind::Const(x, _) => write!(f, "{x:?}"),
             ExprKind::App(uf, es) => write!(f, "{uf:?}({es:?})"),

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -469,6 +469,7 @@ impl NameMap {
                     self.conv_expr(e2, nbinders),
                 )
             }
+            fhir::ExprKind::UnaryOp(op, e) => rty::Expr::unary_op(*op, self.conv_expr(e, nbinders)),
             fhir::ExprKind::App(func, args) => {
                 match func {
                     fhir::Func::Uif(sym, _) => {

--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -16,6 +16,7 @@ pub enum Token {
     OrOr,
     Plus,
     Minus,
+    Not,
     Star,
     Colon,
     Comma,
@@ -131,6 +132,7 @@ impl Cursor {
             TokenKind::BinOp(BinOpToken::And) => Token::And,
             TokenKind::BinOp(BinOpToken::Percent) => Token::Percent,
             TokenKind::BinOp(BinOpToken::Star) => Token::Star,
+            TokenKind::Not => Token::Not,
             _ => Token::Invalid,
         };
         (Location(span.lo() - self.offset), token, Location(span.hi() - self.offset))

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -228,6 +228,7 @@ pub enum ExprKind {
     Dot(Box<Expr>, Ident),
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),
+    UnaryOp(UnOp, Box<Expr>),
     App(Ident, Vec<Expr>),
     IfThenElse(Box<[Expr; 3]>),
 }
@@ -255,6 +256,12 @@ pub enum BinOp {
     Sub,
     Mod,
     Mul,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum UnOp {
+    Not,
+    Neg,
 }
 
 impl RefinedBy {
@@ -495,6 +502,9 @@ pub mod expand {
                     ),
                     span: e.span,
                 }
+            }
+            ExprKind::UnaryOp(op, e) => {
+                Expr { kind: ExprKind::UnaryOp(*op, Box::new(subst_expr(subst, e))), span: e.span }
             }
             ExprKind::Dot(e1, fld) => {
                 Expr { kind: ExprKind::Dot(Box::new(subst_expr(subst, e1)), *fld), span: e.span }

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -47,7 +47,7 @@ pub Defn: surface::Defn = {
     "->"
     <sort:Sort>
     "{"
-    <expr:Level1>
+    <expr:Expr>
     "}"
     <hi:@R> => {
         surface::Defn { name: name, args: args, sort: sort, expr: expr, span: mk_span(lo, hi) }
@@ -59,7 +59,7 @@ pub Qualifier: surface::Qualifier = {
     <name:Ident>
     "(" <args:Comma<RefineParam>> ")"
     "{"
-    <expr:Level1>
+    <expr:Expr>
     "}"
     <hi:@R> => {
         surface::Qualifier { name: name, args: args, expr: expr, span: mk_span(lo, hi) }
@@ -192,7 +192,7 @@ Refinement: surface::Expr = {
         kind: surface::ExprKind::Var(var),
         span: mk_span(lo, hi),
     },
-    "{" <Level1> "}" => <>
+    "{" <Expr> "}" => <>
 };
 
 Indices: surface::Indices = {
@@ -201,8 +201,8 @@ Indices: surface::Indices = {
 
 RefineArg: surface::RefineArg = {
     <lo:@L> "@" <bind:Ident> <hi:@R>               => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
-    <Level1>                                       => surface::RefineArg::Expr(<>),
-    <lo:@L> "|"<params: Comma<Ident>> "|" <body:Level1> <hi:@R> => {
+    <Expr>                                         => surface::RefineArg::Expr(<>),
+    <lo:@L> "|"<params: Comma<Ident>> "|" <body:Expr> <hi:@R> => {
         surface::RefineArg::Abs(params, body, mk_span(lo, hi))
     }
 };
@@ -216,7 +216,16 @@ Level4 = LeftAssoc<BinOp4, Level5>; // &&
 Level5 = NonAssoc<BinOp5, Level6>;  // ==, !=, >=, <=
 Level6 = LeftAssoc<BinOp6, Level7>; // +, -
 Level7 = LeftAssoc<BinOp7, Level8>; // *, %
-Level8: surface::Expr = {
+Level8 = {
+    <lo:@L> <op:UnOp> <e:Level9> <hi:@R> => {
+        surface::Expr {
+            kind: surface::ExprKind::UnaryOp(op, Box::new(e)),
+            span: mk_span(lo, hi),
+        }
+    },
+    <Level9>
+}
+Level9: surface::Expr = {
     <lo:@L> "if" <p:Level1> "{" <e1:Level1> "}" "else" "{" <e2:Level1> "}" <hi:@R> => {
         surface::Expr {
             kind: surface::ExprKind::IfThenElse(Box::new([p, e1, e2])),
@@ -242,13 +251,11 @@ Level8: surface::Expr = {
             span: mk_span(lo, hi),
         }
     },
-
-
     <lo:@L> <var:Ident> <hi:@R> => surface::Expr {
         kind: surface::ExprKind::Var(var),
         span: mk_span(lo, hi),
     },
-    "(" <Level1> ")" => <>
+    "(" <Level1> ")"
 }
 
 
@@ -306,6 +313,11 @@ BinOp7: surface::BinOp = {
     "%" => surface::BinOp::Mod,
 }
 
+UnOp: surface::UnOp = {
+    "!" => surface::UnOp::Not,
+    "-" => surface::UnOp::Neg,
+}
+
 Lit: surface::Lit = {
     <lo:@L> <lit:"literal"> <hi:@R> => surface::Lit {
         kind: lit.kind,
@@ -360,6 +372,7 @@ extern {
         "<=>" => Token::Iff,
         "+"  => Token::Plus,
         "-"  => Token::Minus,
+        "!"  => Token::Not,
         "*"  => Token::Star,
         "|"  => Token::Caret,
         "("  => Token::OpenDelim(Delimiter::Parenthesis),
@@ -369,9 +382,9 @@ extern {
         "["  => Token::OpenDelim(Delimiter::Bracket),
         "]"  => Token::CloseDelim(Delimiter::Bracket),
         "<"  => Token::Lt,
-        "<="  => Token::Le,
+        "<=" => Token::Le,
         ">"  => Token::Gt,
-        ">="  => Token::Ge,
+        ">=" => Token::Ge,
         ":"  => Token::Colon,
         "."  => Token::Dot,
         ";"  => Token::Semi,

--- a/flux-tests/tests/neg/surface/neg.rs
+++ b/flux-tests/tests/neg/surface/neg.rs
@@ -1,0 +1,9 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x: i32, y: i32{y == -x}))]
+pub fn test00(x: i32, y: i32) {}
+
+pub fn test01() {
+    test00(1, 1); //~ ERROR precondition
+}

--- a/flux-tests/tests/neg/surface/not.rs
+++ b/flux-tests/tests/neg/surface/not.rs
@@ -1,0 +1,16 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x:i32{!(x > 0)}))]
+pub fn test00(x: i32) {}
+
+pub fn test01() {
+    test00(1); //~ ERROR precondition
+}
+
+#[flux::sig(fn(bool[@x], bool[!x]))]
+pub fn test02(x: bool, y: bool) {}
+
+pub fn test03() {
+    test02(true, true); //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/neg.rs
+++ b/flux-tests/tests/pos/surface/neg.rs
@@ -1,0 +1,9 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x: i32, y: i32{y == -x}))]
+pub fn test00(x: i32, y: i32) {}
+
+pub fn test01() {
+    test00(1, -1);
+}

--- a/flux-tests/tests/pos/surface/not.rs
+++ b/flux-tests/tests/pos/surface/not.rs
@@ -1,0 +1,16 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(x:i32{!(x > 0)}))]
+pub fn test00(x: i32) {}
+
+pub fn test01() {
+    test00(0);
+}
+
+#[flux::sig(fn(bool[@x], bool[!x]))]
+pub fn test02(x: bool, y: bool) {}
+
+pub fn test03() {
+    test02(true, false);
+}

--- a/flux-typeck/src/wf.rs
+++ b/flux-typeck/src/wf.rs
@@ -345,6 +345,7 @@ impl<'a> Wf<'a> {
             fhir::ExprKind::Var(var, ..) => Ok(env[var]),
             fhir::ExprKind::Literal(lit) => Ok(synth_lit(*lit)),
             fhir::ExprKind::BinaryOp(op, box [e1, e2]) => self.synth_binary_op(env, *op, e1, e2),
+            fhir::ExprKind::UnaryOp(op, e) => self.synth_unary_op(env, *op, e),
             fhir::ExprKind::Const(_, _) => Ok(&fhir::Sort::Int), // TODO: generalize const sorts
             fhir::ExprKind::App(f, es) => self.synth_app(env, f, es, e.span),
             fhir::ExprKind::IfThenElse(box [p, e1, e2]) => {
@@ -386,6 +387,24 @@ impl<'a> Wf<'a> {
             | fhir::BinOp::Div => {
                 self.check_expr(env, e1, &fhir::Sort::Int)?;
                 self.check_expr(env, e2, &fhir::Sort::Int)?;
+                Ok(&fhir::Sort::Int)
+            }
+        }
+    }
+
+    fn synth_unary_op(
+        &self,
+        env: &Env<'a>,
+        op: fhir::UnOp,
+        e: &fhir::Expr,
+    ) -> Result<&'a fhir::Sort, ErrorGuaranteed> {
+        match op {
+            fhir::UnOp::Not => {
+                self.check_expr(env, e, &fhir::Sort::Bool)?;
+                Ok(&fhir::Sort::Bool)
+            }
+            fhir::UnOp::Neg => {
+                self.check_expr(env, e, &fhir::Sort::Int)?;
                 Ok(&fhir::Sort::Int)
             }
         }
@@ -469,6 +488,7 @@ impl<'a> Wf<'a> {
                     .iter()
                     .try_for_each_exhaust(|e| self.check_param_uses(env, e, is_pred))
             }
+            fhir::ExprKind::UnaryOp(_, e) => self.check_param_uses(env, e, false),
             fhir::ExprKind::App(func, args) => {
                 if !is_top_level_conj && let fhir::Func::Var(var) = func {
                     return self.emit_err(errors::InvalidParamPos::new(var.source_info.0, env[var.name]));


### PR DESCRIPTION
Support `-` and `!` in refinement annotations.