### PR TITLE
Generalize exists

### DIFF
--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -331,11 +331,11 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         if pred.params().is_empty() && pred.is_trivially_true() {
             rty::Ty::indexed(bty, rty::RefineArgs::empty())
         } else {
-            let exists = pred.map(|pred| {
+            let ty = pred.map(|pred| {
                 let args = rty::RefineArgs::bound(bty.sorts().len());
-                rty::Exists::new(bty, args, pred)
+                rty::Ty::constr(pred, rty::Ty::indexed(bty, args))
             });
-            rty::Ty::exists(exists)
+            rty::Ty::exists(ty)
         }
     }
 

--- a/flux-tests/tests/neg/surface/join03.rs
+++ b/flux-tests/tests/neg/surface/join03.rs
@@ -2,23 +2,34 @@
 #![register_tool(flux)]
 
 #[flux::refined_by(a: int, b: int)]
-pub struct Range {
+pub struct Pair {
     #[flux::field(i32[a])]
     left: i32,
     #[flux::field(i32[b])]
     right: i32,
 }
 
-#[flux::sig(fn(r: Range, b: bool) -> i32[r.a + 1])]
-fn test00(mut r: Range, b: bool) -> i32 {
+#[flux::sig(fn(p: Pair, b: bool) -> i32[p.a + 1])]
+fn test00(mut p: Pair, b: bool) -> i32 {
     if b {
-        // this is a function call so the `Range` remains folded
-        add_right(&mut r, 1);
+        // this is a function call so the `Pair` remains folded
+        add_right(&mut p, 1);
     }
-    r.left //~ ERROR postcondition
+    p.left //~ ERROR postcondition
 }
 
-#[flux::sig(fn(r: &strg Range[@a, @b], n: i32) ensures r: Range[a, b + n])]
-fn add_right(r: &mut Range, n: i32) {
+#[flux::sig(fn(p: Pair) -> i32[p.a + 1])]
+fn test01(mut p: Pair) -> i32 {
+    let mut i = 0;
+    while i < 10 {
+        // this is a function call so the `Pair` remains folded
+        add_right(&mut p, 1);
+        i += 1;
+    }
+    p.left //~ ERROR postcondition
+}
+
+#[flux::sig(fn(r: &strg Pair[@a, @b], n: i32) ensures r: Pair[a, b + n])]
+fn add_right(r: &mut Pair, n: i32) {
     r.right += n;
 }

--- a/flux-tests/tests/pos/surface/join03.rs
+++ b/flux-tests/tests/pos/surface/join03.rs
@@ -2,23 +2,34 @@
 #![register_tool(flux)]
 
 #[flux::refined_by(a: int, b: int)]
-pub struct Range {
+pub struct Pair {
     #[flux::field(i32[a])]
     left: i32,
     #[flux::field(i32[b])]
     right: i32,
 }
 
-#[flux::sig(fn(r: Range, b: bool) -> i32[r.a])]
-fn test00(mut r: Range, b: bool) -> i32 {
+#[flux::sig(fn(p: Pair, b: bool) -> i32[p.a])]
+fn test00(mut p: Pair, b: bool) -> i32 {
     if b {
-        // this is a function call so the `Range` remains folded
-        add_right(&mut r, 1);
+        // this is a function call so the `Pair` remains folded
+        add_right(&mut p, 1);
     }
-    r.left
+    p.left
 }
 
-#[flux::sig(fn(r: &strg Range[@a, @b], n: i32) ensures r: Range[a, b + n])]
-fn add_right(r: &mut Range, n: i32) {
-    r.right += n;
+#[flux::sig(fn(p: Pair) -> i32[p.a])]
+fn test01(mut p: Pair) -> i32 {
+    let mut i = 0;
+    while i < 10 {
+        // this is a function call so the `Pair` remains folded
+        add_right(&mut p, 1);
+        i += 1;
+    }
+    p.left
+}
+
+#[flux::sig(fn(p: &strg Pair[@a, @b], n: i32) ensures p: Pair[a, b + n])]
+fn add_right(p: &mut Pair, n: i32) {
+    p.right += n;
 }


### PR DESCRIPTION
https://github.com/liquid-rust/flux/pull/281 implemented the possibility to have existentials where only some of the indices of a base type were existentially quantified. This PR goes even further and implements a generic existential type `{v. T}` where `T` can be an arbitrary type (and `v` can appear in `T`). As commented in #281 this can be used internally to do some optimizations and to desugar aliases.