### PR TITLE
Generate at least one kvar

### DIFF
--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -307,13 +307,8 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Slice(ty) => rty::BaseTy::Slice(self.refine_ty(ty, mk_pred)),
             rustc::ty::TyKind::Char => rty::BaseTy::Char,
         };
-        let sorts = bty.sorts();
-        if sorts.is_empty() {
-            rty::Ty::indexed(bty, rty::RefineArgs::empty())
-        } else {
-            let pred = mk_pred(sorts);
-            rty::Ty::exists(bty, pred)
-        }
+        let pred = mk_pred(bty.sorts());
+        rty::Ty::exists(bty, pred)
     }
 
     pub fn refine_generic_arg(

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -680,7 +680,6 @@ impl Pred {
     /// predicates when pretty printing but also to avoid adding unnecesary predicates to the constraint.
     pub fn is_trivially_true(&self) -> bool {
         matches!(self, Pred::Expr(e) if e.is_true())
-            || matches!(self, Pred::Kvar(kvar) if kvar.args.is_empty())
             || matches!(self, Pred::And(preds) if preds.is_empty())
     }
 

--- a/flux-tests/tests/neg/surface/issue-271.rs
+++ b/flux-tests/tests/neg/surface/issue-271.rs
@@ -1,0 +1,20 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub struct S;
+
+#[flux::sig(fn(x: u32) -> Result<{S: x < 100}, bool>)]
+pub fn test01(x: u32) -> Result<S, bool> {
+    if x > 100 {
+        return Err(false);
+    }
+    Ok(S) //~ ERROR postcondition
+}
+
+#[flux::sig(fn(x: u32) -> Option<{S: x < 100}>)]
+pub fn test02(x: u32) -> Option<S> {
+    if x > 100 {
+        return None;
+    }
+    Some(S) //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/issue-271.rs
+++ b/flux-tests/tests/pos/surface/issue-271.rs
@@ -1,0 +1,20 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+pub struct S;
+
+#[flux::sig(fn(x:u32) -> Result<{S: x < 100}, bool>)]
+pub fn test01(x: u32) -> Result<S, bool> {
+    if x >= 100 {
+        return Err(false);
+    }
+    Ok(S)
+}
+
+#[flux::sig(fn(x:u32) -> Option<{S: x < 100}>)]
+pub fn test02(x: u32) -> Option<S> {
+    if x >= 100 {
+        return None;
+    }
+    Some(S)
+}

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -239,6 +239,17 @@ where
             .collect_vec();
 
         let kvids = &self.kvid_map[&kvar.kvid];
+
+        if all_args.is_empty() {
+            let fresh = self.fresh_name();
+            bindings.push((
+                fresh,
+                fixpoint::Sort::Unit,
+                fixpoint::Expr::eq(fixpoint::Expr::Var(fresh), fixpoint::Expr::Unit),
+            ));
+            return fixpoint::Pred::KVar(kvids[0], vec![fresh]);
+        }
+
         let kvars = kvids
             .iter()
             .enumerate()
@@ -249,6 +260,36 @@ where
             .collect_vec();
 
         fixpoint::Pred::And(kvars)
+    }
+
+    fn populate_kvid_map(&mut self, kvid: rty::KVid) {
+        self.kvid_map.entry(kvid).or_insert_with(|| {
+            let decl = self.kvars.get(kvid);
+
+            let all_args = decl.all_args().map(sort_to_fixpoint).collect_vec();
+
+            if all_args.len() == 0 {
+                let sorts = vec![fixpoint::Sort::Unit];
+                let kvid = self.fixpoint_kvars.push(sorts);
+                return vec![kvid];
+            }
+
+            match decl.encoding {
+                KVarEncoding::Single => {
+                    let kvid = self.fixpoint_kvars.push(all_args);
+                    vec![kvid]
+                }
+                KVarEncoding::Conj => {
+                    let n = usize::max(decl.args.len(), 1);
+                    (0..n)
+                        .map(|i| {
+                            let sorts = all_args.iter().skip(n - i - 1).cloned().collect();
+                            self.fixpoint_kvars.push(sorts)
+                        })
+                        .collect_vec()
+                }
+            }
+        });
     }
 
     fn imm(
@@ -267,43 +308,14 @@ where
             rty::ExprKind::BoundVar(_) => panic!("unexpected free bound variable"),
             _ => {
                 let fresh = self.fresh_name();
-                let pred = fixpoint::Expr::BinaryOp(
-                    fixpoint::BinOp::Eq,
-                    Box::new([
-                        fixpoint::Expr::Var(fresh),
-                        expr_to_fixpoint(arg, &self.name_map, &self.const_map),
-                    ]),
+                let pred = fixpoint::Expr::eq(
+                    fixpoint::Expr::Var(fresh),
+                    expr_to_fixpoint(arg, &self.name_map, &self.const_map),
                 );
                 bindings.push((fresh, sort_to_fixpoint(sort), pred));
                 fresh
             }
         }
-    }
-
-    fn populate_kvid_map(&mut self, kvid: rty::KVid) {
-        self.kvid_map.entry(kvid).or_insert_with(|| {
-            let decl = self.kvars.get(kvid);
-
-            let all_args = decl.all_args().map(sort_to_fixpoint).collect_vec();
-            match decl.encoding {
-                KVarEncoding::Single => {
-                    let kvid = self.fixpoint_kvars.push(all_args);
-                    vec![kvid]
-                }
-                KVarEncoding::Conj => {
-                    (0..decl.args.len())
-                        .map(|i| {
-                            let sorts = all_args
-                                .iter()
-                                .skip(decl.args.len() - i - 1)
-                                .cloned()
-                                .collect();
-                            self.fixpoint_kvars.push(sorts)
-                        })
-                        .collect_vec()
-                }
-            }
-        });
     }
 }
 


### PR DESCRIPTION
When mapping a kvar with `KVarEncoding::Conj` that has no self-arguments, generate at least one kvar with the first variable in the scope as the self-argument. In this way a refinement on a type with zero indices can still constraint variables in scope (in particular a kvar can be solved to false). In the special case where both the scope and self-arguments are empty, generate a kvar with a single unit argument.

fixes #271 