### PR TITLE
Refactor conv

### DIFF
--- a/flux-desugar/src/annot_check.rs
+++ b/flux-desugar/src/annot_check.rs
@@ -318,7 +318,6 @@ impl<'genv, 'tcx> ZipChecker<'genv, 'tcx> {
             }
         });
         iter::zip(args, rust_args)
-            .into_iter()
             .try_for_each_exhaust(|(arg, rust_arg)| self.zip_ty(arg, rust_arg))
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -339,7 +339,7 @@ mod errors {
     impl DefinitionCycle {
         pub(super) fn new(span: Span, cycle: Vec<Symbol>) -> Self {
             let root = format!("`{}`", cycle[0]);
-            let names: Vec<String> = cycle.iter().map(|s| format!("`{}`", s)).collect();
+            let names: Vec<String> = cycle.iter().map(|s| format!("`{s}`")).collect();
             let msg = format!("{} -> {}", names.join(" -> "), root);
             Self { span, msg }
         }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -347,13 +347,11 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
 impl BoundVarEnv {
     fn new(iter: impl IntoIterator<Item = fhir::Name>) -> Self {
-        let layer = iter.into_iter().collect();
-        Self { layers: vec![layer] }
+        Self { layers: vec![iter.into_iter().collect()] }
     }
 
     fn push_layer(&mut self, binders: &[fhir::Name]) {
-        let layer = binders.iter().map(|name| *name).collect();
-        self.layers.push(layer);
+        self.layers.push(binders.iter().copied().collect());
     }
 
     fn pop_layer(&mut self) {

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -169,7 +169,7 @@ pub trait TypeFoldable: Sized {
                     if let RefineArg::Expr(e) = sol {
                         e.clone()
                     } else {
-                        panic!("expected expr for `{expr:?}` but found `{:?}` when substituting", sol)
+                        panic!("expected expr for `{expr:?}` but found `{sol:?}` when substituting")
                     }
                 } else if let ExprKind::App(Func::Var(Var::EVar(evar)), args) = expr.kind()
                     && let Some(sol) = self.0.get(*evar)

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -633,9 +633,10 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_ty::Ty<'tcx>) -> Result<Ty, U
         rustc_ty::Array(ty, len) => {
             // TODO(RJ) https://github.com/liquid-rust/flux/pull/255#discussion_r1052554570
             let param_env = ParamEnv::empty().with_reveal_all_normalized(tcx);
-            let val = len.try_eval_usize(tcx, param_env).unwrap_or_else(|| {
-                panic!("failed to evaluate array length: {len:?} in {ty:?}", len = len, ty = ty)
-            }) as usize;
+            let val = len
+                .try_eval_usize(tcx, param_env)
+                .unwrap_or_else(|| panic!("failed to evaluate array length: {len:?} in {ty:?}"))
+                as usize;
             Ok(Ty::mk_array(lower_ty(tcx, *ty)?, Const { val }))
         }
         rustc_ty::Slice(ty) => Ok(Ty::mk_slice(lower_ty(tcx, *ty)?)),

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -43,8 +43,8 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
-pub fn check<'a, 'tcx>(
-    genv: &GlobalEnv<'a, 'tcx>,
+pub fn check<'tcx>(
+    genv: &GlobalEnv<'_, 'tcx>,
     def_id: DefId,
     body: &Body<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {


### PR DESCRIPTION
* Decouple the environment for bound vars (de Bruijn) and free vars (named), by defining an `ExprConvCtxt` trait
* Avoid threading the number of binders by explicitly tracking _layers_ in the bound variable environment