### PR TITLE
Parse nested types

### DIFF
--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -1,4 +1,4 @@
-use std::iter::Peekable;
+use std::{collections::VecDeque, iter::Peekable};
 
 pub use rustc_ast::token::{BinOpToken, Delimiter, Lit, LitKind};
 use rustc_ast::{
@@ -27,6 +27,7 @@ pub enum Token {
     Le,
     Ne,
     Gt,
+    GtFollowedByGt,
     Ge,
     At,
     Fn,
@@ -57,6 +58,7 @@ pub(crate) struct Cursor {
     stack: Vec<Frame>,
     offset: BytePos,
     symbs: Symbols,
+    tokens: VecDeque<(Location, Token, Location)>,
 }
 
 struct Symbols {
@@ -80,6 +82,7 @@ impl Cursor {
         Cursor {
             stack: vec![Frame { cursor: stream.into_trees().peekable(), close: None }],
             offset,
+            tokens: VecDeque::new(),
             symbs: Symbols {
                 fn_: Symbol::intern("fn"),
                 ref_: Symbol::intern("ref"),
@@ -90,7 +93,7 @@ impl Cursor {
         }
     }
 
-    fn map_token(&self, token: token::Token) -> (Location, Token, Location) {
+    fn map_token(&mut self, token: token::Token) {
         let span = token.span;
         let token = match token.kind {
             TokenKind::Lt => Token::Lt,
@@ -132,17 +135,23 @@ impl Cursor {
             TokenKind::BinOp(BinOpToken::And) => Token::And,
             TokenKind::BinOp(BinOpToken::Percent) => Token::Percent,
             TokenKind::BinOp(BinOpToken::Star) => Token::Star,
+            TokenKind::BinOp(BinOpToken::Shr) => {
+                self.push_token(span.lo(), Token::GtFollowedByGt, span.hi() - BytePos(1));
+                self.push_token(span.lo() + BytePos(1), Token::Gt, span.hi());
+                return;
+            }
             TokenKind::Not => Token::Not,
             _ => Token::Invalid,
         };
-        (Location(span.lo() - self.offset), token, Location(span.hi() - self.offset))
+        self.push_token(span.lo(), token, span.hi())
     }
-}
 
-impl Iterator for Cursor {
-    type Item = (Location, Token, Location);
+    fn push_token(&mut self, lo: BytePos, token: Token, hi: BytePos) {
+        self.tokens
+            .push_back((Location(lo - self.offset), token, Location(hi - self.offset)))
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn advance(&mut self) -> Option<()> {
         let top = self.stack.last_mut()?;
 
         match top.cursor.next() {
@@ -153,12 +162,13 @@ impl Iterator for Cursor {
                             let lo = Location(token.span.lo() - self.offset);
                             let hi = Location(next.span.hi() - self.offset);
                             top.cursor.next();
-                            return Some((lo, Token::Iff, hi));
+                            self.tokens.push_back((lo, Token::Iff, hi));
+                            return Some(());
                         }
                         _ => {}
                     }
                 }
-                Some(self.map_token(token))
+                self.map_token(token)
             }
             Some(TokenTree::Delimited(span, delim, tokens)) => {
                 let close = (
@@ -169,10 +179,22 @@ impl Iterator for Cursor {
                 self.stack
                     .push(Frame { cursor: tokens.into_trees().peekable(), close: Some(close) });
                 let token = token::Token { kind: TokenKind::OpenDelim(delim), span: span.open };
-                Some(self.map_token(token))
+                self.map_token(token)
             }
-            None => self.stack.pop().unwrap().close,
+            None => self.tokens.push_back(self.stack.pop()?.close?),
         }
+        Some(())
+    }
+}
+
+impl Iterator for Cursor {
+    type Item = (Location, Token, Location);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.tokens.is_empty() {
+            self.advance();
+        }
+        self.tokens.pop_front()
     }
 }
 

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -69,7 +69,7 @@ pub FnSig: surface::FnSig = {
     <params:("<" <Comma<RefineParam>> ">")?>
     "(" <args:Args> ")"
     <returns:("->" <Ty>)?>
-    <requires:("requires" <Level1>)?>
+    <requires:("requires" <Expr>)?>
     <ensures:("ensures" <Ensures>)?>
     <hi:@R>
     => {
@@ -111,7 +111,7 @@ Ensures = <Comma<(<Ident> ":" <Ty>)>>;
 
 Arg: surface::Arg = {
     <bind:Ident> ":" "&" "strg" <ty:Ty>                    => surface::Arg::StrgRef(<>),
-    <bind:Ident> ":" <path:Path> "{" <pred:Level1> "}"     => surface::Arg::Constr(<>),
+    <bind:Ident> ":" <path:Path> "{" <pred:Expr> "}"     => surface::Arg::Constr(<>),
     <bind:Ident> ":" <path:Path> "[" <indices:Indices> "]" => surface::Arg::Alias(<>),
     <bind:Ident> ":" <lo:@L> <kind:ArgTyKind> <hi:@R> => {
         let ty = surface::Ty { kind, span: mk_span(lo, hi) };
@@ -129,13 +129,10 @@ pub Ty: surface::Ty = {
 
 // FIXME(nilehmann) We can't parse all types using the `x: T` syntax because it conflicts with aliases.
 ArgTyKind: surface::TyKind = {
-
     "(" <tys:Comma<Ty>> ")"  => surface::TyKind::Tuple(tys),
-
     "&"       <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),
     "&" "mut" <ty:Ty> => surface::TyKind::Ref(surface::RefKind::Mut, Box::new(ty)),
-
-    "{" <ty:Ty> ":" <pred:Level1> "}" => surface::TyKind::Constr(pred, Box::new(ty)),
+    "{" <ty:Ty> ":" <pred:Expr> "}" => surface::TyKind::Constr(pred, Box::new(ty)),
     "[" <ty:Ty> ";" <lo:@L> <lit:Lit> <hi:@R> "]" =>? {
         let span = mk_span(lo, hi);
         if let surface::LitKind::Integer = lit.kind && let Ok(val) = lit.symbol.as_str().parse::<usize>() {
@@ -144,17 +141,14 @@ ArgTyKind: surface::TyKind = {
             Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
         }
     },
-    <bty:BaseTy>                                        => surface::TyKind::Base(<>),
-    <bty:BaseTy> "{" <bind:Ident> ":" <pred:Level1> "}" => surface::TyKind::Exists { <> },
+    <bty:BaseTy>                                      => surface::TyKind::Base(<>),
+    <bty:BaseTy> "{" <bind:Ident> ":" <pred:Expr> "}" => surface::TyKind::Exists { <> },
 }
 
 #[inline]
 BaseTy: surface::BaseTy = {
-
-    <path:Path>                                        => surface::BaseTy::Path(<>),
-
+    <path:Path>     => surface::BaseTy::Path(<>),
     "[" <ty:Ty> "]" => surface::BaseTy::Slice(Box::new(ty)),
-
 }
 
 TyKind: surface::TyKind = {
@@ -163,7 +157,8 @@ TyKind: surface::TyKind = {
 }
 
 GenericArgs: Vec<surface::Ty> = {
-    "<" <Comma<Ty>> ">"
+    "<" <Comma<Ty>> ">",
+    "<" <Comma<Ty>> ">(?=>)",
 }
 
 Path: surface::Path = {
@@ -189,8 +184,8 @@ Indices: surface::Indices = {
 };
 
 RefineArg: surface::RefineArg = {
-    <lo:@L> "@" <bind:Ident> <hi:@R>               => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
-    <Expr>                                         => surface::RefineArg::Expr(<>),
+    <lo:@L> "@" <bind:Ident> <hi:@R> => surface::RefineArg::Bind(bind, mk_span(lo, hi)),
+    <Expr>                           => surface::RefineArg::Expr(<>),
     <lo:@L> "|"<params: Comma<Ident>> "|" <body:Expr> <hi:@R> => {
         surface::RefineArg::Abs(params, body, mk_span(lo, hi))
     }
@@ -203,18 +198,19 @@ Level2 = LeftAssoc<BinOp2, Level3>; // =>
 Level3 = LeftAssoc<BinOp3, Level4>; // ||
 Level4 = LeftAssoc<BinOp4, Level5>; // &&
 Level5 = NonAssoc<BinOp5, Level6>;  // ==, !=, >=, <=
-Level6 = LeftAssoc<BinOp6, Level7>; // +, -
-Level7 = LeftAssoc<BinOp7, Level8>; // *, %
-Level8 = {
-    <lo:@L> <op:UnOp> <e:Level9> <hi:@R> => {
+Level6 = LeftAssoc<BinOp6, Level7>; // >>, <<
+Level7 = LeftAssoc<BinOp7, Level8>; // +, -
+Level8 = LeftAssoc<BinOp8, Level9>; // *, %
+Level9 = {
+    <lo:@L> <op:UnOp> <e:Level10> <hi:@R> => {
         surface::Expr {
             kind: surface::ExprKind::UnaryOp(op, Box::new(e)),
             span: mk_span(lo, hi),
         }
     },
-    <Level9>
+    <Level10>
 }
-Level9: surface::Expr = {
+Level10: surface::Expr = {
     <lo:@L> "if" <p:Level1> "{" <e1:Level1> "}" "else" "{" <e2:Level1> "}" <hi:@R> => {
         surface::Expr {
             kind: surface::ExprKind::IfThenElse(Box::new([p, e1, e2])),
@@ -293,11 +289,18 @@ BinOp5: surface::BinOp = {
 }
 
 BinOp6: surface::BinOp = {
+    // TODO(nilehmann) return right shift operator when we support it
+    <lo:@L> ">(?=>)" ">" <hi:@R> =>? {
+        Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
+    }
+}
+
+BinOp7: surface::BinOp = {
     "+" => surface::BinOp::Add,
     "-" => surface::BinOp::Sub,
 }
 
-BinOp7: surface::BinOp = {
+BinOp8: surface::BinOp = {
     "*" => surface::BinOp::Mul,
     "%" => surface::BinOp::Mod,
 }
@@ -373,6 +376,7 @@ extern {
         "<"  => Token::Lt,
         "<=" => Token::Le,
         ">"  => Token::Gt,
+        ">(?=>)"  => Token::GtFollowedByGt,
         ">=" => Token::Ge,
         ":"  => Token::Colon,
         "."  => Token::Dot,

--- a/flux-tests/tests/neg/surface/issue-258.rs
+++ b/flux-tests/tests/neg/surface/issue-258.rs
@@ -1,0 +1,26 @@
+#![feature(register_tool, custom_inner_attributes)]
+#![register_tool(flux)]
+
+struct S<T> {
+    f: T,
+}
+
+#[flux::sig(fn() -> S<i32{v: v > 0}>)]
+fn test00() -> S<i32> {
+    S { f: 0 } //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> S<S<i32{v: v > 0}>>)]
+fn test01() -> S<S<i32>> {
+    S { f: S { f: 0 } } //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> S<S<S<i32{v: v > 0}>>>)]
+fn test02() -> S<S<S<i32>>> {
+    S { f: S { f: S { f: 0 } } } //~ ERROR postcondition
+}
+
+#[flux::sig(fn() -> S<S<S<S<i32{v: v > 0}>>>>)]
+fn test03() -> S<S<S<S<i32>>>> {
+    S { f: S { f: S { f: S { f: 0 } } } } //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/issue-258.rs
+++ b/flux-tests/tests/pos/surface/issue-258.rs
@@ -1,0 +1,26 @@
+#![feature(register_tool, custom_inner_attributes)]
+#![register_tool(flux)]
+
+struct S<T> {
+    f: T,
+}
+
+#[flux::sig(fn() -> S<i32{v: v > 0}>)]
+fn test00() -> S<i32> {
+    S { f: 1 }
+}
+
+#[flux::sig(fn() -> S<S<i32{v: v > 0}>>)]
+fn test01() -> S<S<i32>> {
+    S { f: S { f: 1 } }
+}
+
+#[flux::sig(fn() -> S<S<S<i32{v: v > 0}>>>)]
+fn test02() -> S<S<S<i32>>> {
+    S { f: S { f: S { f: 1 } } }
+}
+
+#[flux::sig(fn() -> S<S<S<S<i32{v: v > 0}>>>>)]
+fn test03() -> S<S<S<S<i32>>>> {
+    S { f: S { f: S { f: S { f: 1 } } } }
+}


### PR DESCRIPTION
Modify the lexer to break ">>" into two tokens (`Token::GtFollowedByGt` and `Token::Gt`) to be able to parse nested types.

fixes #258