### PR TITLE
Implement partial existentials

### DIFF
--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -281,7 +281,7 @@ pub struct Ident {
 }
 
 newtype_index! {
-    #[debug_format = "s{}"]
+    #[debug_format = "a{}"]
     pub struct Name {}
 }
 

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -308,7 +308,11 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Char => rty::BaseTy::Char,
         };
         let pred = mk_pred(bty.sorts());
-        rty::Ty::exists(rty::Exists::full(bty, pred))
+        let exists = pred.map(|pred| {
+            let args = rty::RefineArgs::bound(bty.sorts().len());
+            rty::Exists::new(bty, args, pred)
+        });
+        rty::Ty::exists(exists)
     }
 
     pub fn refine_generic_arg(

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -308,7 +308,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             rustc::ty::TyKind::Char => rty::BaseTy::Char,
         };
         let pred = mk_pred(bty.sorts());
-        rty::Ty::exists(bty, pred)
+        rty::Ty::exists(rty::Exists::full(bty, pred))
     }
 
     pub fn refine_generic_arg(

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -247,7 +247,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     rty::Ty::indexed(bty, rty::RefineArgs::empty())
                 } else {
                     let pred = rty::Binders::new(rty::Expr::tt(), sorts);
-                    rty::Ty::exists(bty, pred)
+                    rty::Ty::exists(rty::Exists::full(bty, pred))
                 }
             }
             fhir::Ty::Indexed(bty, idxs) => {
@@ -261,7 +261,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     .with_binders(binders, nbinders, |name_map, nbinders| {
                         let pred = name_map.conv_expr(pred, nbinders);
                         let pred = rty::Binders::new(pred, bty.sorts());
-                        rty::Ty::exists(bty, pred)
+                        rty::Ty::exists(rty::Exists::full(bty, pred))
                     })
             }
             fhir::Ty::Ptr(loc) => {

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -238,8 +238,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 } else {
                     self.env.push_layer(&[]);
                     let bty = self.conv_base_ty(bty);
-                    let pred = rty::Binders::new(rty::Expr::tt(), bty.sorts());
-                    let ty = rty::Ty::exists(rty::Exists::full(bty, pred));
+                    let ty = rty::Ty::full_exists(bty, rty::Expr::tt());
                     self.env.pop_layer();
                     ty
                 }
@@ -253,8 +252,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 self.env.push_layer(binders);
                 let bty = self.conv_base_ty(bty);
                 let pred = self.env.conv_expr(pred);
-                let pred = rty::Binders::new(pred, bty.sorts());
-                let ty = rty::Ty::exists(rty::Exists::full(bty, pred));
+                let ty = rty::Ty::full_exists(bty, pred);
                 self.env.pop_layer();
                 ty
             }

--- a/flux-middle/src/rty/evars.rs
+++ b/flux-middle/src/rty/evars.rs
@@ -46,6 +46,12 @@ newtype_index! {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct EVarCxId(u64);
 
+impl EVar {
+    pub fn cx(&self) -> EVarCxId {
+        self.cx
+    }
+}
+
 impl EVarGen {
     pub fn new() -> Self {
         EVarGen { evars: FxHashMap::default() }

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -251,8 +251,8 @@ impl Expr {
     }
 
     /// Simple syntactic check to see if the expression is a trivially true predicate. This is used
-    /// mostly for filtering predicates when pretty printing but also to avoid adding unnecesary
-    /// predicates to the constraint.
+    /// mostly for filtering predicates when pretty printing but also to simplify the constraint
+    /// before encoding it into fixpoint.
     pub fn is_trivially_true(&self) -> bool {
         self.is_true()
             || matches!(self.kind(), ExprKind::BinaryOp(BinOp::Eq | BinOp::Iff | BinOp::Imp, e1, e2) if e1 == e2)

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -254,7 +254,8 @@ impl Expr {
     /// mostly for filtering predicates when pretty printing but also to avoid adding unnecesary
     /// predicates to the constraint.
     pub fn is_trivially_true(&self) -> bool {
-        self.is_true() || self.is_trivial_equality()
+        self.is_true()
+            || matches!(self.kind(), ExprKind::BinaryOp(BinOp::Eq | BinOp::Iff | BinOp::Imp, e1, e2) if e1 == e2)
     }
 
     /// Whether the expression is literally the constant true.
@@ -264,10 +265,6 @@ impl Expr {
 
     pub fn is_binary_op(&self) -> bool {
         matches!(self.kind, ExprKind::BinaryOp(..))
-    }
-
-    pub fn is_trivial_equality(&self) -> bool {
-        matches!(self.kind(), ExprKind::BinaryOp(BinOp::Eq, e1, e2) if e1 == e2)
     }
 
     /// Simplify expression applying some simple rules like removing double negation. This is

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -5,9 +5,9 @@ use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use super::{
-    evars::EVarSol, AdtDef, AdtDefData, BaseTy, Binders, Constraint, Defns, Expr, ExprKind, FnSig,
-    GenericArg, Invariant, KVar, Name, PolySig, Qualifier, RefineArg, RefineArgs, RefineArgsData,
-    Sort, Ty, TyKind, VariantRet,
+    evars::EVarSol, AdtDef, AdtDefData, BaseTy, Binders, Constraint, Defns, Exists, Expr, ExprKind,
+    FnSig, GenericArg, Invariant, KVar, Name, PolySig, Qualifier, RefineArg, RefineArgs,
+    RefineArgsData, Sort, Ty, TyKind, VariantRet,
 };
 use crate::{
     intern::{Internable, Interned, List},
@@ -97,7 +97,7 @@ pub trait TypeFoldable: Sized {
             F: FnMut(&[Sort]) -> Binders<Expr>,
         {
             fn fold_binders<T: TypeFoldable>(&mut self, t: &Binders<T>) -> Binders<T> {
-                t.super_fold_with(&mut ReplaceHoles(&mut self.0, &t.params))
+                t.super_fold_with(&mut ReplaceHoles(&mut *self.0, &t.params))
             }
 
             fn fold_expr(&mut self, e: &Expr) -> Expr {
@@ -125,11 +125,24 @@ pub trait TypeFoldable: Sized {
 
         impl TypeFolder for WithHoles {
             fn fold_ty(&mut self, ty: &Ty) -> Ty {
-                if let TyKind::Indexed(bty, _) | TyKind::Exists(bty, _) = ty.kind() {
-                    let sorts = bty.sorts();
-                    Ty::exists(bty.super_fold_with(self), Binders::new(Expr::hole(), sorts))
-                } else {
-                    ty.super_fold_with(self)
+                match ty.kind() {
+                    TyKind::Indexed(bty, _) => {
+                        let sorts = bty.sorts();
+                        Ty::exists(Exists::full(
+                            bty.fold_with(self),
+                            Binders::new(Expr::hole(), sorts),
+                        ))
+                    }
+                    TyKind::Exists(exists) => {
+                        Ty::exists(exists.as_ref().map(|exists| {
+                            Exists {
+                                bty: exists.bty.fold_with(self),
+                                args: exists.args.fold_with(self),
+                                pred: Expr::hole(),
+                            }
+                        }))
+                    }
+                    _ => ty.super_fold_with(self),
                 }
             }
         }
@@ -298,9 +311,7 @@ impl TypeFoldable for Ty {
             TyKind::Indexed(bty, idxs) => {
                 Ty::indexed(bty.fold_with(folder), idxs.fold_with(folder))
             }
-            TyKind::Exists(bty, pred) => {
-                TyKind::Exists(bty.fold_with(folder), pred.fold_with(folder)).intern()
-            }
+            TyKind::Exists(exists) => TyKind::Exists(exists.fold_with(folder)).intern(),
             TyKind::Tuple(tys) => Ty::tuple(tys.fold_with(folder)),
             TyKind::Array(ty, c) => Ty::array(ty.fold_with(folder), c.clone()),
             TyKind::Ptr(rk, path) => {
@@ -333,9 +344,8 @@ impl TypeFoldable for Ty {
                 bty.visit_with(visitor);
                 idxs.visit_with(visitor);
             }
-            TyKind::Exists(bty, pred) => {
-                bty.visit_with(visitor);
-                pred.visit_with(visitor);
+            TyKind::Exists(exists) => {
+                exists.visit_with(visitor);
             }
             TyKind::Tuple(tys) => tys.iter().for_each(|ty| ty.visit_with(visitor)),
             TyKind::Array(ty, _) => ty.visit_with(visitor),
@@ -355,6 +365,22 @@ impl TypeFoldable for Ty {
 
     fn fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         folder.fold_ty(self)
+    }
+}
+
+impl TypeFoldable for Exists {
+    fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Exists {
+        Exists::new(
+            self.bty.fold_with(folder),
+            self.args.fold_with(folder),
+            self.pred.fold_with(folder),
+        )
+    }
+
+    fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {
+        self.bty.visit_with(visitor);
+        self.args.visit_with(visitor);
+        self.pred.visit_with(visitor);
     }
 }
 

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -568,7 +568,7 @@ impl TyS {
 }
 
 impl Exists {
-    fn new(bty: BaseTy, args: RefineArgs, pred: Expr) -> Self {
+    pub fn new(bty: BaseTy, args: RefineArgs, pred: Expr) -> Self {
         Self { bty, args, pred }
     }
 

--- a/flux-tests/tests/neg/surface/join03.rs
+++ b/flux-tests/tests/neg/surface/join03.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool, custom_inner_attributes)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int, b: int)]
+pub struct Range {
+    #[flux::field(i32[a])]
+    left: i32,
+    #[flux::field(i32[b])]
+    right: i32,
+}
+
+#[flux::sig(fn(r: Range, b: bool) -> i32[r.a + 1])]
+fn test00(mut r: Range, b: bool) -> i32 {
+    if b {
+        // this is a function call so the `Range` remains folded
+        add_right(&mut r, 1);
+    }
+    r.left //~ ERROR postcondition
+}
+
+#[flux::sig(fn(r: &strg Range[@a, @b], n: i32) ensures r: Range[a, b + n])]
+fn add_right(r: &mut Range, n: i32) {
+    r.right += n;
+}

--- a/flux-tests/tests/pos/surface/join03.rs
+++ b/flux-tests/tests/pos/surface/join03.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool, custom_inner_attributes)]
+#![register_tool(flux)]
+
+#[flux::refined_by(a: int, b: int)]
+pub struct Range {
+    #[flux::field(i32[a])]
+    left: i32,
+    #[flux::field(i32[b])]
+    right: i32,
+}
+
+#[flux::sig(fn(r: Range, b: bool) -> i32[r.a])]
+fn test00(mut r: Range, b: bool) -> i32 {
+    if b {
+        // this is a function call so the `Range` remains folded
+        add_right(&mut r, 1);
+    }
+    r.left
+}
+
+#[flux::sig(fn(r: &strg Range[@a, @b], n: i32) ensures r: Range[a, b + n])]
+fn add_right(r: &mut Range, n: i32) {
+    r.right += n;
+}

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -16,8 +16,9 @@ use flux_common::{
 use flux_middle::{
     global_env::GlobalEnv,
     rty::{
-        self, BaseTy, BinOp, Binders, Bool, Const, Constraint, Constraints, Expr, Float, FnSig,
-        Int, IntTy, PolySig, RefKind, RefineArgs, Sort, Ty, TyKind, Uint, UintTy, VariantIdx,
+        self, BaseTy, BinOp, Binders, Bool, Const, Constraint, Constraints, Exists, Expr, Float,
+        FnSig, Int, IntTy, PolySig, RefKind, RefineArgs, Sort, Ty, TyKind, Uint, UintTy,
+        VariantIdx,
     },
     rustc::{
         self,
@@ -776,8 +777,8 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         match sig.out {
             sigs::Output::Indexed(mk) => Ty::indexed(bty, RefineArgs::one(mk([e1, e2]))),
             sigs::Output::Exists(mk) => {
-                let pred = mk(Expr::nu(), [e1, e2]);
-                Ty::exists(bty, Binders::new(pred, vec![Sort::Int]))
+                let pred = Binders::new(mk(Expr::nu(), [e1, e2]), vec![Sort::Int]);
+                Ty::exists(Exists::full(bty, pred))
             }
         }
     }
@@ -814,7 +815,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             sigs::Output::Indexed(mk) => Ty::indexed(bty, RefineArgs::one(mk([e1, e2]))),
             sigs::Output::Exists(mk) => {
                 let pred = mk(Expr::nu(), [e1, e2]);
-                Ty::exists(bty, Binders::new(pred, vec![Sort::Bool]))
+                Ty::exists(Exists::full(bty, Binders::new(pred, vec![Sort::Bool])))
             }
         }
     }

--- a/flux-typeck/src/checker.rs
+++ b/flux-typeck/src/checker.rs
@@ -16,9 +16,8 @@ use flux_common::{
 use flux_middle::{
     global_env::GlobalEnv,
     rty::{
-        self, BaseTy, BinOp, Binders, Bool, Const, Constraint, Constraints, Exists, Expr, Float,
-        FnSig, Int, IntTy, PolySig, RefKind, RefineArgs, Sort, Ty, TyKind, Uint, UintTy,
-        VariantIdx,
+        self, BaseTy, BinOp, Binders, Bool, Const, Constraint, Constraints, Expr, Float, FnSig,
+        Int, IntTy, PolySig, RefKind, RefineArgs, Sort, Ty, TyKind, Uint, UintTy, VariantIdx,
     },
     rustc::{
         self,
@@ -776,10 +775,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
 
         match sig.out {
             sigs::Output::Indexed(mk) => Ty::indexed(bty, RefineArgs::one(mk([e1, e2]))),
-            sigs::Output::Exists(mk) => {
-                let pred = Binders::new(mk(Expr::nu(), [e1, e2]), vec![Sort::Int]);
-                Ty::exists(Exists::full(bty, pred))
-            }
+            sigs::Output::Exists(mk) => Ty::full_exists(bty, mk(Expr::nu(), [e1, e2])),
         }
     }
 
@@ -810,13 +806,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                 .check_pred(rcx, constr([e1.clone(), e2.clone()]));
         }
 
-        let bty = BaseTy::Bool;
         match sig.out {
-            sigs::Output::Indexed(mk) => Ty::indexed(bty, RefineArgs::one(mk([e1, e2]))),
-            sigs::Output::Exists(mk) => {
-                let pred = mk(Expr::nu(), [e1, e2]);
-                Ty::exists(Exists::full(bty, Binders::new(pred, vec![Sort::Bool])))
-            }
+            sigs::Output::Indexed(mk) => Ty::indexed(BaseTy::Bool, RefineArgs::one(mk([e1, e2]))),
+            sigs::Output::Exists(mk) => Ty::full_exists(BaseTy::Bool, mk(Expr::nu(), [e1, e2])),
         }
     }
 

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -50,7 +50,9 @@ pub fn check<'a, 'tcx>(
 ) -> Result<(), ErrorGuaranteed> {
     let bb_envs = Checker::infer(genv, body, def_id).emit(genv.sess)?;
     let mut kvars = fixpoint::KVarStore::new();
-    let refine_tree = Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
+    let mut refine_tree =
+        Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
+    refine_tree.simplify();
 
     if CONFIG.dump_constraint {
         dump_constraint(genv.tcx, def_id, &refine_tree, ".lrc").unwrap();

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -415,8 +415,7 @@ impl TypeEnvInfer {
             TyKind::Indexed(bty, idxs) => {
                 let bty = TypeEnvInfer::pack_bty(scope, bty);
                 if scope.has_free_vars(idxs) {
-                    let pred = Binders::new(Expr::hole(), bty.sorts());
-                    Ty::exists(Exists::full(bty, pred))
+                    Ty::full_exists(bty, Expr::hole())
                 } else {
                     Ty::indexed(bty, idxs.clone())
                 }
@@ -608,21 +607,18 @@ impl TypeEnvInfer {
             (TyKind::Exists(exists), TyKind::Indexed(bty2, ..)) => {
                 let bty1 = &exists.as_ref().skip_binders().bty;
                 let bty = self.join_bty(bty1, bty2, src_info);
-                let pred = Binders::new(Expr::hole(), bty.sorts());
-                Ty::exists(Exists::full(bty, pred))
+                Ty::full_exists(bty, Expr::hole())
             }
             (TyKind::Indexed(bty1, _), TyKind::Exists(exists)) => {
                 let bty2 = &exists.as_ref().skip_binders().bty;
                 let bty = self.join_bty(bty1, bty2, src_info);
-                let pred = Binders::new(Expr::hole(), bty.sorts());
-                Ty::exists(Exists::full(bty, pred))
+                Ty::full_exists(bty, Expr::hole())
             }
             (TyKind::Exists(exists1), TyKind::Exists(exists2)) => {
                 let bty1 = &exists1.as_ref().skip_binders().bty;
                 let bty2 = &exists2.as_ref().skip_binders().bty;
                 let bty = self.join_bty(bty1, bty2, src_info);
-                let pred = Binders::new(Expr::hole(), bty.sorts());
-                Ty::exists(Exists::full(bty, pred))
+                Ty::full_exists(bty, Expr::hole())
             }
             (TyKind::Ref(rk1, ty1), TyKind::Ref(rk2, ty2)) => {
                 debug_assert_eq!(rk1, rk2);

--- a/flux-typeck/src/type_env.rs
+++ b/flux-typeck/src/type_env.rs
@@ -588,13 +588,12 @@ impl TypeEnvInfer {
                 let bty = self.join_bty(bty1, bty2, src_info);
                 let mut sorts = vec![];
                 let args = itertools::izip!(idxs1.args(), idxs2.args(), bty.sorts())
-                    .enumerate()
-                    .map(|(i, (arg1, arg2, sort))| {
+                    .map(|(arg1, arg2, sort)| {
                         if !self.scope.has_free_vars(arg2) && arg1 == arg2 {
                             arg1.clone()
                         } else {
                             sorts.push(sort.clone());
-                            RefineArg::Expr(Expr::bvar(BoundVar::innermost(i)))
+                            RefineArg::Expr(Expr::bvar(BoundVar::innermost(sorts.len() - 1)))
                         }
                     })
                     .collect();

--- a/flux-typeck/src/type_env/paths_tree.rs
+++ b/flux-typeck/src/type_env/paths_tree.rs
@@ -267,7 +267,7 @@ impl PathsTree {
                                     kind: LookupKind::Weak(rk, ty),
                                 });
                             }
-                            TyKind::Indexed(BaseTy::Adt(_, substs), _) if ty.is_box() => {
+                            TyKind::Indexed(BaseTy::Adt(adt, substs), _) if adt.is_box() => {
                                 let (boxed, alloc) = box_args(substs);
                                 let fresh = rcx.define_var(&Sort::Loc);
                                 let loc = Loc::from(fresh);
@@ -325,7 +325,7 @@ impl PathsTree {
                     rk = rk.min(WeakKind::from(*rk2));
                     ty = ty2.clone();
                 }
-                (Deref, TyKind::Indexed(BaseTy::Adt(_, substs), _)) if ty.is_box() => {
+                (Deref, TyKind::Indexed(BaseTy::Adt(adt, substs), _)) if adt.is_box() => {
                     let (boxed, _) = box_args(substs);
                     ty = boxed.clone();
                 }


### PR DESCRIPTION
Allows wrapping a base type in an existential where only some of the indices are existentially quantified. For example, if we have 
```rust
#[flux::refined_by(a: int, b: int)]
pub struct Pair {
    #[flux::field(i32[a])]
    fst: i32,
    #[flux::field(i32[b])]
    snd: i32,
}
```
Then we can have the type `{v. Pair[0, v] | v > 0}`  of pairs where the first component is zero and the second is greater than zero. This type is not exposed in the surface syntax, but we can use it internally. For example, in this PR we optimize how we compute the join of two types if we realize they have common indices, for instance, if we need to take the join of `Pair[0, 1]` and `Pair[0, 2]` we generate `{v. Pair[0, v] | *}`  (`*` is a hole that will be filled with a kvar). With this optimization, we can simplify the constrain generated in the example [join03.rs](https://github.com/liquid-rust/flux/blob/f3c6eb190137ef9e860dee40ba23ef95b294ad67/flux-tests/tests/pos/surface/join03.rs) from 
```
∀ a0: int, a1: int, a2: bool.
  ¬a2 => $k0(a0, a1)[a0, a1, a2] ~ Goto(17:6: 17:6, bb4)
  a2 => $k0(a0, a1 + 1)[a0, a1, a2] ~ Goto(15:10: 17:6, bb4)
  ∀ a3: int, a4: int.
    $k0(a3, a4)[a0, a1, a2] => (a3 = a0) ~ RetAt(18:5: 18:11)
```
to
```
∀ a0: int, a1: int, a2: bool.
  ¬a2 => $k0(a0, a1)[a0, a1, a2] ~ Goto(17:6: 17:6, bb4)
  a2 => $k0(a0, a1 + 1)[a0, a1, a2] ~ Goto(15:10: 17:6, bb4)
```
We could do the same when joining an existential with some other type, for example, `{v. Pair[0, v] | v > 0}` joined with `Pair[0, 10]` could generate `{v. Pair[0, v] | *}`, but this hasn't been implemented yet.

Additionally, even if we never expose partial existential in the surface syntax I expect them to be useful as the target for other syntax sugar:
* An indexed type where only some of the index are provided: `Pair[{a: 0, ..}]` could be desugared to `{v. Pair[0, v] | true}`
* Type aliases:  given the definition `type P[@b] = Pair[0, b]` we can desugar `P{v: v > 0}` to `{v. Pair[0, v] | v > 0}` (I think this will be particularly useful for abstract refinements)

