### PR TITLE
Do not fail on unsupported alias when creating NameResTable

### DIFF
--- a/flux-tests/tests/neg/error_messages/resolver/unsupported_signature.rs
+++ b/flux-tests/tests/neg/error_messages/resolver/unsupported_signature.rs
@@ -3,5 +3,5 @@
 
 type A<'a> = &'a [i32];
 
-#[flux::sig(fn())]
+#[flux::sig(fn(A))]
 fn dipa(x: A) {} //~ ERROR unsupported function signature


### PR DESCRIPTION
Do not fail on unsupported alias when creating NameResTable and defer the error to the point a path is trying to be resolved.