### PR TITLE
Support (some) `Projection` by normalizing them away

### DIFF
--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -8,10 +8,12 @@ extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_index;
+extern crate rustc_infer;
 extern crate rustc_middle;
 extern crate rustc_serialize;
 extern crate rustc_span;
 extern crate rustc_target;
+extern crate rustc_trait_selection;
 
 pub mod fhir;
 pub mod global_env;

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use rustc_const_eval::interpret::ConstValue;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::{
     mir as rustc_mir,
     ty::{
@@ -13,6 +14,7 @@ use rustc_middle::{
         ParamEnv, TyCtxt, TypeVisitable,
     },
 };
+use rustc_trait_selection::traits::query::normalize::AtExt;
 
 use super::{
     mir::{
@@ -558,21 +560,24 @@ pub fn lower_variant_def(
 pub fn lower_fn_sig_of(tcx: TyCtxt, def_id: DefId) -> Result<PolyFnSig, errors::UnsupportedFnSig> {
     let fn_sig = tcx.fn_sig(def_id);
     let span = tcx.def_span(def_id);
-    let fn_sig = if !fn_sig.has_projections() {
-        fn_sig
-    } else {
-        let param_env = tcx.param_env_reveal_all_normalized(def_id);
-        match tcx.try_normalize_erasing_regions(param_env, fn_sig) {
-            Ok(fn_sig) => fn_sig,
-            Err(_) => {
-                return Err(errors::UnsupportedFnSig {
-                    span,
-                    reason: "Sorry, projections are not yet supported!".to_string(),
-                })
-            }
+    let param_env = tcx.param_env(def_id);
+    match tcx
+        .infer_ctxt()
+        .build()
+        .at(&rustc_middle::traits::ObligationCause::dummy(), param_env)
+        .normalize(fn_sig)
+    {
+        Ok(fn_sig) => {
+            lower_fn_sig(tcx, fn_sig.value)
+                .map_err(|err| errors::UnsupportedFnSig { span, reason: err.reason })
         }
-    };
-    lower_fn_sig(tcx, fn_sig).map_err(|err| errors::UnsupportedFnSig { span, reason: err.reason })
+        Err(_) => {
+            return Err(errors::UnsupportedFnSig {
+                span,
+                reason: "Sorry, projections are not yet supported!".to_string(),
+            })
+        }
+    }
 }
 
 fn lower_fn_sig<'tcx>(

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -572,7 +572,7 @@ pub fn lower_fn_sig_of(tcx: TyCtxt, def_id: DefId) -> Result<PolyFnSig, errors::
                 .map_err(|err| errors::UnsupportedFnSig { span, reason: err.reason })
         }
         Err(_) => {
-            return Err(errors::UnsupportedFnSig {
+            Err(errors::UnsupportedFnSig {
                 span,
                 reason: "Sorry, projections are not yet supported!".to_string(),
             })

--- a/flux-tests/tests/neg/surface/result00.rs
+++ b/flux-tests/tests/neg/surface/result00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> Result<i32[0], ()>)]
+fn baz() -> Result<i32, ()> {
+    Ok(0)
+}
+
+#[flux::sig(fn() -> Result<i32[2], ()>)]
+pub fn baz_call() -> Result<i32, ()> {
+    let r = baz()?;
+    Ok(r + 1) //~ ERROR: postcondition
+}

--- a/flux-tests/tests/pos/surface/result00.rs
+++ b/flux-tests/tests/pos/surface/result00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> Result<i32[0], ()>)]
+fn baz() -> Result<i32, ()> {
+    Ok(0)
+}
+
+#[flux::sig(fn() -> Result<i32[1], ()>)]
+pub fn baz_call() -> Result<i32, ()> {
+    let r = baz()?;
+    Ok(r + 1)
+}

--- a/flux-tests/tests/pos/surface/trait00.rs
+++ b/flux-tests/tests/pos/surface/trait00.rs
@@ -1,0 +1,14 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub trait Trait {
+    type A;
+}
+
+impl Trait for i32 {
+    type A = i32;
+}
+
+pub fn foo(x: &i32) -> <i32 as Trait>::A {
+    *x
+}


### PR DESCRIPTION
fixes #260 

The main trick is to build on the support for `instance` (c.f. #115) and when given a `def_id` with `Projection` in it, use the `rustc` API to `normalize` away the projections prior to `lower_fn_sig` etc.