### PR TITLE
Implement join for arrays

### DIFF
--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -633,6 +633,10 @@ impl TypeEnvInfer {
                     .collect_vec();
                 Ty::tuple(tys)
             }
+            (TyKind::Array(ty1, len1), TyKind::Array(ty2, len2)) => {
+                debug_assert_eq!(len1, len2);
+                Ty::array(self.join_ty(ty1, ty2, src_info), len1.clone())
+            }
             _ => unreachable!("`{ty1:?}` -- `{ty2:?}`"),
         }
     }

--- a/flux-tests/tests/pos/surface/join04.rs
+++ b/flux-tests/tests/pos/surface/join04.rs
@@ -1,0 +1,8 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(bool) -> i32{v: v > 0})]
+fn join_arr(b: bool) -> i32 {
+    let arr = if b { [1, 2] } else { [3, 4] };
+    arr[0]
+}


### PR DESCRIPTION
Fixes the issue [here](https://github.com/liquid-rust/flux-wave/blob/fdfdb096c11b49ccdfd43c9b695666e0b0ac86eb/src/wrappers.rs#L242).  

It also removes that one particular panic [here](https://github.com/liquid-rust/flux-wave/blob/fdfdb096c11b49ccdfd43c9b695666e0b0ac86eb/src/wrappers.rs#L1295), but fixing it there reveals a new panic.

```
thread 'rustc' panicked at 'expected owned at Some(src/wrappers.rs:1295:5: 1295:65 (#0))', flux-refineck/src/type_env/paths_tree.rs:739:36
```

ping @ranjitjhala 