### PR TITLE
Unify `ufn` and `dfn` into `def`

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -62,10 +62,16 @@ pub fn resolve_defn_uif(
 
 pub fn resolve_uif_def(
     sess: &FluxSession,
-    uif_def: surface::UifDef,
+    defn: surface::UifDef,
 ) -> Result<fhir::UifDef, ErrorGuaranteed> {
-    let sort = resolve_func_sort(sess, &uif_def.inputs, &uif_def.output)?;
-    Ok(fhir::UifDef { name: uif_def.name.name, sort })
+    let inputs: Vec<surface::Ident> = defn
+        .args
+        .iter()
+        .map(|arg| sort_ident(&arg.sort))
+        .try_collect_exhaust()?;
+    let output: surface::Ident = sort_ident(&defn.sort)?;
+    let sort = resolve_func_sort(sess, &inputs[..], &output)?;
+    Ok(fhir::UifDef { name: defn.name.name, sort })
 }
 
 pub fn desugar_adt_def(

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -6,8 +6,8 @@ use flux_common::{
 };
 use flux_errors::{FluxSession, ResultExt};
 use flux_syntax::{
-    parse_defn, parse_expr, parse_fn_surface_sig, parse_qualifier, parse_refined_by, parse_ty,
-    parse_type_alias, parse_uif_def, parse_variant, surface, ParseResult,
+    parse_def, parse_expr, parse_fn_surface_sig, parse_qualifier, parse_refined_by, parse_ty,
+    parse_type_alias, parse_variant, surface, ParseResult,
 };
 use itertools::Itertools;
 use rustc_ast::{
@@ -324,13 +324,12 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 let qualifer = self.parse(tokens.clone(), span.entire(), parse_qualifier)?;
                 FluxAttrKind::Qualifier(qualifer)
             }
-            ("dfn", MacArgs::Delimited(span, _, tokens)) => {
-                let defn = self.parse(tokens.clone(), span.entire(), parse_defn)?;
-                FluxAttrKind::Defn(defn)
-            }
-            ("ufn", MacArgs::Delimited(span, _, tokens)) => {
-                let uif_def = self.parse(tokens.clone(), span.entire(), parse_uif_def)?;
-                FluxAttrKind::UifDef(uif_def)
+            ("def", MacArgs::Delimited(span, _, tokens)) => {
+                let def = self.parse(tokens.clone(), span.entire(), parse_def)?;
+                match def {
+                    surface::Def::Defn(defn) => FluxAttrKind::Defn(defn),
+                    surface::Def::UifDef(uif_def) => FluxAttrKind::UifDef(uif_def),
+                }
             }
             ("cfg", MacArgs::Delimited(_, _, _)) => {
                 let crate_cfg = FluxAttrCFG::parse_cfg(attr_item)

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -53,12 +53,8 @@ pub fn parse_qualifier(tokens: TokenStream, span: Span) -> ParseResult<surface::
     parse!(surface_grammar::QualifierParser, tokens, span)
 }
 
-pub fn parse_defn(tokens: TokenStream, span: Span) -> ParseResult<surface::Defn> {
-    parse!(surface_grammar::DefnParser, tokens, span)
-}
-
-pub fn parse_uif_def(tokens: TokenStream, span: Span) -> ParseResult<surface::UifDef> {
-    parse!(surface_grammar::UifDefParser, tokens, span)
+pub fn parse_def(tokens: TokenStream, span: Span) -> ParseResult<surface::Def> {
+    parse!(surface_grammar::DefParser, tokens, span)
 }
 
 pub fn parse_ty(tokens: TokenStream, span: Span) -> ParseResult<surface::Ty> {

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -17,6 +17,12 @@ pub struct Qualifier {
 }
 
 #[derive(Debug)]
+pub enum Def {
+    Defn(Defn),
+    UifDef(UifDef),
+}
+
+#[derive(Debug)]
 pub struct Defn {
     pub name: Ident,
     pub args: RefinedBy,
@@ -30,9 +36,9 @@ pub struct UifDef {
     /// name of the uninterpreted function
     pub name: Ident,
     /// input sorts
-    pub inputs: Vec<Ident>,
+    pub args: RefinedBy,
     /// output sort
-    pub output: Ident,
+    pub sort: Sort,
     /// definition source position
     pub span: Span,
 }

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -28,29 +28,18 @@ pub RefinedBy: surface::RefinedBy = {
     <lo:@L> <params:Comma<RefineParam>> <hi:@R> => surface::RefinedBy { params, span: mk_span(lo, hi) }
 }
 
-pub UifDef: surface::UifDef = {
-    <lo:@L>
-    "fn"
-    <name:Ident>
-    "(" <inputs:Comma<Ident>> ")"
-    "->"
-    <output:Ident>
-    <hi:@R> => {
-        surface::UifDef { name, inputs, output, span: mk_span(lo, hi) }
-    }
-}
-
-pub Defn: surface::Defn = {
+pub Def: surface::Def = {
     <lo:@L>
     <name:Ident>
     "(" <args:RefinedBy> ")"
     "->"
     <sort:Sort>
-    "{"
-    <expr:Expr>
-    "}"
+    <expr: ("{" <Expr> "}")?>
     <hi:@R> => {
-        surface::Defn { name: name, args: args, sort: sort, expr: expr, span: mk_span(lo, hi) }
+        match expr {
+            None => surface::Def::UifDef(surface::UifDef { name, args, sort, span: mk_span(lo, hi) }),
+            Some(expr) => surface::Def::Defn(surface::Defn { name, args, sort, expr, span: mk_span(lo, hi) }),
+        }
     }
 }
 

--- a/flux-tests/tests/neg/error_messages/bad_alias00.rs
+++ b/flux-tests/tests/neg/error_messages/bad_alias00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::def(foo(x:int, y:int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]

--- a/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_ill_formed.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::def(foo(x:int, y:int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x)])] //~ ERROR this function takes 2 refinement parameters but 1 was found

--- a/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
+++ b/flux-tests/tests/neg/error_messages/bad_uif_unresolved.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::def(foo(x:int, y:int) -> int)]
 
 #[flux::sig(fn (i32[fog(10, 20)]) -> i32)] //~ ERROR cannot find value `fog`
 pub fn baz(a: i32) -> i32 {

--- a/flux-tests/tests/neg/error_messages/dfn_cycle.rs
+++ b/flux-tests/tests/neg/error_messages/dfn_cycle.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(even(x: int) -> bool { x == 0 || odd(x-1) })] //~ ERROR cycle
-#![flux::dfn(odd(x: int) -> bool { x == 1 || even(x-1) })]
+#![flux::def(even(x: int) -> bool { x == 0 || odd(x-1) })] //~ ERROR cycle
+#![flux::def(odd(x: int) -> bool { x == 1 || even(x-1) })]
 
 #[flux::sig(fn(x:i32) -> i32[x+1])]
 pub fn test(x: i32) -> i32 {

--- a/flux-tests/tests/neg/error_messages/dfn_err.rs
+++ b/flux-tests/tests/neg/error_messages/dfn_err.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(nat(x: int) -> bool { 0 <= x })]
-#![flux::dfn(bat(x: int) -> int  { 0 <= x })] //~ ERROR mismatched sorts
+#![flux::def(nat(x: int) -> bool { 0 <= x })]
+#![flux::def(bat(x: int) -> int  { 0 <= x })] //~ ERROR mismatched sorts
 
 #[flux::sig(fn(x:i32{nat(x)}) -> i32{v:nat(v, v)})] //~ ERROR this function takes 1 refinement parameters but 2 were found
 pub fn test1(x: i32) -> i32 {

--- a/flux-tests/tests/neg/error_messages/dfn_self_cycle.rs
+++ b/flux-tests/tests/neg/error_messages/dfn_self_cycle.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(sum(n: int) -> int { n + sum(n-1) })] //~ ERROR cycle
+#![flux::def(sum(n: int) -> int { n + sum(n-1) })] //~ ERROR cycle
 
 #[flux::sig(fn(x:i32) -> i32[x+1])]
 pub fn test(x: i32) -> i32 {

--- a/flux-tests/tests/neg/surface/date.rs
+++ b/flux-tests/tests/neg/surface/date.rs
@@ -1,13 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(is_btwn(v:int, lo:int, hi: int) -> bool { lo <= v && v <= hi })]
-#![flux::dfn(ok_day(d:int) -> bool { is_btwn(d, 1, 31) })]
-#![flux::dfn(is_month30(m:int) -> bool { m == 4 || m == 6 || m == 9 || m == 11 })]
-#![flux::dfn(ok_month(d:int, m:int) -> bool { is_btwn(m, 1, 12) && (is_month30(m) => d <= 30) })]
-#![flux::dfn(is_leap_year(y:int) -> bool { y % 400 == 0 || (y % 4 == 0 && (y % 100) > 0) })]
-#![flux::dfn(is_feb_day(d:int, y:int) -> bool { d <= 29 && ( d == 29 => is_leap_year(y) ) })]
-#![flux::dfn(ok_year(d:int, m:int, y:int) -> bool { 1 <= y && (m == 2 => is_feb_day(d, y)) })]
+#![flux::def(is_btwn(v:int, lo:int, hi: int) -> bool { lo <= v && v <= hi })]
+#![flux::def(ok_day(d:int) -> bool { is_btwn(d, 1, 31) })]
+#![flux::def(is_month30(m:int) -> bool { m == 4 || m == 6 || m == 9 || m == 11 })]
+#![flux::def(ok_month(d:int, m:int) -> bool { is_btwn(m, 1, 12) && (is_month30(m) => d <= 30) })]
+#![flux::def(is_leap_year(y:int) -> bool { y % 400 == 0 || (y % 4 == 0 && (y % 100) > 0) })]
+#![flux::def(is_feb_day(d:int, y:int) -> bool { d <= 29 && ( d == 29 => is_leap_year(y) ) })]
+#![flux::def(ok_year(d:int, m:int, y:int) -> bool { 1 <= y && (m == 2 => is_feb_day(d, y)) })]
 
 // https://github.com/chrisdone/sandbox/blob/master/liquid-haskell-dates.hs
 

--- a/flux-tests/tests/neg/surface/ealias00.rs
+++ b/flux-tests/tests/neg/surface/ealias00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(nat(x: int) -> bool { 0 <= x })]
+#![flux::def(nat(x: int) -> bool { 0 <= x })]
 
 #[flux::sig(fn(x:i32{nat(x)}) -> i32{v:nat(v)})]
 pub fn test1(x: i32) -> i32 {

--- a/flux-tests/tests/neg/surface/ealias01.rs
+++ b/flux-tests/tests/neg/surface/ealias01.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(leq(x: int, y: int) -> bool { x <= y })]
-#![flux::dfn(nat(x: int) -> bool { leq(0,x) })]
+#![flux::def(leq(x: int, y: int) -> bool { x <= y })]
+#![flux::def(nat(x: int) -> bool { leq(0,x) })]
 
 #[flux::alias(type Nat() = i32{v:nat(v)})]
 type _Nat = i32;

--- a/flux-tests/tests/neg/surface/ealias02.rs
+++ b/flux-tests/tests/neg/surface/ealias02.rs
@@ -1,9 +1,9 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(nat(x: int) -> bool { leq(0, x) })]
-#![flux::dfn(leq(x: int, y: int) -> bool { x <= y })]
-#![flux::dfn(inc(x: int) -> int { x + 1 })]
+#![flux::def(nat(x: int) -> bool { leq(0, x) })]
+#![flux::def(leq(x: int, y: int) -> bool { x <= y })]
+#![flux::def(inc(x: int) -> int { x + 1 })]
 
 #[flux::alias(type Nat() = i32{v: nat(v)})]
 type _Nat = i32;

--- a/flux-tests/tests/neg/surface/uif00.rs
+++ b/flux-tests/tests/neg/surface/uif00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn valid(int) -> bool)]
+#![flux::def(valid(x:int) -> bool)]
 
 #[flux::assume]
 #[flux::sig(fn(x:i32) -> bool[valid(x)])]

--- a/flux-tests/tests/neg/surface/uif01.rs
+++ b/flux-tests/tests/neg/surface/uif01.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::def(foo(x:int, y:int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]

--- a/flux-tests/tests/pos/surface/date.rs
+++ b/flux-tests/tests/pos/surface/date.rs
@@ -1,13 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(is_btwn(v:int, lo:int, hi: int) -> bool { lo <= v && v <= hi })]
-#![flux::dfn(ok_day(d:int) -> bool { is_btwn(d, 1, 31) })]
-#![flux::dfn(is_month30(m:int) -> bool { m == 4 || m == 6 || m == 9 || m == 11 })]
-#![flux::dfn(ok_month(d:int, m:int) -> bool { is_btwn(m, 1, 12) && (is_month30(m) => d <= 30) })]
-#![flux::dfn(is_leap_year(y:int) -> bool { y % 400 == 0 || (y % 4 == 0 && (y % 100) > 0) })]
-#![flux::dfn(is_feb_day(d:int, y:int) -> bool { d <= 29 && ( d == 29 => is_leap_year(y) ) })]
-#![flux::dfn(ok_year(d:int, m:int, y:int) -> bool { 1 <= y && (m == 2 => is_feb_day(d, y)) })]
+#![flux::def(is_btwn(v:int, lo:int, hi: int) -> bool { lo <= v && v <= hi })]
+#![flux::def(ok_day(d:int) -> bool { is_btwn(d, 1, 31) })]
+#![flux::def(is_month30(m:int) -> bool { m == 4 || m == 6 || m == 9 || m == 11 })]
+#![flux::def(ok_month(d:int, m:int) -> bool { is_btwn(m, 1, 12) && (is_month30(m) => d <= 30) })]
+#![flux::def(is_leap_year(y:int) -> bool { y % 400 == 0 || (y % 4 == 0 && (y % 100) > 0) })]
+#![flux::def(is_feb_day(d:int, y:int) -> bool { d <= 29 && ( d == 29 => is_leap_year(y) ) })]
+#![flux::def(ok_year(d:int, m:int, y:int) -> bool { 1 <= y && (m == 2 => is_feb_day(d, y)) })]
 
 // https://github.com/chrisdone/sandbox/blob/master/liquid-haskell-dates.hs
 

--- a/flux-tests/tests/pos/surface/ealias00.rs
+++ b/flux-tests/tests/pos/surface/ealias00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(nat(x: int) -> bool { 0 <= x })]
+#![flux::def(nat(x: int) -> bool { 0 <= x })]
 
 #[flux::sig(fn(x:i32{nat(x)}) -> i32{v:nat(v)})]
 pub fn test1(x: i32) -> i32 {

--- a/flux-tests/tests/pos/surface/ealias01.rs
+++ b/flux-tests/tests/pos/surface/ealias01.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(leq(x: int, y: int) -> bool { x <= y })]
-#![flux::dfn(nat(x: int) -> bool { leq(0,x) })]
+#![flux::def(leq(x: int, y: int) -> bool { x <= y })]
+#![flux::def(nat(x: int) -> bool { leq(0,x) })]
 
 #[flux::alias(type Nat() = i32{v:nat(v)})]
 type _Nat = i32;

--- a/flux-tests/tests/pos/surface/ealias02.rs
+++ b/flux-tests/tests/pos/surface/ealias02.rs
@@ -1,9 +1,9 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::dfn(nat(x: int) -> bool { leq(0, x) })]
-#![flux::dfn(leq(x: int, y: int) -> bool { x <= y })]
-#![flux::dfn(inc(x: int) -> int { x + 1 })]
+#![flux::def(nat(x: int) -> bool { leq(0, x) })]
+#![flux::def(leq(x: int, y: int) -> bool { x <= y })]
+#![flux::def(inc(x: int) -> int { x + 1 })]
 
 #[flux::alias(type Nat() = i32{v: nat(v)})]
 type _Nat = i32;

--- a/flux-tests/tests/pos/surface/uif00.rs
+++ b/flux-tests/tests/pos/surface/uif00.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn valid(int) -> bool)]
+#![flux::def(valid(x:int) -> bool)]
 
 #[flux::assume]
 #[flux::sig(fn(x:i32) -> bool[valid(x)])]

--- a/flux-tests/tests/pos/surface/uif01.rs
+++ b/flux-tests/tests/pos/surface/uif01.rs
@@ -1,7 +1,7 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::ufn(fn foo(int, int) -> int)]
+#![flux::def(foo(x:int, y:int) -> int)]
 
 #[flux::assume]
 #[flux::sig(fn(x: i32, y:i32) -> i32[foo(x, y)])]


### PR DESCRIPTION
Supersedes #265 

With this PR you write

```rust
// for uninterpreted functions
#![flux::def(name(x1:t1...) -> t)] 

// for defined functions
#![flux::def(name(x1:t1...) -> t { e }] 
```

bit unfortunate we can't use `fn` -- that seems to mess up the syntax highlighting...