### PR TITLE
Add simple profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "flux-syntax",
  "flux-typeck",
  "itertools",
+ "tracing",
 ]
 
 [[package]]
@@ -846,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -989,9 +990,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1248,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1354,9 +1355,9 @@ checksum = "3c4db64c78ed1b303e5820f74bae56ff7a94b7f10ba8231d9ddaa484d80118c7"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1366,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1377,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +192,82 @@ dependencies = [
  "serde_json",
  "toml",
  "yaml-rust",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -244,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +375,16 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-bundle"
@@ -324,6 +428,7 @@ dependencies = [
  "flux-driver",
  "tracing",
  "tracing-subscriber",
+ "tracing-timing",
 ]
 
 [[package]]
@@ -441,6 +546,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +597,20 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -537,6 +665,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json5"
@@ -619,6 +756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,10 +777,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "miow"
@@ -659,6 +823,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -824,6 +997,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +1049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1019,6 +1217,15 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1217,6 +1424,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-timing"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe4966d7b6ae25201de6ff9fa822afb0c9e933809187d5b82ad846ec108771b"
+dependencies = [
+ "crossbeam",
+ "doc-comment",
+ "fxhash",
+ "hdrhistogram",
+ "indexmap",
+ "quanta",
+ "slab",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "type-map"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1533,70 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/flux-common/src/config.rs
+++ b/flux-common/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub log_dir: PathBuf,
     pub dump_constraint: bool,
     pub dump_checker_trace: bool,
+    pub dump_timings: bool,
     pub check_asserts: AssertBehavior,
     pub dump_mir: bool,
     pub pointer_width: u64,
@@ -50,6 +51,7 @@ pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("log_dir", "./log/")?
             .set_default("dump_constraint", false)?
             .set_default("dump_checker_trace", false)?
+            .set_default("dump_timings", false)?
             .set_default("dump_mir", false)?
             .set_default("check_asserts", "assume")?
             .set_default("check_asserts", "assume")?

--- a/flux-driver/Cargo.toml
+++ b/flux-driver/Cargo.toml
@@ -15,6 +15,7 @@ flux-middle = { path = "../flux-middle" }
 flux-syntax = { path = "../flux-syntax" }
 flux-typeck = { path = "../flux-typeck" }
 itertools = "0.10"
+tracing = "0.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -81,6 +81,8 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
         let map = build_fhir_map(tcx, sess, &mut specs)?;
         check_wf(tcx, sess, &map)?;
 
+        tracing::info!("Callbacks::check_wf");
+
         let mut genv = GlobalEnv::new(tcx, sess, map)?;
         // Assert behavior from Crate config
         // TODO(atgeller) rest of settings from crate config

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -70,7 +70,6 @@ impl Callbacks for FluxCallbacks {
 
 fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
     tracing::info_span!("check_crate").in_scope(|| {
-        tracing::info!(event = "check_crate start");
         let mut specs = SpecCollector::collect(tcx, sess)?;
 
         // Ignore everything and go home
@@ -102,11 +101,13 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
             .impl_items()
             .map(|impl_item| impl_item.owner_id.def_id);
 
-        tracing::info!(event = "check_crate end");
-
-        items
+        let result = items
             .chain(impl_items)
-            .try_for_each_exhaust(|def_id| ck.check_def(def_id))
+            .try_for_each_exhaust(|def_id| ck.check_def(def_id));
+
+        tracing::info!("Callbacks::check_crate");
+
+        result
     })
 }
 

--- a/flux-typeck/src/dbg.rs
+++ b/flux-typeck/src/dbg.rs
@@ -29,16 +29,6 @@ macro_rules! _check_top_span {
 pub use crate::_check_top_span as check_top_span;
 
 #[macro_export]
-macro_rules! _fixpoint_span {
-    ($tcx:expr, $def_id:expr) => {{
-        let path = $tcx.def_path($def_id);
-        let def_id = path.data.iter().join("::");
-        tracing::info_span!("fixpoint", def_id = def_id.as_str())
-    }};
-}
-pub use crate::_fixpoint_span as fixpoint_span;
-
-#[macro_export]
 macro_rules! _basic_block_start {
     ($bb:expr, $rcx:expr, $env:expr) => {{
         tracing::debug!(event = "basic_block_start", bb = ?$bb, rcx = ?$rcx, env = ?$env)

--- a/flux-typeck/src/dbg.rs
+++ b/flux-typeck/src/dbg.rs
@@ -19,6 +19,16 @@ macro_rules! _check_span {
 pub use crate::_check_span as check_span;
 
 #[macro_export]
+macro_rules! _fixpoint_span {
+    ($tcx:expr, $def_id:expr) => {{
+        let path = $tcx.def_path($def_id);
+        let def_id = path.data.iter().join("::");
+        tracing::info_span!("fixpoint", def_id = def_id.as_str())
+    }};
+}
+pub use crate::_fixpoint_span as fixpoint_span;
+
+#[macro_export]
 macro_rules! _basic_block_start {
     ($bb:expr, $rcx:expr, $env:expr) => {{
         tracing::debug!(event = "basic_block_start", bb = ?$bb, rcx = ?$rcx, env = ?$env)

--- a/flux-typeck/src/dbg.rs
+++ b/flux-typeck/src/dbg.rs
@@ -19,6 +19,16 @@ macro_rules! _check_span {
 pub use crate::_check_span as check_span;
 
 #[macro_export]
+macro_rules! _check_top_span {
+    ($tcx:expr, $def_id:expr) => {{
+        let path = $tcx.def_path($def_id);
+        let def_id = path.data.iter().join("::");
+        tracing::info_span!("check_top", def_id = def_id.as_str())
+    }};
+}
+pub use crate::_check_top_span as check_top_span;
+
+#[macro_export]
 macro_rules! _fixpoint_span {
     ($tcx:expr, $def_id:expr) => {{
         let path = $tcx.def_path($def_id);

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -1,6 +1,5 @@
 use std::{fs, io::Write, iter};
 
-use crate::dbg::fixpoint_span;
 use fixpoint::FixpointResult;
 use flux_common::{
     config::CONFIG,
@@ -16,6 +15,8 @@ use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_index::newtype_index;
 use rustc_middle::ty::TyCtxt;
+
+use crate::dbg::fixpoint_span;
 
 newtype_index! {
     #[debug_format = "TagIdx({})"]
@@ -123,7 +124,7 @@ where
         did: DefId,
         constraint: fixpoint::Constraint<TagIdx>,
     ) -> Result<(), Vec<Tag>> {
-        fixpoint_span!(self.genv.tcx, did).in_scope( || {
+        fixpoint_span!(self.genv.tcx, did).in_scope(|| {
             tracing::debug!(event = "fixpoint start");
             let kvars = self
                 .fixpoint_kvars

--- a/flux-typeck/src/fixpoint.rs
+++ b/flux-typeck/src/fixpoint.rs
@@ -124,6 +124,7 @@ where
         constraint: fixpoint::Constraint<TagIdx>,
     ) -> Result<(), Vec<Tag>> {
         fixpoint_span!(self.genv.tcx, did).in_scope( || {
+            tracing::debug!(event = "fixpoint start");
             let kvars = self
                 .fixpoint_kvars
                 .into_iter_enumerated()
@@ -162,7 +163,7 @@ where
                 dump_constraint(self.genv.tcx, did, &task, ".smt2").unwrap();
             }
 
-            match task.check() {
+            let result = match task.check() {
                 Ok(FixpointResult::Safe(_)) => Ok(()),
                 Ok(FixpointResult::Unsafe(_, errors)) => {
                     Err(errors
@@ -173,7 +174,11 @@ where
                 }
                 Ok(FixpointResult::Crash(err)) => panic!("fixpoint crash: {err:?}"),
                 Err(err) => panic!("failed to run fixpoint: {err:?}"),
-            }
+            };
+
+            tracing::debug!(event = "fixpoint end");
+
+            result
         })
     }
 

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -38,6 +38,7 @@ use constraint_gen::Tag;
 use flux_common::config::CONFIG;
 use flux_errors::ResultExt;
 use flux_middle::{global_env::GlobalEnv, rty, rustc::mir::Body};
+use itertools::Itertools;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
@@ -48,24 +49,35 @@ pub fn check<'tcx>(
     def_id: DefId,
     body: &Body<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {
-    let bb_envs = Checker::infer(genv, body, def_id).emit(genv.sess)?;
-    let mut kvars = fixpoint::KVarStore::new();
-    let mut refine_tree =
-        Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
-    refine_tree.simplify();
+    dbg::check_top_span!(genv.tcx, def_id).in_scope(|| {
+        let bb_envs = Checker::infer(genv, body, def_id).emit(genv.sess)?;
 
-    if CONFIG.dump_constraint {
-        dump_constraint(genv.tcx, def_id, &refine_tree, ".lrc").unwrap();
-    }
+        tracing::info!("Checker::infer");
 
-    let mut fcx = fixpoint::FixpointCtxt::new(genv, kvars);
+        let mut kvars = fixpoint::KVarStore::new();
+        let mut refine_tree =
+            Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
+        refine_tree.simplify();
 
-    let constraint = refine_tree.into_fixpoint(&mut fcx);
+        tracing::info!("Checker::check");
 
-    match fcx.check(def_id, constraint) {
-        Ok(_) => Ok(()),
-        Err(tags) => report_errors(genv, body.span(), tags),
-    }
+        if CONFIG.dump_constraint {
+            dump_constraint(genv.tcx, def_id, &refine_tree, ".lrc").unwrap();
+        }
+
+        let mut fcx = fixpoint::FixpointCtxt::new(genv, kvars);
+
+        let constraint = refine_tree.into_fixpoint(&mut fcx);
+
+        let result = match fcx.check(def_id, constraint) {
+            Ok(_) => Ok(()),
+            Err(tags) => report_errors(genv, body.span(), tags),
+        };
+
+        tracing::info!("FixpointCtx::check");
+
+        result
+    })
 }
 
 fn report_errors(

--- a/flux-typeck/src/lib.rs
+++ b/flux-typeck/src/lib.rs
@@ -57,9 +57,10 @@ pub fn check<'tcx>(
         let mut kvars = fixpoint::KVarStore::new();
         let mut refine_tree =
             Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
-        refine_tree.simplify();
 
         tracing::info!("Checker::check");
+
+        refine_tree.simplify();
 
         if CONFIG.dump_constraint {
             dump_constraint(genv.tcx, def_id, &refine_tree, ".lrc").unwrap();

--- a/flux/Cargo.toml
+++ b/flux/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 flux-common = { path = "../flux-common" }
 flux-driver = { path = "../flux-driver" }
 tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-timing = "0.6.0"
 
 [dependencies.tracing]
 features = ["max_level_debug", "release_max_level_warn"]

--- a/flux/src/logger.rs
+++ b/flux/src/logger.rs
@@ -1,23 +1,85 @@
-use std::{fs, io, sync::Arc};
+use std::{
+    fs,
+    io::{self, Write},
+    sync::Arc,
+};
 
 use flux_common::config::CONFIG;
-use tracing::Level;
+use tracing::{Dispatch, Level};
 use tracing_subscriber::{filter::Targets, fmt::writer::BoxMakeWriter, prelude::*, Registry};
+use tracing_timing::TimingLayer;
 
-pub fn install() -> io::Result<()> {
-    if CONFIG.dump_checker_trace {
-        let log_dir = &CONFIG.log_dir;
+const ONE_HUNDRED_MILLIS: u64 = 100_000_000;
+const ONE_MINUTE: u64 = 60_000_000_000;
+
+const CHECKER_FILE: &str = "checker";
+const TIMINGS_FILE: &str = "timings";
+
+pub fn install() -> io::Result<impl FnOnce() -> io::Result<()>> {
+    let log_dir = &CONFIG.log_dir;
+
+    if CONFIG.dump_checker_trace || CONFIG.dump_timings {
         fs::create_dir_all(log_dir)?;
-        let file = fs::File::create(log_dir.join("checker"))?;
-
-        let writer = BoxMakeWriter::new(Arc::new(file));
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_writer(writer)
-            .json()
-            .with_filter(Targets::new().with_target("flux_typeck::checker", Level::DEBUG));
-
-        Registry::default().with(fmt_layer).init();
     }
 
-    Ok(())
+    let fmt_layer = if CONFIG.dump_checker_trace {
+        let file = fs::File::create(log_dir.join(CHECKER_FILE))?;
+
+        let writer = BoxMakeWriter::new(Arc::new(file));
+        Some(
+            tracing_subscriber::fmt::layer()
+                .with_writer(writer)
+                .json()
+                .with_filter(Targets::new().with_target("flux_typeck::checker", Level::DEBUG)),
+        )
+    } else {
+        None
+    };
+
+    let timing_layer = if CONFIG.dump_timings {
+        Some(
+            tracing_timing::Builder::default()
+                .layer(|| {
+                    tracing_timing::Histogram::new_with_bounds(ONE_HUNDRED_MILLIS, ONE_MINUTE, 3)
+                        .unwrap()
+                })
+                .with_filter(
+                    Targets::new()
+                        .with_target("flux_typeck::checker", Level::DEBUG)
+                        .with_target("flux_typeck::fixpoint", Level::DEBUG),
+                ),
+        )
+    } else {
+        None
+    };
+
+    let dispatch = Dispatch::new(Registry::default().with(fmt_layer).with(timing_layer));
+
+    dispatch.clone().init();
+
+    Ok(move || {
+        if CONFIG.dump_timings {
+            let mut file = fs::File::create(log_dir.join(TIMINGS_FILE))?;
+            let mut file_contents = String::new();
+            let timing_layer = dispatch.downcast_ref::<TimingLayer>().unwrap();
+            timing_layer.force_synchronize();
+            timing_layer.with_histograms(|spans_map| {
+                for (span_name, events_map) in spans_map {
+                    let mut total_time = 0;
+                    for (_event_name, event_histogram) in events_map {
+                        event_histogram.refresh();
+                        for iteration_value in event_histogram.iter_recorded() {
+                            total_time += iteration_value.value_iterated_to();
+                        }
+                    }
+                    let message =
+                        format!("{}: total time {}ms\n", span_name, total_time / 1_000_000);
+                    file_contents += &message;
+                }
+            });
+            file.write_all(file_contents.as_bytes())
+        } else {
+            Ok(())
+        }
+    })
 }

--- a/flux/src/logger.rs
+++ b/flux/src/logger.rs
@@ -9,7 +9,7 @@ use tracing::{Dispatch, Level};
 use tracing_subscriber::{filter::Targets, fmt::writer::BoxMakeWriter, prelude::*, Registry};
 use tracing_timing::TimingLayer;
 
-const ONE_HUNDRED_MILLIS: u64 = 100_000_000;
+const ONE_MILLIS: u64 = 1_000_000;
 const ONE_MINUTE: u64 = 60_000_000_000;
 
 const CHECKER_FILE: &str = "checker";
@@ -40,7 +40,7 @@ pub fn install() -> io::Result<impl FnOnce() -> io::Result<()>> {
         Some(
             tracing_timing::Builder::default()
                 .layer(|| {
-                    tracing_timing::Histogram::new_with_bounds(ONE_HUNDRED_MILLIS, ONE_MINUTE, 3)
+                    tracing_timing::Histogram::new_with_bounds(ONE_MILLIS, ONE_MINUTE, 3)
                         .unwrap()
                 })
                 .with_filter(

--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, io, process::exit};
 const CMD_RUSTC: &str = "rustc";
 
 fn main() -> io::Result<()> {
-    logger::install()?;
+    let resolve_logs = logger::install()?;
 
     // HACK(nilehmann)
     // * Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument. We igore the
@@ -32,6 +32,7 @@ fn main() -> io::Result<()> {
         }
     }
     let exit_code = flux_driver::run_compiler(args, in_cargo);
+    resolve_logs()?;
     // Exit with the exit code returned by the compiler.
     exit(exit_code)
 }


### PR DESCRIPTION
# TL;DR

Set `LR_DUMP_TIMINGS=true` when you run `flux` to have flux write timing diagnostics to `./log/timings`.

Right now this is _extremely_ simple, it just provides some details for the spans under `flux_typeck` and `flux_driver`.

# Sample output

Below is a sample output for an invocation of `cargo-flux check` that took 19 seconds. The missing 2 seconds approximately accounts for the time it takes for `cargo check` to run.

Note that `check_crate` contains everything running under `check_top`, which is why the sum of the spans is greater than 19 seconds.

```
check_top
  Checker::infer
    num events:   205
    min non-zero: 0.52ms
    1st quartile: 0.52ms
    2nd quartile: 1.05ms
    3rd quartile: 2.62ms
    max:          24.12ms
    total time:   229.64ms
  Checker::check
    num events:   205
    min non-zero: 0.52ms
    1st quartile: 0.52ms
    2nd quartile: 1.05ms
    3rd quartile: 5.24ms
    max:          159.91ms
    total time:   2028.47ms
  FixpointCtx::check
    num events:   205
    min non-zero: 22.02ms
    1st quartile: 26.21ms
    2nd quartile: 28.31ms
    3rd quartile: 40.37ms
    max:          1867.51ms
    total time:   9106.36ms
total time: 11364.47ms

check_crate
  Callbacks::check_wf
    num events:   1
    min non-zero: 18.35ms
    1st quartile: 18.87ms
    2nd quartile: 18.87ms
    3rd quartile: 18.87ms
    max:          18.87ms
    total time:   18.87ms
  Callbacks::check_crate
    num events:   1
    min non-zero: 16986.93ms
    1st quartile: 16995.32ms
    2nd quartile: 16995.32ms
    3rd quartile: 16995.32ms
    max:          16995.32ms
    total time:   16995.32ms
total time: 17014.19ms
```

Edit: Updated the output, which previously showed 0ms for both `infer` and `check` due to too low a resolution on the timing histogram.

Edit 2: Updated the output again.

# Code changes

1. Added a variable (`dump_timings`) to the config.
2. Added a `check_top_span!` macro + some `info!` traces.
3. Updated `logger.rs` to conditionally add layers corresponding to `LR_DUMP_CHECKER_TRACE` and `LR_DUMP_TIMINGS`. It now returns a closure that generates the timing output (see comments for why I chose to do this).