### PR TITLE
Check Target

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 See the [blog](https://liquid-rust.github.io/) for details on refinement types and rust.
 
-
 ## Requirements
 
 - [rustup](https://rustup.rs/)

--- a/flux-common/src/config.rs
+++ b/flux-common/src/config.rs
@@ -42,7 +42,7 @@ pub struct Config {
     pub check_asserts: AssertBehavior,
     pub dump_mir: bool,
     pub pointer_width: u64,
-    pub unsound_incremental: bool,
+    pub check_target: String,
 }
 
 pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
@@ -55,7 +55,7 @@ pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("check_asserts", "assume")?
             .set_default("check_asserts", "assume")?
             .set_default("pointer_width", 64)?
-            .set_default("unsound_incremental", false)?
+            .set_default("check_target", "")?
             .add_source(Environment::with_prefix("LR").ignore_empty(true))
             .build()?
             .try_deserialize()

--- a/flux-common/src/config.rs
+++ b/flux-common/src/config.rs
@@ -42,7 +42,7 @@ pub struct Config {
     pub check_asserts: AssertBehavior,
     pub dump_mir: bool,
     pub pointer_width: u64,
-    pub check_target: String,
+    pub check_def: String,
 }
 
 pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
@@ -55,7 +55,7 @@ pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("check_asserts", "assume")?
             .set_default("check_asserts", "assume")?
             .set_default("pointer_width", 64)?
-            .set_default("check_target", "")?
+            .set_default("check_def", "")?
             .add_source(Environment::with_prefix("LR").ignore_empty(true))
             .build()?
             .try_deserialize()

--- a/flux-common/src/config.rs
+++ b/flux-common/src/config.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub check_asserts: AssertBehavior,
     pub dump_mir: bool,
     pub pointer_width: u64,
+    pub unsound_incremental: bool,
 }
 
 pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
@@ -54,6 +55,7 @@ pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("check_asserts", "assume")?
             .set_default("check_asserts", "assume")?
             .set_default("pointer_width", 64)?
+            .set_default("unsound_incremental", false)?
             .add_source(Environment::with_prefix("LR").ignore_empty(true))
             .build()?
             .try_deserialize()

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -1,4 +1,4 @@
-use flux_common::iter::IterExt;
+use flux_common::{config::CONFIG, iter::IterExt};
 use flux_desugar as desugar;
 use flux_errors::FluxSession;
 use flux_middle::{
@@ -131,8 +131,15 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         }
     }
 
+    fn is_target(&self, def_id: LocalDefId) -> bool {
+        let def_id_str = format!("{def_id:?}");
+        let res = def_id_str.contains(&CONFIG.check_target);
+        println!("TRACE: is_target {def_id:?} = {res}");
+        res
+    }
+
     fn check_def(&self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        if self.is_ignored(def_id) {
+        if self.is_ignored(def_id) || !self.is_target(def_id) {
             return Ok(());
         }
 
@@ -144,7 +151,6 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
     }
 
     fn check_fn(&self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        println!("TRACE: incremental check {def_id:?}");
         if self.is_assumed(def_id) {
             return Ok(());
         }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -132,10 +132,7 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
     }
 
     fn is_target(&self, def_id: LocalDefId) -> bool {
-        let def_id_str = format!("{def_id:?}");
-        let res = def_id_str.contains(&CONFIG.check_target);
-        println!("TRACE: is_target {def_id:?} = {res}");
-        res
+        format!("{def_id:?}").contains(&CONFIG.check_target)
     }
 
     fn check_def(&self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -132,7 +132,8 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
     }
 
     fn is_target(&self, def_id: LocalDefId) -> bool {
-        format!("{def_id:?}").contains(&CONFIG.check_target)
+        let def_path = self.genv.tcx.def_path_str(def_id.to_def_id());
+        def_path.contains(&CONFIG.check_def)
     }
 
     fn check_def(&self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -144,6 +144,7 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
     }
 
     fn check_fn(&self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
+        println!("TRACE: incremental check {def_id:?}");
         if self.is_assumed(def_id) {
             return Ok(());
         }

--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -1,11 +1,14 @@
 mod logger;
 use std::{env, io, process::exit};
 
+use flux_common::config::CONFIG;
+
 const CMD_RUSTC: &str = "rustc";
 
 fn main() -> io::Result<()> {
     logger::install()?;
 
+    println!("TRACE: unsound_incr = {}", CONFIG.unsound_incremental);
     // HACK(nilehmann)
     // * Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument. We igore the
     //   argument and use it to determine if the binary is being called from cargo.
@@ -17,7 +20,7 @@ fn main() -> io::Result<()> {
     for arg in env::args() {
         if arg.starts_with("-C") || arg.starts_with("--codegen") {
             is_codegen = true;
-        } else if is_codegen && arg.starts_with("incremental=") {
+        } else if is_codegen && arg.starts_with("incremental=") && !CONFIG.unsound_incremental {
             is_codegen = false;
         } else {
             if is_codegen {

--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -8,7 +8,6 @@ const CMD_RUSTC: &str = "rustc";
 fn main() -> io::Result<()> {
     logger::install()?;
 
-    println!("TRACE: unsound_incr = {}", CONFIG.unsound_incremental);
     // HACK(nilehmann)
     // * Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument. We igore the
     //   argument and use it to determine if the binary is being called from cargo.
@@ -20,7 +19,7 @@ fn main() -> io::Result<()> {
     for arg in env::args() {
         if arg.starts_with("-C") || arg.starts_with("--codegen") {
             is_codegen = true;
-        } else if is_codegen && arg.starts_with("incremental=") && !CONFIG.unsound_incremental {
+        } else if is_codegen && arg.starts_with("incremental=") {
             is_codegen = false;
         } else {
             if is_codegen {
@@ -34,7 +33,6 @@ fn main() -> io::Result<()> {
             }
         }
     }
-
     let exit_code = flux_driver::run_compiler(args, in_cargo);
     // Exit with the exit code returned by the compiler.
     exit(exit_code)

--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -1,8 +1,6 @@
 mod logger;
 use std::{env, io, process::exit};
 
-use flux_common::config::CONFIG;
-
 const CMD_RUSTC: &str = "rustc";
 
 fn main() -> io::Result<()> {


### PR DESCRIPTION
Adds an env-variable `LR_CHECK_TARGET=str` which focuses checking on `DefId` that contain `str` as a substring (so by default, `""` which checks everything.)

Rationale below (**11.56s vs 1.68s**)

```
rjhala@pozole ~/r/flux-wave (main) [101]> time RUSTFLAGS=-Awarnings cargo-flux check
   Compiling libc v0.2.138
   Compiling paste v1.0.11
    Checking flux-wave v0.1.0 (/Users/rjhala/research/flux-wave)
error[FLUX]: precondition might not hold
   --> src/os/mod.rs:550:13
    |
550 |     let r = os_futimens(os_fd, specs);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `flux-wave` due to previous error

________________________________________________________
Executed in   11.56 secs    fish           external
   usr time   13.76 secs    5.64 millis   13.76 secs
   sys time    0.90 secs    2.16 millis    0.90 secs
```

vs. with a specific target

```
$ time RUSTFLAGS=-Awarnings LR_CHECK_TARGET=futimens cargo-flux check
   Compiling libc v0.2.138
   Compiling paste v1.0.11
    Checking flux-wave v0.1.0 (/Users/rjhala/research/flux-wave)
error[FLUX]: precondition might not hold
   --> src/os/mod.rs:550:13
    |
550 |     let r = os_futimens(os_fd, specs);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `flux-wave` due to previous error

________________________________________________________
Executed in    1.68 secs    fish           external
   usr time    4.20 secs  195.00 micros    4.20 secs
   sys time    0.27 secs  806.00 micros    0.27 secs
```