### PR TITLE
Add support for real numbers in refinements

### DIFF
--- a/flux-errors/locales/en-US/desugar.ftl
+++ b/flux-errors/locales/en-US/desugar.ftl
@@ -35,3 +35,7 @@ desugar_invalid_unrefined_param =
 desugar_illegal_binder =
     illegal binder
     .label = binder not allowed in this position
+
+desugar_invalid_numeric_suffix =
+    invalid suffix `{$suffix}` for number literal
+    .label = the suffix must be one of the numeric sorts `int` or `real`

--- a/flux-errors/locales/en-US/wf.ftl
+++ b/flux-errors/locales/en-US/wf.ftl
@@ -62,3 +62,7 @@ wf_def_span_note =
         [true] {$def_kind} defined here
         *[false] {$def_kind} defined here with no parameters
     }
+
+wf_expected_numeric=
+    mismatched sorts
+    .label = expected numeric sort, found `{$found}`

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -18,6 +18,7 @@ pub enum Constraint<Tag> {
 pub enum Sort {
     Int,
     Bool,
+    Real,
     Unit,
     Pair(Box<Sort>, Box<Sort>),
     Func(FuncSort),
@@ -108,6 +109,7 @@ pub enum UnOp {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Constant {
     Int(Sign, u128),
+    Real(i128),
     Bool(bool),
 }
 
@@ -243,6 +245,7 @@ impl fmt::Display for Sort {
         match self {
             Sort::Int => write!(f, "int"),
             Sort::Bool => write!(f, "bool"),
+            Sort::Real => write!(f, "real"),
             Sort::Unit => write!(f, "Unit"),
             Sort::Pair(s1, s2) => write!(f, "(Pair {s1} {s2})"),
             Sort::Func(sort) => write!(f, "{sort}"),
@@ -535,6 +538,7 @@ impl fmt::Display for Constant {
         match self {
             Constant::Int(Sign::Positive, n) => write!(f, "{n}"),
             Constant::Int(Sign::Negative, n) => write!(f, "-{n}"),
+            Constant::Real(r) => write!(f, "{r}"),
             Constant::Bool(b) => write!(f, "{b}"),
         }
     }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -274,7 +274,6 @@ pub struct UFun {
 #[derive(Clone, Copy)]
 pub enum Lit {
     Int(i128),
-    /// We only support integer real literals
     Real(i128),
     Bool(bool),
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -226,6 +226,7 @@ pub enum InferMode {
 pub enum Sort {
     Int,
     Bool,
+    Real,
     Loc,
     Tuple(List<Sort>),
     Func(FuncSort),
@@ -273,6 +274,8 @@ pub struct UFun {
 #[derive(Clone, Copy)]
 pub enum Lit {
     Int(i128),
+    /// We only support integer real literals
+    Real(i128),
     Bool(bool),
 }
 
@@ -420,6 +423,10 @@ impl Sort {
     #[must_use]
     pub fn is_loc(&self) -> bool {
         matches!(self, Self::Loc)
+    }
+
+    pub fn is_numeric(&self) -> bool {
+        matches!(self, Self::Int | Self::Real)
     }
 
     /// Whether the sort is a function with return sort bool
@@ -804,6 +811,7 @@ impl fmt::Debug for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Lit::Int(i) => write!(f, "{i}"),
+            Lit::Real(r) => write!(f, "{r}real"),
             Lit::Bool(b) => write!(f, "{b}"),
         }
     }
@@ -814,6 +822,7 @@ impl fmt::Display for Sort {
         match self {
             Sort::Bool => write!(f, "bool"),
             Sort::Int => write!(f, "int"),
+            Sort::Real => write!(f, "real"),
             Sort::Loc => write!(f, "loc"),
             Sort::Func(sort) => write!(f, "{sort}"),
             Sort::Tuple(sorts) => write!(f, "({})", sorts.iter().join(", ")),

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -512,6 +512,7 @@ fn flatten_sort(map: &fhir::Map, sort: &fhir::Sort) -> Vec<rty::Sort> {
         fhir::Sort::Func(fsort) => vec![rty::Sort::Func(flatten_func_sort(map, fsort))],
         fhir::Sort::Adt(def_id) => flatten_sorts(map, map.sorts_of(*def_id).unwrap_or(&[])),
         fhir::Sort::Int
+        | fhir::Sort::Real
         | fhir::Sort::Bool
         | fhir::Sort::Loc
         | fhir::Sort::User(_)
@@ -528,6 +529,7 @@ fn flatten_func_sort(map: &fhir::Map, fsort: &fhir::FuncSort) -> rty::FuncSort {
 fn conv_lit(lit: fhir::Lit) -> rty::Constant {
     match lit {
         fhir::Lit::Int(n) => rty::Constant::from(n),
+        fhir::Lit::Real(r) => rty::Constant::Real(r),
         fhir::Lit::Bool(b) => rty::Constant::from(b),
     }
 }

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -414,6 +414,7 @@ impl std::str::FromStr for TagIdx {
 pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
     match sort {
         rty::Sort::Int => fixpoint::Sort::Int,
+        rty::Sort::Real => fixpoint::Sort::Real,
         rty::Sort::Bool => fixpoint::Sort::Bool,
         rty::Sort::Tuple(sorts) => {
             match &sorts[..] {

--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -115,7 +115,7 @@ impl Cursor {
             TokenKind::Dot => Token::Dot,
             TokenKind::OpenDelim(delim) => Token::OpenDelim(delim),
             TokenKind::CloseDelim(delim) => Token::CloseDelim(delim),
-            TokenKind::Literal(lit) if lit.suffix.is_none() => Token::Literal(lit),
+            TokenKind::Literal(lit) => Token::Literal(lit),
             TokenKind::Ident(symb, _) if symb == kw::True || symb == kw::False => {
                 Token::Literal(Lit { kind: LitKind::Bool, symbol: symb, suffix: None })
             }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -250,13 +250,6 @@ pub enum ExprKind {
     IfThenElse(Box<[Expr; 3]>),
 }
 
-// #[derive(Debug, Clone, Copy)]
-// pub struct Lit {
-//     pub kind: LitKind,
-//     pub symbol: Symbol,
-//     pub span: Span,
-// }
-
 #[derive(Copy, Clone)]
 pub enum BinOp {
     Iff,

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-pub use rustc_ast::token::LitKind;
+pub use rustc_ast::token::{Lit, LitKind};
 use rustc_hir::def_id::{DefId, LocalDefId};
 pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, TyCtxt, UintTy};
 pub use rustc_span::symbol::Ident;
-use rustc_span::{Span, Symbol};
+use rustc_span::Span;
 
 pub type AliasMap = rustc_hash::FxHashMap<Ident, Alias>;
 
@@ -250,12 +250,12 @@ pub enum ExprKind {
     IfThenElse(Box<[Expr; 3]>),
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct Lit {
-    pub kind: LitKind,
-    pub symbol: Symbol,
-    pub span: Span,
-}
+// #[derive(Debug, Clone, Copy)]
+// pub struct Lit {
+//     pub kind: LitKind,
+//     pub symbol: Symbol,
+//     pub span: Span,
+// }
 
 #[derive(Copy, Clone)]
 pub enum BinOp {

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -337,14 +337,7 @@ UnOp: surface::UnOp = {
     "-" => surface::UnOp::Neg,
 }
 
-Lit: surface::Lit = {
-    <lo:@L> <lit:"literal"> <hi:@R> => surface::Lit {
-        kind: lit.kind,
-        span: mk_span(lo, hi),
-        symbol: lit.symbol
-    },
-}
-
+Lit: surface::Lit = "literal";
 
 Ident: surface::Ident = {
     <lo:@L> <name:"ident"> <hi:@R> => {

--- a/flux-tests/tests/neg/error_messages/desugar/invalid_lit_suffix.rs
+++ b/flux-tests/tests/neg/error_messages/desugar/invalid_lit_suffix.rs
@@ -1,0 +1,5 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(i32[0asd]))] //~ ERROR invalid suffix `asd` for number literal
+fn test00(x: i32) {}

--- a/flux-tests/tests/neg/error_messages/wf/mixed_arith.rs
+++ b/flux-tests/tests/neg/error_messages/wf/mixed_arith.rs
@@ -1,0 +1,16 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::opaque]
+#[flux::refined_by(r: real)]
+struct Real;
+
+#[flux::sig(fn(r: Real, z: i32) -> i32[r + z])] //~ ERROR mismatched sorts
+fn test00(r: Real, z: i32) -> i32 {
+    todo!()
+}
+
+#[flux::sig(fn(r: Real, z: i32) -> i32[z + r])] //~ ERROR mismatched sorts
+fn test01(r: Real, z: i32) -> i32 {
+    todo!()
+}

--- a/flux-tests/tests/neg/error_messages/wf/non_numeric_arith.rs
+++ b/flux-tests/tests/neg/error_messages/wf/non_numeric_arith.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(b: bool) -> i32[b + 0])] //~ ERROR mismatched sorts
+fn test00(b: bool) -> i32 {
+    todo!()
+}
+
+#[flux::sig(fn(b: bool) -> i32[0 + b])] //~ ERROR mismatched sorts
+fn test01(b: bool) -> i32 {
+    todo!()
+}
+
+#[flux::sig(fn(b: bool) -> bool[b < 0])] //~ ERROR mismatched sorts
+fn test02(b: bool) -> bool {
+    todo!()
+}

--- a/flux-tests/tests/neg/surface/real00.rs
+++ b/flux-tests/tests/neg/surface/real00.rs
@@ -1,0 +1,26 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::opaque]
+#[flux::refined_by(r: real)]
+#[derive(Clone, Copy)]
+struct Real;
+
+#[flux::trusted]
+#[flux::sig(fn(x: Real, y: Real) -> Real[x + y])]
+fn add(x: Real, y: Real) -> Real {
+    Real
+}
+
+#[flux::trusted]
+#[flux::sig(fn(x: Real) -> Real[x + 1real])]
+fn add1(x: Real) -> Real {
+    Real
+}
+
+#[flux::sig(fn(x: Real, y: Real{y > x}))]
+fn assert_gt(x: Real, y: Real) {}
+
+fn test(x: Real) {
+    assert_gt(add1(x), x) //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/real00.rs
+++ b/flux-tests/tests/pos/surface/real00.rs
@@ -1,0 +1,26 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::opaque]
+#[flux::refined_by(r: real)]
+#[derive(Clone, Copy)]
+struct Real;
+
+#[flux::trusted]
+#[flux::sig(fn(x: Real, y: Real) -> Real[x + y])]
+fn add(x: Real, y: Real) -> Real {
+    Real
+}
+
+#[flux::trusted]
+#[flux::sig(fn(x: Real) -> Real[x + 1real])]
+fn add1(x: Real) -> Real {
+    Real
+}
+
+#[flux::sig(fn(x: Real, y: Real{y > x}))]
+fn assert_gt(x: Real, y: Real) {}
+
+fn test(x: Real) {
+    assert_gt(x, add1(x))
+}


### PR DESCRIPTION
Add basic support for real numbers, which are encoded with the sort `real` in fixpoint. One caveat of the implementation is that sort checking doesn't allow _mixed_ arithmetic, i.e., adding reals to ints. As a result, numeric literals (only ints for now) have to be marked with a suffix to specify they are reals (e.g., `x + 0real`). We can come back to this later and either allow mixed arithmetic (automatically coercing ints to reals) or add some inference to delay picking a sort for numeric literals.