### PR TITLE
Rename ENV variables to use `FLUX_` prefix and enable config file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dirs",
+ "flux-common",
  "rust-toolchain-file",
 ]
 

--- a/flux-bin/Cargo.toml
+++ b/flux-bin/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+flux-common = { path = "../flux-common" }
 anyhow = "1.0.68"
 dirs = "4.0.0"
 rust-toolchain-file = "0.1.0"

--- a/flux-bin/src/utils.rs
+++ b/flux-bin/src/utils.rs
@@ -1,7 +1,6 @@
 use std::{env, ffi::OsString, fs, path::PathBuf};
 
 use anyhow::{anyhow, Result};
-
 use flux_common::config::CONFIG;
 
 #[cfg(target_os = "windows")]

--- a/flux-bin/src/utils.rs
+++ b/flux-bin/src/utils.rs
@@ -2,6 +2,8 @@ use std::{env, ffi::OsString, fs, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 
+use flux_common::config::CONFIG;
+
 #[cfg(target_os = "windows")]
 pub const LIB_PATH: &str = "PATH";
 #[cfg(target_os = "linux")]
@@ -20,16 +22,11 @@ pub fn get_default_flux_path() -> Result<PathBuf> {
 }
 
 pub fn get_flux_path() -> Result<PathBuf> {
-    let flux_path = env::var("FLUX_PATH").map(PathBuf::from).or_else(|err| {
-        match err {
-            env::VarError::NotPresent => get_default_flux_path(),
-            _ => Err(anyhow::Error::from(err)),
-        }
-    })?;
+    let flux_path = &CONFIG.path.clone().map_or_else(get_default_flux_path, Ok)?;
     if !flux_path.is_file() {
         return Err(anyhow!("flux executable {:?} does not exist or is not a file", flux_path));
     }
-    Ok(flux_path)
+    Ok(flux_path.to_path_buf())
 }
 
 pub fn get_rust_toolchain() -> Result<String> {

--- a/flux-common/src/config.rs
+++ b/flux-common/src/config.rs
@@ -54,6 +54,7 @@ pub struct Config {
 pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
     fn build() -> Result<Config, config::ConfigError> {
         let mut config_builder = config::Config::builder()
+            .set_default("path", None::<String>)?
             .set_default("log_dir", "./log/")?
             .set_default("dump_constraint", false)?
             .set_default("dump_checker_trace", false)?

--- a/flux-docs/src/dev/flags.md
+++ b/flux-docs/src/dev/flags.md
@@ -2,16 +2,46 @@
 
 You can set various `env` variables to customize the behavior of `flux`.
 
-* `LR_LOG_DIR=path/to/log/`  with default `./log/`
-* `LR_DUMP_CONSTRAINT=1` sets the directory where constraints, timing and cache are saved.
-* `LR_DUMP_CHECKER_TRACE=1` saves the checker's trace (useful for debugging!)
-* `LR_DUMP_TIMINGS=1` saves the profile information
-* `LR_DUMP_MIR=1` saves the low-level MIR for each analyzed function
-* `LR_CHECK_ASSERTS={ignore, assume, check}` TODO
-* `LR_POINTER_WIDTH=N` TODO (default `64`)
-* `LR_CHECK_DEF=name` only checks definitions containing `name` as a substring
-* `LR_CACHE=1"` switches on query caching and saves the cache in `LR_CACHE_FILE`
-* `LR_CACHE_FILE=file.json` customizes the cache file, default `LR_LOG_DIR/cache.json`
+* `FLUX_CONFIG` tells `flux` where to find a config file for these settings.
+  - By default, `flux` searches its directory for a `flux.toml` or `.flux.toml`.
+* `FLUX_PATH=path/to/flux` tells `cargo-flux` and `rustc-flux` where to find the `flux` binary. 
+  - Defaults to the default `flux` installation (typically found in `~/.cargo/bin`).
+* `FLUX_LOG_DIR=path/to/log/`  with default `./log/`
+* `FLUX_DUMP_CONSTRAINT=1` sets the directory where constraints, timing and cache are saved.
+* `FLUX_DUMP_CHECKER_TRACE=1` saves the checker's trace (useful for debugging!)
+* `FLUX_DUMP_TIMINGS=1` saves the profile information
+* `FLUX_DUMP_MIR=1` saves the low-level MIR for each analyzed function
+* `FLUX_CHECK_ASSERTS={ignore, assume, check}` TODO
+* `FLUX_POINTER_WIDTH=N` TODO (default `64`)
+* `FLUX_CHECK_DEF=name` only checks definitions containing `name` as a substring
+* `FLUX_CACHE=1"` switches on query caching and saves the cache in `FLUX_CACHE_FILE`
+* `FLUX_CACHE_FILE=file.json` customizes the cache file, default `FLUX_LOG_DIR/cache.json`
+
+# Config file
+
+The config file is a `.toml` file that just contains on each line the lowercase
+name of a `flux` command line flag without the `FLUX_` prefix. Set environment
+variables take priority over the config file.
+
+The config file should be in the project root.
+
+For example, suppose your project root contains the following `flux.toml`.
+
+```toml
+log_dir = "./test"
+dump_timings = true
+dump_mir = true
+```
+
+and you run in the project root
+
+```bash
+FLUX_DUMP_MIR=0 cargo-flux check
+```
+
+then `flux` will create the directory `./test/` and write `./test/timings`, a file
+containing profiling information. It will _not_ dump the MIR because that setting
+was overriden by setting `FLUX_DUMP_MIR=0`.
 
 ## Check Asserts
 

--- a/flux-docs/src/dev/flags.md
+++ b/flux-docs/src/dev/flags.md
@@ -19,8 +19,8 @@ You can set various `env` variables to customize the behavior of `flux`.
 
 # Config file
 
-The config file is a `.toml` file that just contains on each line the lowercase
-name of a `flux` command line flag without the `FLUX_` prefix. Set environment
+The config file is a `.toml` file that contains on each line the lowercase name
+of a `flux` command line flag without the `FLUX_` prefix. Set environment
 variables take priority over the config file.
 
 The config file should be in the project root.
@@ -41,7 +41,7 @@ FLUX_DUMP_MIR=0 cargo-flux check
 
 then `flux` will create the directory `./test/` and write `./test/timings`, a file
 containing profiling information. It will _not_ dump the MIR because that setting
-was overriden by setting `FLUX_DUMP_MIR=0`.
+was overriden by setting the environment variable `FLUX_DUMP_MIR=0`.
 
 ## Check Asserts
 
@@ -49,7 +49,7 @@ TODO
 
 ## Query Caching
 
-`LR_CACHE=1` persistently caches the safe fixpoint queries for each DefId
-in `LR_LOG_DIR/LR_CACHE_FILE`, and on subsequent runs, skips queries that
-are already in the cache, which considerably speeds up `cargo-flux check`
-on an entire crate.
+`FLUX_CACHE=1` persistently caches the safe fixpoint queries for each DefId in
+`FLUX_LOG_DIR/FLUX_CACHE_FILE`, and on subsequent runs, skips queries that are
+already in the cache, which considerably speeds up `cargo-flux check` on an
+entire crate.

--- a/flux-docs/src/dev/profile.md
+++ b/flux-docs/src/dev/profile.md
@@ -1,6 +1,6 @@
 # Profiling Flux
 
-Set `LR_DUMP_TIMINGS=true` to have flux write timing diagnostics to `./log/timings`.
+Set `FLUX_DUMP_TIMINGS=true` to have flux write timing diagnostics to `./log/timings`.
 
 Right now this is _extremely_ simple, it just provides some details for the spans under `flux_typeck` and `flux_driver`.
 


### PR DESCRIPTION
See the new `flags.md` for more details.