### PR TITLE
Drop extra `fn` from `ufn` syntax

### DIFF
--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -30,7 +30,6 @@ pub RefinedBy: surface::RefinedBy = {
 
 pub UifDef: surface::UifDef = {
     <lo:@L>
-    "fn"
     <name:Ident>
     "(" <inputs:Comma<Ident>> ")"
     "->"

--- a/flux-tests/tests/neg/error_messages/bad_alias00.rs
+++ b/flux-tests/tests/neg/error_messages/bad_alias00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::ufn(foo(int, int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]

--- a/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::ufn(foo(int, int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x)])] //~ ERROR this function takes 2 refinement parameters but 1 was found

--- a/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::ufn(foo(int, int) -> int)]
 
 #[flux::sig(fn (i32[fog(10, 20)]) -> i32)] //~ ERROR cannot find value `fog`
 pub fn baz(a: i32) -> i32 {

--- a/flux-tests/tests/neg/surface/result00.rs
+++ b/flux-tests/tests/neg/surface/result00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> Result<i32[0], ()>)]
+fn baz() -> Result<i32, ()> {
+    Ok(0)
+}
+
+#[flux::sig(fn() -> Result<i32[2], ()>)]
+pub fn baz_call() -> Result<i32, ()> {
+    let r = baz()?;
+    Ok(r + 1) //~ ERROR: postcondition
+}

--- a/flux-tests/tests/neg/surface/uif00.rs
+++ b/flux-tests/tests/neg/surface/uif00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn valid(int) -> bool)]
+#![flux::ufn(valid(int) -> bool)]
 
 #[flux::assume]
 #[flux::sig(fn(x:i32) -> bool[valid(x)])]

--- a/flux-tests/tests/neg/surface/uif01.rs
+++ b/flux-tests/tests/neg/surface/uif01.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::ufn(foo(int, int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]

--- a/flux-tests/tests/pos/surface/result00.rs
+++ b/flux-tests/tests/pos/surface/result00.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> Result<i32[0], ()>)]
+fn baz() -> Result<i32, ()> {
+    Ok(0)
+}
+
+#[flux::sig(fn() -> Result<i32[1], ()>)]
+pub fn baz_call() -> Result<i32, ()> {
+    let r = baz()?;
+    Ok(r + 1)
+}

--- a/flux-tests/tests/pos/surface/uif00.rs
+++ b/flux-tests/tests/pos/surface/uif00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn valid(int) -> bool)]
+#![flux::ufn(valid(int) -> bool)]
 
 #[flux::assume]
 #[flux::sig(fn(x:i32) -> bool[valid(x)])]

--- a/flux-tests/tests/pos/surface/uif01.rs
+++ b/flux-tests/tests/pos/surface/uif01.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::ufn(foo(int, int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]


### PR DESCRIPTION
... to make it more symmetric with the `dfn` syntax.

A more aggressive/ uniform thing would be to write

1. `flux::fn(name(x1:t1...) -> t)` for **uninterpreted** functions
2. `flux::fn(name(x1:t1...) -> t { e }` for **defined** (inlined) functions   