### PR TITLE
Support loading flux annotations from external crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ version = "0.1.0"
 dependencies = [
  "flux-common",
  "flux-errors",
+ "flux-macros",
  "flux-middle",
  "itertools",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "flux-common",
  "flux-errors",
  "flux-middle",
+ "itertools",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "flux-metadata"
+version = "0.1.0"
+dependencies = [
+ "flux-common",
+ "flux-middle",
+]
+
+[[package]]
 name = "flux-middle"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "flux-errors",
  "flux-fixpoint",
  "flux-macros",
+ "flux-metadata",
  "flux-middle",
  "flux-refineck",
  "flux-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ name = "flux-metadata"
 version = "0.1.0"
 dependencies = [
  "flux-common",
+ "flux-errors",
  "flux-middle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "flux-errors",
     "flux-fixpoint",
     "flux-macros",
+    "flux-metadata",
     "flux-middle",
     "flux-refineck",
     "flux-syntax",

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -1083,7 +1083,7 @@ impl Binder {
     }
 }
 
-fn sorts<'a>(early_cx: &EarlyCtxt<'a, '_>, bty: &surface::BaseTy<Res>) -> Option<&'a [fhir::Sort]> {
+fn sorts<'a>(early_cx: &'a EarlyCtxt, bty: &surface::BaseTy<Res>) -> Option<&'a [fhir::Sort]> {
     let sorts = match bty {
         surface::BaseTy::Path(path) => {
             match path.res {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -3,8 +3,8 @@ use std::{borrow::Borrow, iter};
 
 use flux_common::{bug, index::IndexGen, iter::IterExt};
 use flux_errors::FluxSession;
-use flux_middle::{fhir, intern::List};
-use flux_syntax::surface::{self, Res, TyCtxt};
+use flux_middle::{early_ctxt::EarlyCtxt, fhir, intern::List};
+use flux_syntax::surface::{self, Res};
 use itertools::Itertools;
 use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
 use rustc_errors::ErrorGuaranteed;
@@ -12,14 +12,12 @@ use rustc_hir::def_id::DefId;
 use rustc_span::{sym, symbol::kw, Span, Symbol};
 
 pub fn desugar_qualifier(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     qualifier: &surface::Qualifier,
 ) -> Result<fhir::Qualifier, ErrorGuaranteed> {
-    let mut binders = Binders::from_params(sess, map, &qualifier.args)?;
+    let mut binders = Binders::from_params(early_cx, &qualifier.args)?;
     let name = qualifier.name.name.to_ident_string();
-    let expr = ExprCtxt::new(tcx, sess, map, &binders).desugar_expr(&qualifier.expr);
+    let expr = ExprCtxt::new(early_cx, &binders).desugar_expr(&qualifier.expr);
 
     Ok(fhir::Qualifier {
         name,
@@ -30,15 +28,13 @@ pub fn desugar_qualifier(
 }
 
 pub fn desugar_defn(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     defn: surface::Defn,
 ) -> Result<fhir::Defn, ErrorGuaranteed> {
-    let mut binders = Binders::from_params(sess, map, &defn.args.params)?;
-    let expr = ExprCtxt::new(tcx, sess, map, &binders).desugar_expr(&defn.expr)?;
+    let mut binders = Binders::from_params(early_cx, &defn.args.params)?;
+    let expr = ExprCtxt::new(early_cx, &binders).desugar_expr(&defn.expr)?;
     let name = defn.name.name;
-    let sort = resolve_sort(sess, map, &defn.sort)?;
+    let sort = resolve_sort(early_cx, &defn.sort)?;
     let args = binders.pop_layer().into_args();
     Ok(fhir::Defn { name, args, sort, expr })
 }
@@ -52,8 +48,7 @@ fn sort_ident(sort: &surface::Sort) -> Result<surface::Ident, ErrorGuaranteed> {
 }
 
 pub fn resolve_defn_uif(
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     defn: &surface::Defn,
 ) -> Result<fhir::UifDef, ErrorGuaranteed> {
     let inputs: Vec<surface::Ident> = defn
@@ -62,13 +57,12 @@ pub fn resolve_defn_uif(
         .map(|arg| sort_ident(&arg.sort))
         .try_collect_exhaust()?;
     let output: surface::Ident = sort_ident(&defn.sort)?;
-    let sort = resolve_func_sort(sess, map, &inputs[..], &output)?;
+    let sort = resolve_func_sort(early_cx, &inputs[..], &output)?;
     Ok(fhir::UifDef { name: defn.name.name, sort })
 }
 
 pub fn resolve_uif_def(
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     defn: surface::UifDef,
 ) -> Result<fhir::UifDef, ErrorGuaranteed> {
     let inputs: Vec<surface::Ident> = defn
@@ -77,24 +71,22 @@ pub fn resolve_uif_def(
         .map(|arg| sort_ident(&arg.sort))
         .try_collect_exhaust()?;
     let output: surface::Ident = sort_ident(&defn.sort)?;
-    let sort = resolve_func_sort(sess, map, &inputs[..], &output)?;
+    let sort = resolve_func_sort(early_cx, &inputs[..], &output)?;
     Ok(fhir::UifDef { name: defn.name.name, sort })
 }
 
 pub fn desugar_adt_def(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     def_id: DefId,
     refined_by: &surface::RefinedBy,
     invariants: &[surface::Expr],
     opaque: bool,
 ) -> Result<fhir::AdtDef, ErrorGuaranteed> {
-    let mut binders = Binders::from_params(sess, map, refined_by)?;
+    let mut binders = Binders::from_params(early_cx, refined_by)?;
 
     let invariants = invariants
         .iter()
-        .map(|invariant| ExprCtxt::new(tcx, sess, map, &binders).desugar_expr(invariant))
+        .map(|invariant| ExprCtxt::new(early_cx, &binders).desugar_expr(invariant))
         .try_collect_exhaust()?;
 
     let refined_by =
@@ -103,15 +95,13 @@ pub fn desugar_adt_def(
 }
 
 pub fn desugar_struct_def(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     adt_def: surface::StructDef<Res>,
 ) -> Result<fhir::StructDef, ErrorGuaranteed> {
     let def_id = adt_def.def_id.to_def_id();
-    let binders = Binders::from_params(sess, map, adt_def.refined_by.iter().flatten())?;
+    let binders = Binders::from_params(early_cx, adt_def.refined_by.iter().flatten())?;
 
-    let mut cx = DesugarCtxt::new(tcx, sess, map, binders);
+    let mut cx = DesugarCtxt::new(early_cx, binders);
 
     let kind = if adt_def.opaque {
         fhir::StructKind::Opaque
@@ -127,30 +117,26 @@ pub fn desugar_struct_def(
 }
 
 pub fn desugar_enum_def(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     enum_def: &surface::EnumDef<Res>,
 ) -> Result<fhir::EnumDef, ErrorGuaranteed> {
     let def_id = enum_def.def_id.to_def_id();
     let variants = enum_def
         .variants
         .iter()
-        .map(|variant| desugar_variant(tcx, sess, map, variant))
+        .map(|variant| desugar_variant(early_cx, variant))
         .try_collect_exhaust()?;
 
     Ok(fhir::EnumDef { def_id, variants })
 }
 
 fn desugar_variant(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     variant: &surface::VariantDef<Res>,
 ) -> Result<fhir::VariantDef, ErrorGuaranteed> {
     let mut binders = Binders::new();
-    binders.gather_params_variant(tcx, sess, map, variant)?;
-    let mut cx = DesugarCtxt::new(tcx, sess, map, binders);
+    binders.gather_params_variant(early_cx, variant)?;
+    let mut cx = DesugarCtxt::new(early_cx, binders);
 
     let fields = variant
         .fields
@@ -164,16 +150,14 @@ fn desugar_variant(
 }
 
 pub fn desugar_fn_sig(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     fn_sig: &surface::FnSig<Res>,
 ) -> Result<fhir::FnSig, ErrorGuaranteed> {
     let mut binders = Binders::new();
 
     // # Desugar inputs
-    binders.gather_input_params_fn_sig(tcx, sess, map, fn_sig)?;
-    let mut cx = DesugarCtxt::new(tcx, sess, map, binders);
+    binders.gather_input_params_fn_sig(early_cx, fn_sig)?;
+    let mut cx = DesugarCtxt::new(early_cx, binders);
 
     if let Some(e) = &fn_sig.requires {
         let pred = cx.as_expr_ctxt().desugar_expr(e)?;
@@ -189,8 +173,7 @@ pub fn desugar_fn_sig(
 
     // # Desugar output
     cx.binders.push_layer();
-    cx.binders
-        .gather_output_params_fn_sig(tcx, sess, map, fn_sig)?;
+    cx.binders.gather_output_params_fn_sig(early_cx, fn_sig)?;
     let ret = match &fn_sig.returns {
         Some(returns) => cx.desugar_ty(None, returns),
         None => Ok(fhir::Ty::Tuple(vec![])),
@@ -219,9 +202,7 @@ pub fn desugar_fn_sig(
 }
 
 pub struct DesugarCtxt<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
-    sess: &'a FluxSession,
-    map: &'a fhir::Map,
+    early_cx: &'a EarlyCtxt<'a, 'tcx>,
     binders: Binders,
     requires: Vec<fhir::Constraint>,
 }
@@ -255,9 +236,7 @@ enum Binder {
 }
 
 struct ExprCtxt<'a, 'tcx> {
-    _tcx: TyCtxt<'tcx>,
-    sess: &'a FluxSession,
-    map: &'a fhir::Map,
+    early_cx: &'a EarlyCtxt<'a, 'tcx>,
     binders: &'a Binders,
 }
 
@@ -272,17 +251,12 @@ enum FuncRes<'a> {
 }
 
 impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
-    fn new(
-        tcx: TyCtxt<'tcx>,
-        sess: &'a FluxSession,
-        map: &'a fhir::Map,
-        binders: Binders,
-    ) -> DesugarCtxt<'a, 'tcx> {
-        DesugarCtxt { tcx, sess, binders, requires: vec![], map }
+    fn new(early_cx: &'a EarlyCtxt<'a, 'tcx>, binders: Binders) -> DesugarCtxt<'a, 'tcx> {
+        DesugarCtxt { early_cx, binders, requires: vec![] }
     }
 
     fn as_expr_ctxt(&self) -> ExprCtxt<'_, 'tcx> {
-        ExprCtxt::new(self.tcx, self.sess, self.map, &self.binders)
+        ExprCtxt::new(self.early_cx, &self.binders)
     }
 
     fn desugar_fun_arg(&mut self, arg: &surface::Arg<Res>) -> Result<fhir::Ty, ErrorGuaranteed> {
@@ -322,7 +296,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                         Ok(fhir::Ty::Indexed(bty, idx))
                     }
                     BtyOrTy::Ty(_) => {
-                        Err(self.sess.emit_err(errors::ParamCountMismatch::new(
+                        Err(self.early_cx.emit_err(errors::ParamCountMismatch::new(
                             indices.span,
                             0,
                             indices.indices.len(),
@@ -336,8 +310,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                         if let Some(bind) = bind {
                             let binder = self.binders[bind].clone();
                             let pred = self.binders.with_binder(*ident, binder, |binders| {
-                                ExprCtxt::new(self.tcx, self.sess, self.map, binders)
-                                    .desugar_expr(pred)
+                                ExprCtxt::new(self.early_cx, binders).desugar_expr(pred)
                             })?;
                             let idxs = self.desugar_bind(bind)?;
                             Ok(fhir::Ty::Constr(pred, Box::new(fhir::Ty::Indexed(bty, idxs))))
@@ -345,8 +318,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                             let name = self.binders.fresh();
                             let binder = Binder::Refined(name, bty.sort(), false);
                             let pred = self.binders.with_binder(*ident, binder, |binders| {
-                                ExprCtxt::new(self.tcx, self.sess, self.map, binders)
-                                    .desugar_expr(pred)
+                                ExprCtxt::new(self.early_cx, binders).desugar_expr(pred)
                             })?;
                             let bind = fhir::Ident::new(name, *ident);
                             Ok(fhir::Ty::Exists(bty, bind, pred))
@@ -354,7 +326,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                     }
                     BtyOrTy::Ty(_) => {
                         Err(self
-                            .sess
+                            .early_cx
                             .emit_err(errors::ParamCountMismatch::new(ident.span, 0, 1)))
                     }
                 }
@@ -413,7 +385,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 Ok(fhir::RefineArg::Expr { expr, is_binder: true })
             }
             Some(Binder::Unrefined) => todo!(),
-            None => Err(self.sess.emit_err(errors::UnresolvedVar::new(ident))),
+            None => Err(self.early_cx.emit_err(errors::UnresolvedVar::new(ident))),
         }
     }
 
@@ -431,7 +403,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             }
             surface::RefineArg::Abs(params, body, span) => {
                 let (body, names) = self.binders.with_abs_params(params, |binders| {
-                    let cx = ExprCtxt::new(self.tcx, self.sess, self.map, binders);
+                    let cx = ExprCtxt::new(self.early_cx, binders);
                     cx.desugar_expr(body)
                 })?;
                 Ok(fhir::RefineArg::Abs(names, body, *span))
@@ -508,13 +480,8 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
-    fn new(
-        tcx: TyCtxt<'tcx>,
-        sess: &'a FluxSession,
-        map: &'a fhir::Map,
-        binders: &'a Binders,
-    ) -> Self {
-        Self { _tcx: tcx, sess, map, binders }
+    fn new(early_cx: &'a EarlyCtxt<'a, 'tcx>, binders: &'a Binders) -> Self {
+        Self { early_cx, binders }
     }
 
     fn desugar_expr(&self, expr: &surface::Expr) -> Result<fhir::Expr, ErrorGuaranteed> {
@@ -536,7 +503,7 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                     fhir::ExprKind::Dot(var, *fld)
                 } else {
                     return Err(self
-                        .sess
+                        .early_cx
                         .emit_err(errors::InvalidDotVar { span: expr.span }));
                 }
             }
@@ -576,22 +543,22 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                 Binder::Unrefined => {
                     let def_ident = self.binders.def_ident(func).unwrap();
                     return Err(self
-                        .sess
+                        .early_cx
                         .emit_err(errors::InvalidUnrefinedParam::new(def_ident, func)));
                 }
             }
         }
-        if let Some(uif) = self.map.uif(func.name) {
+        if let Some(uif) = self.early_cx.uif(func.name) {
             return Ok(FuncRes::Uif(uif));
         }
-        Err(self.sess.emit_err(errors::UnresolvedVar::new(func)))
+        Err(self.early_cx.emit_err(errors::UnresolvedVar::new(func)))
     }
 
     fn desugar_lit(&self, span: Span, lit: surface::Lit) -> Result<fhir::Lit, ErrorGuaranteed> {
         match lit.kind {
             surface::LitKind::Integer => {
                 let Ok(n) = lit.symbol.as_str().parse::<i128>() else {
-                    return Err(self.sess.emit_err(errors::IntTooLarge { span }));
+                    return Err(self.early_cx.emit_err(errors::IntTooLarge { span }));
                 };
                 let suffix = lit.suffix.unwrap_or(SORTS.int);
                 if suffix == SORTS.int {
@@ -600,28 +567,28 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                     Ok(fhir::Lit::Real(n))
                 } else {
                     Err(self
-                        .sess
+                        .early_cx
                         .emit_err(errors::InvalidNumericSuffix::new(span, suffix)))
                 }
             }
             surface::LitKind::Bool => Ok(fhir::Lit::Bool(lit.symbol == kw::True)),
-            _ => Err(self.sess.emit_err(errors::UnexpectedLiteral { span })),
+            _ => Err(self.early_cx.emit_err(errors::UnexpectedLiteral { span })),
         }
     }
 
     fn desugar_var(&self, ident: surface::Ident) -> Result<fhir::Expr, ErrorGuaranteed> {
-        let kind = match (self.binders.get(ident), self.map.const_by_name(ident.name)) {
+        let kind = match (self.binders.get(ident), self.early_cx.const_by_name(ident.name)) {
             (Some(Binder::Refined(name, ..)), _) => {
                 fhir::ExprKind::Var(fhir::Ident::new(*name, ident))
             }
             (Some(Binder::Unrefined), _) => {
                 let def_ident = self.binders.def_ident(ident).unwrap();
                 return Err(self
-                    .sess
+                    .early_cx
                     .emit_err(errors::InvalidUnrefinedParam::new(def_ident, ident)));
             }
             (None, Some(const_info)) => fhir::ExprKind::Const(const_info.def_id, ident.span),
-            (None, None) => return Err(self.sess.emit_err(errors::UnresolvedVar::new(ident))),
+            (None, None) => return Err(self.early_cx.emit_err(errors::UnresolvedVar::new(ident))),
         };
         Ok(fhir::Expr { kind, span: ident.span })
     }
@@ -635,7 +602,7 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                 // locs in ensure clauses are guaranteed to be locs during annot_check.
                 panic!("aggregate or unrefined binder used in loc position: `{binder:?}`")
             }
-            None => Err(self.sess.emit_err(errors::UnresolvedVar::new(loc))),
+            None => Err(self.early_cx.emit_err(errors::UnresolvedVar::new(loc))),
         }
     }
 }
@@ -647,37 +614,31 @@ fn desugar_ref_kind(rk: surface::RefKind) -> fhir::RefKind {
     }
 }
 
-fn resolve_sort(
-    sess: &FluxSession,
-    map: &fhir::Map,
-    sort: &surface::Sort,
-) -> Result<fhir::Sort, ErrorGuaranteed> {
+fn resolve_sort(early_cx: &EarlyCtxt, sort: &surface::Sort) -> Result<fhir::Sort, ErrorGuaranteed> {
     match sort {
-        surface::Sort::Base(sort) => resolve_base_sort(sess, map, *sort),
+        surface::Sort::Base(sort) => resolve_base_sort(early_cx, *sort),
         surface::Sort::Func { inputs, output } => {
-            Ok(resolve_func_sort(sess, map, inputs, output)?.into())
+            Ok(resolve_func_sort(early_cx, inputs, output)?.into())
         }
         surface::Sort::Infer => todo!(),
     }
 }
 
 fn resolve_func_sort(
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     inputs: &[surface::Ident],
     output: &surface::Ident,
 ) -> Result<fhir::FuncSort, ErrorGuaranteed> {
     let mut inputs_and_output: Vec<fhir::Sort> = inputs
         .iter()
-        .map(|sort| resolve_base_sort(sess, map, *sort))
+        .map(|sort| resolve_base_sort(early_cx, *sort))
         .try_collect_exhaust()?;
-    inputs_and_output.push(resolve_base_sort(sess, map, *output)?);
+    inputs_and_output.push(resolve_base_sort(early_cx, *output)?);
     Ok(fhir::FuncSort { inputs_and_output: List::from_vec(inputs_and_output) })
 }
 
 fn resolve_base_sort(
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     sort: surface::Ident,
 ) -> Result<fhir::Sort, ErrorGuaranteed> {
     if sort.name == SORTS.int {
@@ -686,10 +647,10 @@ fn resolve_base_sort(
         Ok(fhir::Sort::Bool)
     } else if sort.name == SORTS.real {
         Ok(fhir::Sort::Real)
-    } else if map.sort_decl(sort.name).is_some() {
+    } else if early_cx.sort_decl(sort.name).is_some() {
         Ok(fhir::Sort::User(sort.name))
     } else {
-        Err(sess.emit_err(errors::UnresolvedSort::new(sort)))
+        Err(early_cx.emit_err(errors::UnresolvedSort::new(sort)))
     }
 }
 
@@ -699,16 +660,15 @@ impl Binders {
     }
 
     fn from_params<'a>(
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         params: impl IntoIterator<Item = &'a surface::RefineParam>,
     ) -> Result<Self, ErrorGuaranteed> {
         let mut binders = Self::new();
         for param in params {
             binders.insert_binder(
-                sess,
+                early_cx.sess,
                 param.name,
-                Binder::Refined(binders.fresh(), resolve_sort(sess, map, &param.sort)?, false),
+                Binder::Refined(binders.fresh(), resolve_sort(early_cx, &param.sort)?, false),
             )?;
         }
         Ok(binders)
@@ -781,16 +741,14 @@ impl Binders {
 
     fn gather_params_variant(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         variant: &surface::VariantDef<Res>,
     ) -> Result<(), ErrorGuaranteed> {
         for ty in &variant.fields {
-            self.gather_params_ty(tcx, sess, map, None, ty, TypePos::Input)?;
+            self.gather_params_ty(early_cx, None, ty, TypePos::Input)?;
         }
         // Traverse return type to find illegal binders.
-        self.gather_params_path(tcx, sess, map, &variant.ret.path, TypePos::Other)?;
+        self.gather_params_path(early_cx, &variant.ret.path, TypePos::Other)?;
         // Check binders in `VariantRet`
         variant
             .ret
@@ -799,7 +757,7 @@ impl Binders {
             .iter()
             .try_for_each_exhaust(|idx| {
                 if let surface::RefineArg::Bind(_, kind, span) = idx {
-                    Err(sess.emit_err(errors::IllegalBinder::new(*span, *kind)))
+                    Err(early_cx.emit_err(errors::IllegalBinder::new(*span, *kind)))
                 } else {
                     Ok(())
                 }
@@ -808,20 +766,18 @@ impl Binders {
 
     fn gather_input_params_fn_sig(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         fn_sig: &surface::FnSig<Res>,
     ) -> Result<(), ErrorGuaranteed> {
         for param in &fn_sig.params {
             self.insert_binder(
-                sess,
+                early_cx.sess,
                 param.name,
-                Binder::Refined(self.fresh(), resolve_sort(sess, map, &param.sort)?, false),
+                Binder::Refined(self.fresh(), resolve_sort(early_cx, &param.sort)?, false),
             )?;
         }
         for arg in &fn_sig.args {
-            self.gather_params_fun_arg(tcx, sess, map, arg)?;
+            self.gather_params_fun_arg(early_cx, arg)?;
         }
 
         Ok(())
@@ -829,41 +785,41 @@ impl Binders {
 
     fn gather_output_params_fn_sig(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         fn_sig: &surface::FnSig<Res>,
     ) -> Result<(), ErrorGuaranteed> {
         if let Some(ret_ty) = &fn_sig.returns {
-            self.gather_params_ty(tcx, sess, map, None, ret_ty, TypePos::Output)?;
+            self.gather_params_ty(early_cx, None, ret_ty, TypePos::Output)?;
         }
         for (_, ty) in &fn_sig.ensures {
-            self.gather_params_ty(tcx, sess, map, None, ty, TypePos::Output)?;
+            self.gather_params_ty(early_cx, None, ty, TypePos::Output)?;
         }
         Ok(())
     }
 
     fn gather_params_fun_arg(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         arg: &surface::Arg<Res>,
     ) -> Result<(), ErrorGuaranteed> {
         match arg {
             surface::Arg::Constr(bind, path, _) => {
-                self.insert_binder(sess, *bind, Binder::from_res(&self.name_gen, path.res))?;
+                self.insert_binder(
+                    early_cx.sess,
+                    *bind,
+                    Binder::from_res(&self.name_gen, path.res),
+                )?;
             }
             surface::Arg::StrgRef(loc, ty) => {
                 self.insert_binder(
-                    sess,
+                    early_cx.sess,
                     *loc,
                     Binder::Refined(self.fresh(), fhir::Sort::Loc, false),
                 )?;
-                self.gather_params_ty(tcx, sess, map, None, ty, TypePos::Input)?;
+                self.gather_params_ty(early_cx, None, ty, TypePos::Input)?;
             }
             surface::Arg::Ty(bind, ty) => {
-                self.gather_params_ty(tcx, sess, map, *bind, ty, TypePos::Input)?;
+                self.gather_params_ty(early_cx, *bind, ty, TypePos::Input)?;
             }
             surface::Arg::Alias(..) => panic!("alias are not allowed after expansion"),
         }
@@ -872,9 +828,7 @@ impl Binders {
 
     fn gather_params_ty(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         bind: Option<surface::Ident>,
         ty: &surface::Ty<Res>,
         pos: TypePos,
@@ -892,96 +846,92 @@ impl Binders {
                 if let [surface::RefineArg::Bind(ident, kind, span)] = indices.indices[..] {
                     let binder = Binder::from_bty(&self.name_gen, bty);
                     if !pos.is_binder_allowed(kind) {
-                        return Err(sess.emit_err(errors::IllegalBinder::new(span, kind)));
+                        return Err(early_cx.emit_err(errors::IllegalBinder::new(span, kind)));
                     }
-                    self.insert_binder(sess, ident, binder)?;
+                    self.insert_binder(early_cx.sess, ident, binder)?;
                 } else {
-                    let refined_by = sorts(map, bty).unwrap();
+                    let refined_by = sorts(early_cx, bty).unwrap();
                     let exp = refined_by.len();
                     let got = indices.indices.len();
                     if exp != got {
                         return Err(
-                            sess.emit_err(errors::ParamCountMismatch::new(ty.span, exp, got))
+                            early_cx.emit_err(errors::ParamCountMismatch::new(ty.span, exp, got))
                         );
                     }
 
                     for (idx, sort) in iter::zip(&indices.indices, refined_by) {
                         if let surface::RefineArg::Bind(ident, kind, span) = idx {
                             if !pos.is_binder_allowed(*kind) {
-                                return Err(sess.emit_err(errors::IllegalBinder::new(*span, *kind)));
+                                return Err(
+                                    early_cx.emit_err(errors::IllegalBinder::new(*span, *kind))
+                                );
                             }
                             let name = self.name_gen.fresh();
                             self.insert_binder(
-                                sess,
+                                early_cx.sess,
                                 *ident,
                                 Binder::Refined(name, sort.clone(), true),
                             )?;
                         }
                     }
                 }
-                self.gather_params_bty(tcx, sess, map, bty, pos)
+                self.gather_params_bty(early_cx, bty, pos)
             }
             surface::TyKind::Base(bty) => {
                 if let Some(bind) = bind {
-                    self.insert_binder(sess, bind, Binder::from_bty(&self.name_gen, bty))?;
+                    self.insert_binder(early_cx.sess, bind, Binder::from_bty(&self.name_gen, bty))?;
                 }
-                self.gather_params_bty(tcx, sess, map, bty, pos)
+                self.gather_params_bty(early_cx, bty, pos)
             }
 
             surface::TyKind::Ref(_, ty) | surface::TyKind::Constr(_, ty) => {
                 if let Some(bind) = bind {
-                    self.insert_binder(sess, bind, Binder::Unrefined)?;
+                    self.insert_binder(early_cx.sess, bind, Binder::Unrefined)?;
                 }
-                self.gather_params_ty(tcx, sess, map, None, ty, pos)
+                self.gather_params_ty(early_cx, None, ty, pos)
             }
             surface::TyKind::Tuple(tys) => {
                 if let Some(bind) = bind {
-                    self.insert_binder(sess, bind, Binder::Unrefined)?;
+                    self.insert_binder(early_cx.sess, bind, Binder::Unrefined)?;
                 }
                 for ty in tys {
-                    self.gather_params_ty(tcx, sess, map, None, ty, pos)?;
+                    self.gather_params_ty(early_cx, None, ty, pos)?;
                 }
                 Ok(())
             }
             surface::TyKind::Array(ty, _) => {
-                self.gather_params_ty(tcx, sess, map, None, ty, TypePos::Other)
+                self.gather_params_ty(early_cx, None, ty, TypePos::Other)
             }
             surface::TyKind::Exists { bty, .. } => {
                 if let Some(bind) = bind {
-                    self.insert_binder(sess, bind, Binder::from_bty(&self.name_gen, bty))?;
+                    self.insert_binder(early_cx.sess, bind, Binder::from_bty(&self.name_gen, bty))?;
                 }
-                self.gather_params_bty(tcx, sess, map, bty, pos)
+                self.gather_params_bty(early_cx, bty, pos)
             }
         }
     }
 
     fn gather_params_path(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         path: &surface::Path<Res>,
         pos: TypePos,
     ) -> Result<(), ErrorGuaranteed> {
-        let pos = if is_box(tcx, path.res) { pos } else { TypePos::Other };
+        let pos = if is_box(early_cx, path.res) { pos } else { TypePos::Other };
         path.args
             .iter()
-            .try_for_each_exhaust(|ty| self.gather_params_ty(tcx, sess, map, None, ty, pos))
+            .try_for_each_exhaust(|ty| self.gather_params_ty(early_cx, None, ty, pos))
     }
 
     fn gather_params_bty(
         &mut self,
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         bty: &surface::BaseTy<Res>,
         pos: TypePos,
     ) -> Result<(), ErrorGuaranteed> {
         match bty {
-            surface::BaseTy::Path(path) => self.gather_params_path(tcx, sess, map, path, pos),
-            surface::BaseTy::Slice(ty) => {
-                self.gather_params_ty(tcx, sess, map, None, ty, TypePos::Other)
-            }
+            surface::BaseTy::Path(path) => self.gather_params_path(early_cx, path, pos),
+            surface::BaseTy::Slice(ty) => self.gather_params_ty(early_cx, None, ty, TypePos::Other),
         }
     }
 
@@ -1010,9 +960,9 @@ fn infer_mode(implicit: bool, sort: &fhir::Sort) -> fhir::InferMode {
     }
 }
 
-fn is_box(tcx: TyCtxt, res: surface::Res) -> bool {
+fn is_box(early_cx: &EarlyCtxt, res: surface::Res) -> bool {
     if let Res::Adt(def_id) = res {
-        tcx.adt_def(def_id).is_box()
+        early_cx.tcx.adt_def(def_id).is_box()
     } else {
         false
     }
@@ -1133,13 +1083,13 @@ impl Binder {
     }
 }
 
-fn sorts<'a>(map: &'a fhir::Map, bty: &surface::BaseTy<Res>) -> Option<&'a [fhir::Sort]> {
+fn sorts<'a>(early_cx: &EarlyCtxt<'a, '_>, bty: &surface::BaseTy<Res>) -> Option<&'a [fhir::Sort]> {
     let sorts = match bty {
         surface::BaseTy::Path(path) => {
             match path.res {
                 Res::Bool => &[fhir::Sort::Bool],
                 Res::Int(_) | Res::Uint(_) => &[fhir::Sort::Int],
-                Res::Adt(def_id) => map.sorts_of(def_id).unwrap_or(&[]),
+                Res::Adt(def_id) => early_cx.sorts_of(def_id),
                 Res::Float(_) | Res::Param(_) | Res::Str | Res::Char => return None,
             }
         }

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -18,62 +18,55 @@ mod table_resolver;
 pub use desugar::{
     desugar_adt_def, desugar_defn, desugar_qualifier, resolve_defn_uif, resolve_uif_def,
 };
-use flux_errors::FluxSession;
-use flux_middle::fhir;
-use flux_syntax::surface::{self, TyCtxt};
+use flux_middle::{early_ctxt::EarlyCtxt, fhir};
+use flux_syntax::surface;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::LocalDefId;
 
 pub fn desugar_struct_def(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     struct_def: surface::StructDef,
 ) -> Result<fhir::StructDef, ErrorGuaranteed> {
     // Resolve
-    let resolver = table_resolver::Resolver::new(tcx, sess, struct_def.def_id)?;
+    let resolver = table_resolver::Resolver::new(early_cx.tcx, early_cx.sess, struct_def.def_id)?;
     let struct_def = resolver.resolve_struct_def(struct_def)?;
 
     // Check
-    annot_check::check_struct_def(tcx, sess, &struct_def)?;
+    annot_check::check_struct_def(early_cx.tcx, early_cx.sess, &struct_def)?;
 
     // Desugar
-    desugar::desugar_struct_def(tcx, sess, map, struct_def)
+    desugar::desugar_struct_def(early_cx, struct_def)
 }
 
 pub fn desugar_enum_def(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     enum_def: surface::EnumDef,
 ) -> Result<fhir::EnumDef, ErrorGuaranteed> {
     // Resolve
-    let resolver = table_resolver::Resolver::new(tcx, sess, enum_def.def_id)?;
+    let resolver = table_resolver::Resolver::new(early_cx.tcx, early_cx.sess, enum_def.def_id)?;
     let enum_def = resolver.resolve_enum_def(enum_def)?;
 
     // Check
-    annot_check::check_enum_def(tcx, sess, &enum_def)?;
+    annot_check::check_enum_def(early_cx.tcx, early_cx.sess, &enum_def)?;
 
     // Desugar
-    desugar::desugar_enum_def(tcx, sess, map, &enum_def)
+    desugar::desugar_enum_def(early_cx, &enum_def)
 }
 
 pub fn desugar_fn_sig(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     def_id: LocalDefId,
     fn_sig: surface::FnSig,
 ) -> Result<fhir::FnSig, ErrorGuaranteed> {
     // Resolve
-    let resolver = table_resolver::Resolver::new(tcx, sess, def_id)?;
+    let resolver = table_resolver::Resolver::new(early_cx.tcx, early_cx.sess, def_id)?;
     let fn_sig = resolver.resolve_fn_sig(fn_sig)?;
 
     // Check
-    annot_check::check_fn_sig(tcx, sess, def_id.to_def_id(), &fn_sig)?;
+    annot_check::check_fn_sig(early_cx.tcx, early_cx.sess, def_id.to_def_id(), &fn_sig)?;
 
     // Desugar
-    desugar::desugar_fn_sig(tcx, sess, map, &fn_sig)
+    desugar::desugar_fn_sig(early_cx, &fn_sig)
 }
 
 pub fn desugar_sort_decl(sort_decl: surface::SortDecl) -> fhir::SortDecl {

--- a/flux-driver/Cargo.toml
+++ b/flux-driver/Cargo.toml
@@ -11,6 +11,7 @@ flux-desugar = { path = "../flux-desugar" }
 flux-errors = { path = "../flux-errors" }
 flux-fixpoint = { path = "../flux-fixpoint" }
 flux-macros = { path = "../flux-macros" }
+flux-metadata = { path = "../flux-metadata" }
 flux-middle = { path = "../flux-middle" }
 flux-refineck = { path = "../flux-refineck" }
 flux-syntax = { path = "../flux-syntax" }

--- a/flux-errors/locales/en-US/metadata.ftl
+++ b/flux-errors/locales/en-US/metadata.ftl
@@ -1,0 +1,1 @@
+metadata_decode_file_error = "error when decoding flux metadata file {$path}: {$err}"

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private)]
+#![feature(rustc_private, never_type)]
 
 extern crate rustc_data_structures;
 extern crate rustc_errors;
@@ -56,6 +56,11 @@ impl FluxSession {
     #[track_caller]
     pub fn emit_err<'a>(&'a self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         err.into_diagnostic(&self.parse_sess.span_diagnostic).emit()
+    }
+
+    #[track_caller]
+    pub fn emit_fatal<'a>(&'a self, fatal: impl IntoDiagnostic<'a, !>) -> ! {
+        self.parse_sess.emit_fatal(fatal)
     }
 
     pub fn abort_if_errors(&self) {

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -23,8 +23,8 @@ use rustc_session::{
 };
 use rustc_span::source_map::SourceMap;
 
-// These are sorted loosely following the order of the pipeline except for lowering which doesn't
-// quite fit this ordering.
+// These are sorted loosely following the order of the pipeline except for lowering and metadata
+// which don't quite fit this ordering.
 fluent_messages! {
     parse => "../locales/en-US/parse.ftl",
     resolver => "../locales/en-US/resolver.ftl",
@@ -34,6 +34,7 @@ fluent_messages! {
     invariants => "../locales/en-US/invariants.ftl",
     refineck => "../locales/en-US/refineck.ftl",
     lowering => "../locales/en-US/lowering.ftl",
+    metadata => "../locales/en-US/metadata.ftl",
 }
 
 pub use fluent_generated::{self as fluent, DEFAULT_LOCALE_RESOURCES};

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -7,6 +7,7 @@ use std::{
 use flux_common::format::PadAdapter;
 use itertools::Itertools;
 use rustc_index::newtype_index;
+use rustc_macros::{Decodable, Encodable};
 
 pub enum Constraint<Tag> {
     Pred(Pred, Option<Tag>),
@@ -87,7 +88,7 @@ pub struct Const {
     pub val: i128,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum BinOp {
     Iff,
     Imp,
@@ -106,20 +107,20 @@ pub enum BinOp {
     Mod,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum UnOp {
     Not,
     Neg,
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Constant {
     Int(Sign, u128),
     Real(i128),
     Bool(bool),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Sign {
     Positive,
     Negative,

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private, min_specialization, once_cell, box_patterns, let_chains)]
 
 extern crate rustc_index;
+extern crate rustc_macros;
 extern crate rustc_serialize;
 
 mod constraint;

--- a/flux-metadata/Cargo.toml
+++ b/flux-metadata/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 flux-common = { path = "../flux-common" }
+flux-errors = { path = "../flux-errors" }
 flux-middle = { path = "../flux-middle" }
 
 [package.metadata.rust-analyzer]

--- a/flux-metadata/Cargo.toml
+++ b/flux-metadata/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 flux-common = { path = "../flux-common" }
 flux-errors = { path = "../flux-errors" }
 flux-middle = { path = "../flux-middle" }
+itertools = "0.10"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/flux-metadata/Cargo.toml
+++ b/flux-metadata/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+edition = "2021"
+name = "flux-metadata"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+flux-common = { path = "../flux-common" }
+flux-middle = { path = "../flux-middle" }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/flux-metadata/Cargo.toml
+++ b/flux-metadata/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [dependencies]
 flux-common = { path = "../flux-common" }
 flux-errors = { path = "../flux-errors" }
+flux-macros = { path = "../flux-macros" }
 flux-middle = { path = "../flux-middle" }
 itertools = "0.10"
 

--- a/flux-metadata/src/decoder.rs
+++ b/flux-metadata/src/decoder.rs
@@ -1,0 +1,78 @@
+use std::mem;
+
+use flux_common::bug;
+use rustc_data_structures::sync::HashMapExt;
+use rustc_middle::{
+    implement_ty_decoder,
+    ty::{self, TyCtxt},
+};
+use rustc_serialize::{opaque::MemDecoder, Decodable};
+use rustc_span::def_id::{CrateNum, StableCrateId};
+use rustc_type_ir::TyDecoder;
+
+struct DecodeContext<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    opaque: MemDecoder<'a>,
+}
+
+impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for CrateNum {
+    fn decode(d: &mut DecodeContext<'a, 'tcx>) -> Self {
+        let stable_id = StableCrateId::decode(d);
+        d.tcx.stable_crate_id_to_crate_num(stable_id)
+    }
+}
+
+implement_ty_decoder!(DecodeContext<'a, 'tcx>);
+
+impl<'a, 'tcx> TyDecoder for DecodeContext<'a, 'tcx> {
+    type I = TyCtxt<'tcx>;
+
+    const CLEAR_CROSS_CRATE: bool = true;
+
+    fn interner(&self) -> Self::I {
+        self.tcx
+    }
+
+    fn peek_byte(&self) -> u8 {
+        self.opaque.data[self.opaque.position()]
+    }
+
+    fn position(&self) -> usize {
+        self.opaque.position()
+    }
+
+    fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> ty::Ty<'tcx>
+    where
+        F: FnOnce(&mut Self) -> ty::Ty<'tcx>,
+    {
+        let tcx = self.tcx;
+
+        let cache_key = ty::CReaderCacheKey { cnum: None, pos: shorthand };
+
+        if let Some(&ty) = tcx.ty_rcache.borrow().get(&cache_key) {
+            return ty;
+        }
+
+        let ty = or_insert_with(self);
+        // This may overwrite the entry, but it should overwrite with the same value.
+        tcx.ty_rcache.borrow_mut().insert_same(cache_key, ty);
+        ty
+    }
+
+    fn with_position<F, R>(&mut self, pos: usize, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        debug_assert!(pos < self.opaque.data.len());
+
+        let new_opaque = MemDecoder::new(self.opaque.data, pos);
+        let old_opaque = mem::replace(&mut self.opaque, new_opaque);
+        let r = f(self);
+        self.opaque = old_opaque;
+        r
+    }
+
+    fn decode_alloc_id(&mut self) -> rustc_middle::mir::interpret::AllocId {
+        bug!("Encoding `interpret::AllocId` is not supported")
+    }
+}

--- a/flux-metadata/src/encoder.rs
+++ b/flux-metadata/src/encoder.rs
@@ -9,7 +9,7 @@ use rustc_serialize::{opaque, Encodable, Encoder};
 use rustc_span::def_id::{CrateNum, DefIndex};
 use rustc_type_ir::TyEncoder;
 
-use crate::{CrateRoot, METADATA_HEADER};
+use crate::{CrateMetadata, METADATA_HEADER};
 
 struct EncodeContext<'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -25,7 +25,7 @@ pub fn encode_metadata(genv: &GlobalEnv, path: &std::path::Path) {
 
     encoder.emit_raw_bytes(METADATA_HEADER);
 
-    let crate_root = CrateRoot::new(genv);
+    let crate_root = CrateMetadata::new(genv);
 
     let mut ecx = EncodeContext {
         tcx: genv.tcx,

--- a/flux-metadata/src/encoder.rs
+++ b/flux-metadata/src/encoder.rs
@@ -1,0 +1,79 @@
+use rustc_hash::FxHashMap;
+use rustc_middle::{
+    bug,
+    ty::{self, TyCtxt},
+};
+use rustc_serialize::{opaque, Encodable, Encoder};
+use rustc_span::def_id::CrateNum;
+use rustc_type_ir::TyEncoder;
+
+struct EncodeContext<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    opaque: opaque::FileEncoder,
+    type_shorthands: FxHashMap<ty::Ty<'tcx>, usize>,
+    predicate_shorthands: FxHashMap<ty::PredicateKind<'tcx>, usize>,
+    // interpret_allocs: FxIndexSet<interpret::AllocId>,
+}
+
+impl<'tcx> TyEncoder for EncodeContext<'tcx> {
+    const CLEAR_CROSS_CRATE: bool = true;
+
+    type I = TyCtxt<'tcx>;
+
+    fn position(&self) -> usize {
+        self.opaque.position()
+    }
+
+    fn type_shorthands(&mut self) -> &mut FxHashMap<ty::Ty<'tcx>, usize> {
+        &mut self.type_shorthands
+    }
+
+    fn predicate_shorthands(&mut self) -> &mut FxHashMap<ty::PredicateKind<'tcx>, usize> {
+        &mut self.predicate_shorthands
+    }
+
+    fn encode_alloc_id(&mut self, _alloc_id: &rustc_middle::mir::interpret::AllocId) {
+        bug!("Encoding `interpret::AllocId` is not supported");
+        // let (index, _) = self.interpret_allocs.insert_full(*alloc_id);
+        // index.encode(self);
+    }
+}
+
+impl<'tcx> Encodable<EncodeContext<'tcx>> for CrateNum {
+    fn encode(&self, s: &mut EncodeContext<'tcx>) {
+        s.tcx.stable_crate_id(*self).encode(s);
+    }
+}
+
+macro_rules! encoder_methods {
+    ($($name:ident($ty:ty);)*) => {
+        $(fn $name(&mut self, value: $ty) {
+            self.opaque.$name(value)
+        })*
+    }
+}
+
+impl<'tcx> Encoder for EncodeContext<'tcx> {
+    encoder_methods! {
+        emit_usize(usize);
+        emit_u128(u128);
+        emit_u64(u64);
+        emit_u32(u32);
+        emit_u16(u16);
+        emit_u8(u8);
+
+        emit_isize(isize);
+        emit_i128(i128);
+        emit_i64(i64);
+        emit_i32(i32);
+        emit_i16(i16);
+        emit_i8(i8);
+
+        emit_bool(bool);
+        emit_f64(f64);
+        emit_f32(f32);
+        emit_char(char);
+        emit_str(&str);
+        emit_raw_bytes(&[u8]);
+    }
+}

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -1,0 +1,23 @@
+#![allow(incomplete_features)]
+#![feature(rustc_private, specialization)]
+
+extern crate rustc_data_structures;
+extern crate rustc_hash;
+extern crate rustc_macros;
+extern crate rustc_middle;
+extern crate rustc_serialize;
+extern crate rustc_span;
+extern crate rustc_type_ir;
+
+mod decoder;
+mod encoder;
+
+use flux_middle::rty;
+use rustc_hash::FxHashMap;
+use rustc_macros::{TyDecodable, TyEncodable};
+use rustc_span::def_id::DefIndex;
+
+#[derive(TyEncodable, TyDecodable)]
+pub struct CrateRoot {
+    type_of: FxHashMap<DefIndex, rty::Ty>,
+}

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -3,7 +3,9 @@
 
 extern crate rustc_data_structures;
 extern crate rustc_hash;
+extern crate rustc_hir;
 extern crate rustc_macros;
+extern crate rustc_metadata;
 extern crate rustc_middle;
 extern crate rustc_serialize;
 extern crate rustc_span;
@@ -12,12 +14,48 @@ extern crate rustc_type_ir;
 mod decoder;
 mod encoder;
 
-use flux_middle::rty;
+use flux_middle::{global_env::GlobalEnv, rty};
 use rustc_hash::FxHashMap;
+use rustc_hir::def::DefKind;
 use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_span::def_id::DefIndex;
 
+pub use crate::encoder::encode_metadata;
+
+const METADATA_VERSION: u8 = 0;
+const METADATA_HEADER: &[u8] = &[b'f', b'l', b'u', b'x', 0, 0, 0, METADATA_VERSION];
+
 #[derive(TyEncodable, TyDecodable)]
 pub struct CrateRoot {
-    type_of: FxHashMap<DefIndex, rty::Ty>,
+    fn_sigs: FxHashMap<DefIndex, rty::PolySig>,
+}
+
+impl CrateRoot {
+    fn new(genv: &GlobalEnv) -> Self {
+        let tcx = genv.tcx;
+        let mut fn_sigs = FxHashMap::default();
+
+        for local_id in tcx.iter_local_def_id() {
+            let def_id = local_id.to_def_id();
+            let def_kind = tcx.def_kind(local_id);
+
+            match def_kind {
+                DefKind::Fn | DefKind::AssocFn => {
+                    fn_sigs.insert(
+                        def_id.index,
+                        genv.lookup_fn_sig(def_id)
+                            .unwrap_or_else(|err| genv.sess.emit_fatal(err)),
+                    );
+                }
+                DefKind::Enum | DefKind::Struct => {
+                    // println!("adt {:?}", tcx.def_path_str(def_id));
+                }
+                DefKind::Variant => {
+                    // println!("variant {:?}", tcx.def_path_str(def_id));
+                }
+                _ => {}
+            }
+        }
+        Self { fn_sigs }
+    }
 }

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -1,7 +1,8 @@
 #![allow(incomplete_features)]
-#![feature(rustc_private, specialization)]
+#![feature(rustc_private, specialization, if_let_guard)]
 
 extern crate rustc_data_structures;
+extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_macros;
@@ -60,7 +61,7 @@ impl CStore {
             .iter()
             .filter_map(|crate_num| {
                 let path = flux_metadata_extern_location(tcx, *crate_num)?;
-                let meta = decode_crate_metadata(tcx, sess, path.as_path());
+                let meta = decode_crate_metadata(tcx, sess, path.as_path())?;
                 Some((*crate_num, meta))
             })
             .collect();

--- a/flux-middle/src/cstore.rs
+++ b/flux-middle/src/cstore.rs
@@ -1,0 +1,9 @@
+use rustc_hir::def_id::DefId;
+
+use crate::rty;
+
+pub trait CrateStore {
+    fn fn_sig(&self, def_id: DefId) -> Option<rty::PolySig>;
+}
+
+pub type CrateStoreDyn = dyn CrateStore;

--- a/flux-middle/src/cstore.rs
+++ b/flux-middle/src/cstore.rs
@@ -1,9 +1,14 @@
-use rustc_hir::def_id::DefId;
+use rustc_span::{def_id::DefId, Symbol};
 
 use crate::rty;
 
 pub trait CrateStore {
     fn fn_sig(&self, def_id: DefId) -> Option<rty::PolySig>;
+    fn sorts_of(&self, def_id: DefId) -> Option<&[rty::Sort]>;
+    fn field_index(&self, def_id: DefId, fld: Symbol) -> Option<usize>;
+    fn field_sort(&self, def_id: DefId, fld: Symbol) -> Option<&rty::Sort>;
+    fn adt_def(&self, def_id: DefId) -> Option<&rty::AdtDef>;
+    fn variants(&self, def_id: DefId) -> Option<Option<&[rty::PolyVariant]>>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore;

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -1,4 +1,4 @@
-///! Context used before refinement checking while building [`fhir::Map`] and during
+///! The context used before refinement checking while building the [`fhir::Map`] and for
 ///! well-formedness checking.
 use std::borrow::Borrow;
 

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -1,0 +1,44 @@
+///! Context used before refinement checking while building [`fhir::Map`] and during
+///! well-formedness checking.
+use std::borrow::Borrow;
+
+use flux_errors::{ErrorGuaranteed, FluxSession};
+use rustc_errors::IntoDiagnostic;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::{def_id::DefId, Symbol};
+
+use crate::{cstore::CrateStoreDyn, fhir};
+
+pub struct EarlyCtxt<'a, 'tcx> {
+    pub tcx: TyCtxt<'tcx>,
+    pub sess: &'a FluxSession,
+    pub cstore: &'a CrateStoreDyn,
+    pub map: &'a mut fhir::Map,
+}
+
+impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, sess: &'a FluxSession, map: &'a mut fhir::Map) -> Self {
+        todo!()
+    }
+
+    pub fn sort_decl(&self, name: impl Borrow<Symbol>) -> Option<fhir::SortDecl> {
+        todo!()
+    }
+
+    #[track_caller]
+    pub fn emit_err<'b>(&'b self, err: impl IntoDiagnostic<'b>) -> ErrorGuaranteed {
+        self.sess.emit_err(err)
+    }
+
+    pub fn sorts_of(&self, def_id: DefId) -> &'a [fhir::Sort] {
+        todo!()
+    }
+
+    pub fn uif(&self, name: impl Borrow<Symbol>) -> Option<&fhir::UifDef> {
+        todo!()
+    }
+
+    pub fn const_by_name(&self, name: impl Borrow<Symbol>) -> Option<&fhir::ConstInfo> {
+        todo!()
+    }
+}

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -12,17 +12,22 @@ use crate::{cstore::CrateStoreDyn, fhir};
 pub struct EarlyCtxt<'a, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub sess: &'a FluxSession,
-    pub cstore: &'a CrateStoreDyn,
-    pub map: &'a mut fhir::Map,
+    pub cstore: Box<CrateStoreDyn>,
+    pub map: fhir::Map,
 }
 
 impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, sess: &'a FluxSession, map: &'a mut fhir::Map) -> Self {
-        todo!()
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        sess: &'a FluxSession,
+        cstore: Box<CrateStoreDyn>,
+        map: fhir::Map,
+    ) -> Self {
+        Self { tcx, sess, cstore, map }
     }
 
-    pub fn sort_decl(&self, name: impl Borrow<Symbol>) -> Option<fhir::SortDecl> {
-        todo!()
+    pub fn sort_decl(&self, name: impl Borrow<Symbol>) -> Option<&fhir::SortDecl> {
+        self.map.sort_decl(name)
     }
 
     #[track_caller]
@@ -30,15 +35,35 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
         self.sess.emit_err(err)
     }
 
-    pub fn sorts_of(&self, def_id: DefId) -> &'a [fhir::Sort] {
-        todo!()
+    pub fn sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {
+        if let Some(local_id) = def_id.as_local() {
+            self.map.sorts_of(local_id)
+        } else {
+            &[]
+        }
     }
 
     pub fn uif(&self, name: impl Borrow<Symbol>) -> Option<&fhir::UifDef> {
-        todo!()
+        self.map.uif(name)
     }
 
     pub fn const_by_name(&self, name: impl Borrow<Symbol>) -> Option<&fhir::ConstInfo> {
-        todo!()
+        self.map.const_by_name(name)
+    }
+
+    pub fn field_index(&self, adt_def_id: DefId, fld: Symbol) -> Option<usize> {
+        if let Some(local_id) = adt_def_id.as_local() {
+            self.map.adt(local_id).field_index(fld)
+        } else {
+            todo!()
+        }
+    }
+
+    pub fn field_sort(&self, adt_def_id: DefId, fld: Symbol) -> Option<&fhir::Sort> {
+        if let Some(local_id) = adt_def_id.as_local() {
+            self.map.adt(local_id).field_sort(fld)
+        } else {
+            todo!()
+        }
     }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -213,7 +213,7 @@ pub struct RefineParam {
 }
 
 /// *Infer*ence *mode* for parameter at function calls
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum InferMode {
     /// Generate a fresh evar for the parameter and solve it via syntactic unification. The
     /// parameter must appear as an index for unification to succeed, but otherwise it can appear

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -26,6 +26,7 @@ use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::newtype_index;
+use rustc_macros::{Decodable, Encodable};
 pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, UintTy};
 use rustc_span::{Span, Symbol, DUMMY_SP};
 pub use rustc_target::abi::VariantIdx;
@@ -153,7 +154,7 @@ pub struct ArrayLen {
     pub val: usize,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Encodable, Decodable)]
 pub enum RefKind {
     Shr,
     Mut,
@@ -224,7 +225,7 @@ pub enum InferMode {
     KVar,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Sort {
     Int,
     Bool,
@@ -238,7 +239,7 @@ pub enum Sort {
     User(Symbol),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct FuncSort {
     pub inputs_and_output: List<Sort>,
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -392,6 +392,10 @@ impl AdtDef {
             },
         )
     }
+
+    pub fn sorts(&self) -> &[Sort] {
+        &self.sorts
+    }
 }
 
 impl RefinedBy {
@@ -583,10 +587,6 @@ impl Map {
 
     pub fn insert_adt(&mut self, def_id: LocalDefId, sort_info: AdtDef) {
         self.adts.insert(def_id, sort_info);
-    }
-
-    pub fn sorts_of(&self, def_id: LocalDefId) -> &[Sort] {
-        &self.adts[&def_id].sorts
     }
 
     pub fn adt(&self, def_id: LocalDefId) -> &AdtDef {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -548,8 +548,8 @@ impl Map {
         self.consts.values()
     }
 
-    pub fn const_by_name(&self, name: Symbol) -> Option<&ConstInfo> {
-        self.consts.get(&name)
+    pub fn const_by_name(&self, name: impl Borrow<Symbol>) -> Option<&ConstInfo> {
+        self.consts.get(name.borrow())
     }
 
     // UIF
@@ -585,14 +585,8 @@ impl Map {
         self.adts.insert(def_id, sort_info);
     }
 
-    pub fn sorts_of(&self, def_id: DefId) -> Option<&[Sort]> {
-        let info = self.adts.get(&def_id.as_local()?)?;
-        Some(&info.sorts)
-    }
-
-    pub fn refined_by(&self, def_id: DefId) -> Option<&RefinedBy> {
-        let adt_def = self.adts.get(&def_id.as_local()?)?;
-        Some(&adt_def.refined_by)
+    pub fn sorts_of(&self, def_id: LocalDefId) -> &[Sort] {
+        &self.adts[&def_id].sorts
     }
 
     pub fn adt(&self, def_id: LocalDefId) -> &AdtDef {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -514,12 +514,8 @@ impl Map {
         self.fn_quals.iter().map(|(def_id, quals)| (*def_id, quals))
     }
 
-    pub fn is_trusted(&self, def_id: DefId) -> bool {
-        if let Some(def_id) = def_id.as_local() {
-            self.trusted.contains(&def_id)
-        } else {
-            false
-        }
+    pub fn is_trusted(&self, def_id: LocalDefId) -> bool {
+        self.trusted.contains(&def_id)
     }
 
     // Structs

--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -9,11 +9,13 @@ extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_infer;
+extern crate rustc_macros;
 extern crate rustc_middle;
 extern crate rustc_serialize;
 extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
+extern crate rustc_type_ir;
 
 pub mod const_eval;
 pub mod fhir;

--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -19,6 +19,7 @@ extern crate rustc_type_ir;
 
 pub mod const_eval;
 pub mod cstore;
+pub mod early_ctxt;
 pub mod fhir;
 pub mod global_env;
 pub mod intern;

--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -18,6 +18,7 @@ extern crate rustc_trait_selection;
 extern crate rustc_type_ir;
 
 pub mod const_eval;
+pub mod cstore;
 pub mod fhir;
 pub mod global_env;
 pub mod intern;

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -9,13 +9,14 @@
 //! 3. Refinements are well-sorted
 use std::{borrow::Borrow, iter, ops::Range};
 
+use flux_common::bug;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use rustc_middle::ty::TyCtxt;
 use rustc_target::abi::VariantIdx;
 
 use super::{Binders, PolyVariant, VariantRet};
 use crate::{
+    early_ctxt::EarlyCtxt,
     fhir,
     global_env::GlobalEnv,
     intern::List,
@@ -23,13 +24,13 @@ use crate::{
     rustc::ty::GenericParamDefKind,
 };
 
-pub struct ConvCtxt<'a, 'genv, 'tcx> {
-    genv: &'a GlobalEnv<'genv, 'tcx>,
-    env: Env<'a>,
+pub struct ConvCtxt<'a, 'tcx> {
+    genv: &'a GlobalEnv<'a, 'tcx>,
+    env: Env<'a, 'tcx>,
 }
 
-struct Env<'a> {
-    map: &'a fhir::Map,
+struct Env<'a, 'tcx> {
+    early_cx: &'a EarlyCtxt<'a, 'tcx>,
     layers: Vec<Layer>,
 }
 
@@ -37,9 +38,9 @@ struct Layer {
     map: FxHashMap<fhir::Name, (fhir::Sort, Range<usize>)>,
 }
 
-pub(crate) fn conv_adt_def(tcx: TyCtxt, map: &fhir::Map, adt_def: &fhir::AdtDef) -> rty::AdtDef {
-    let env = Env::from_refined_by(map, &adt_def.refined_by);
-    let sorts = flatten_sorts(map, adt_def.refined_by.params.iter().map(|(_, sort)| sort));
+pub(crate) fn conv_adt_def(early_cx: &EarlyCtxt, adt_def: &fhir::AdtDef) -> rty::AdtDef {
+    let env = Env::from_refined_by(early_cx, &adt_def.refined_by);
+    let sorts = flatten_sorts(early_cx, adt_def.refined_by.params.iter().map(|(_, sort)| sort));
 
     let invariants = adt_def
         .invariants
@@ -47,24 +48,24 @@ pub(crate) fn conv_adt_def(tcx: TyCtxt, map: &fhir::Map, adt_def: &fhir::AdtDef)
         .map(|invariant| env.conv_invariant(&sorts, invariant))
         .collect_vec();
 
-    rty::AdtDef::new(tcx.adt_def(adt_def.def_id), sorts, invariants, adt_def.opaque)
+    rty::AdtDef::new(early_cx.tcx.adt_def(adt_def.def_id), sorts, invariants, adt_def.opaque)
 }
 
-pub(crate) fn conv_defn(map: &fhir::Map, defn: &fhir::Defn) -> rty::Defn {
-    let env = Env::from_args(map, &defn.args);
-    let sorts = flatten_sorts(map, defn.args.iter().map(|(_, sort)| sort));
+pub(crate) fn conv_defn(early_cx: &EarlyCtxt, defn: &fhir::Defn) -> rty::Defn {
+    let env = Env::from_args(early_cx, &defn.args);
+    let sorts = flatten_sorts(early_cx, defn.args.iter().map(|(_, sort)| sort));
     let expr = Binders::new(env.conv_expr(&defn.expr), sorts);
     rty::Defn { name: defn.name, expr }
 }
 
-impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
-    fn from_refined_by(genv: &'a GlobalEnv<'genv, 'tcx>, refined_by: &fhir::RefinedBy) -> Self {
-        let env = Env::from_refined_by(genv.map(), refined_by);
+impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
+    fn from_refined_by(genv: &'a GlobalEnv<'a, 'tcx>, refined_by: &fhir::RefinedBy) -> Self {
+        let env = Env::from_refined_by(genv.early_cx(), refined_by);
         Self { genv, env }
     }
 
-    fn from_params(genv: &'a GlobalEnv<'genv, 'tcx>, params: &[fhir::RefineParam]) -> Self {
-        let env = Env::from_params(genv.map(), params);
+    fn from_params(genv: &'a GlobalEnv<'a, 'tcx>, params: &[fhir::RefineParam]) -> Self {
+        let env = Env::from_params(genv.early_cx(), params);
         Self { genv, env }
     }
 
@@ -83,14 +84,14 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
         let output = cx.conv_fn_output(&fn_sig.output);
 
-        let sorts = flatten_sorts(genv.map(), fn_sig.params.iter().map(|param| &param.sort));
+        let sorts = flatten_sorts(genv.early_cx(), fn_sig.params.iter().map(|param| &param.sort));
         let modes = cx.conv_infer_modes(&fn_sig.params);
         rty::PolySig::new(rty::Binders::new(rty::FnSig::new(requires, args, output), sorts), modes)
     }
 
     fn conv_fn_output(&mut self, output: &fhir::FnOutput) -> Binders<rty::FnOutput> {
         self.env.push_layer(Layer::new(
-            self.genv.map(),
+            self.early_cx(),
             output
                 .params
                 .iter()
@@ -103,7 +104,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .iter()
             .map(|constr| self.conv_constr(constr))
             .collect_vec();
-        let sorts = flatten_sorts(self.genv.map(), output.params.iter().map(|param| &param.sort));
+        let sorts = flatten_sorts(self.early_cx(), output.params.iter().map(|param| &param.sort));
         let output = rty::FnOutput::new(ret, ensures);
 
         self.env.pop_layer();
@@ -116,7 +117,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             .iter()
             .flat_map(|param| {
                 let n = if let fhir::Sort::Adt(def_id) = &param.sort {
-                    self.genv.map().sorts_of(*def_id).unwrap_or(&[]).len()
+                    self.early_cx().sorts_of(*def_id).len()
                 } else {
                     1
                 };
@@ -148,7 +149,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     fn conv_variant(genv: &GlobalEnv, variant: &fhir::VariantDef) -> PolyVariant {
         let mut cx = ConvCtxt::from_params(genv, &variant.params);
         let fields = variant.fields.iter().map(|ty| cx.conv_ty(ty)).collect_vec();
-        let sorts = flatten_sorts(genv.map(), variant.params.iter().map(|param| &param.sort));
+        let sorts = flatten_sorts(genv.early_cx(), variant.params.iter().map(|param| &param.sort));
         let variant = rty::VariantDef::new(fields, cx.conv_variant_ret(&variant.ret));
         Binders::new(variant, sorts)
     }
@@ -156,7 +157,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     fn conv_variant_ret(&mut self, ret: &fhir::VariantRet) -> VariantRet {
         let bty = self.conv_base_ty(&ret.bty);
         let args = List::from_iter(
-            iter::zip(ret.idx.flatten(), flatten_sort(self.genv.map(), &ret.bty.sort()))
+            iter::zip(ret.idx.flatten(), flatten_sort(self.early_cx(), &ret.bty.sort()))
                 .flat_map(|(arg, sort)| self.conv_refine_arg(arg, &sort)),
         );
 
@@ -199,7 +200,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 })
                 .collect_vec();
 
-            let sorts = flatten_sorts(genv.map(), refined_by.sorts());
+            let sorts = flatten_sorts(genv.early_cx(), refined_by.sorts());
             let idxs =
                 (0..sorts.len()).map(|idx| rty::Expr::bvar(rty::BoundVar::innermost(idx)).into());
             let ret = VariantRet {
@@ -225,9 +226,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         }
     }
 
-    pub fn conv_qualifier(map: &fhir::Map, qualifier: &fhir::Qualifier) -> rty::Qualifier {
-        let env = Env::from_args(map, &qualifier.args);
-        let sorts = flatten_sorts(map, qualifier.args.iter().map(|(_, sort)| sort));
+    pub fn conv_qualifier(early_cx: &EarlyCtxt, qualifier: &fhir::Qualifier) -> rty::Qualifier {
+        let env = Env::from_args(early_cx, &qualifier.args);
+        let sorts = flatten_sorts(early_cx, qualifier.args.iter().map(|(_, sort)| sort));
         let body = Binders::new(env.conv_expr(&qualifier.expr), sorts);
         rty::Qualifier { name: qualifier.name.clone(), body, global: qualifier.global }
     }
@@ -235,7 +236,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     fn conv_ty(&mut self, ty: &fhir::Ty) -> rty::Ty {
         match ty {
             fhir::Ty::BaseTy(bty) => {
-                if flatten_sort(self.genv.map(), &bty.sort()).is_empty() {
+                if flatten_sort(self.early_cx(), &bty.sort()).is_empty() {
                     let bty = self.conv_base_ty(bty);
                     rty::Ty::indexed(bty, rty::RefineArgs::empty())
                 } else {
@@ -248,7 +249,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             fhir::Ty::Indexed(bty, idx) => self.conv_indexed(bty, idx),
             fhir::Ty::Exists(bty, bind, pred) => {
                 self.env
-                    .push_layer(Layer::new(self.genv.map(), [(&bind.name, &bty.sort())]));
+                    .push_layer(Layer::new(self.early_cx(), [(&bind.name, &bty.sort())]));
                 let bty = self.conv_base_ty(bty);
                 let pred = self.env.conv_expr(pred);
                 self.env.pop_layer();
@@ -283,7 +284,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
     fn conv_indexed(&mut self, bty: &fhir::BaseTy, idx: &fhir::Index) -> rty::Ty {
         let mut args = vec![];
-        for (arg, sort) in iter::zip(idx.flatten(), flatten_sort(self.genv.map(), &bty.sort())) {
+        for (arg, sort) in iter::zip(idx.flatten(), flatten_sort(self.early_cx(), &bty.sort())) {
             let is_binder = matches!(arg, fhir::RefineArg::Expr { is_binder: true, .. });
             args.extend(
                 self.conv_refine_arg(arg, &sort)
@@ -314,9 +315,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             fhir::RefineArg::Abs(params, body, _) => {
                 let fsort = sort.as_func();
                 self.env
-                    .push_layer(Layer::new(self.genv.map(), iter::zip(params, fsort.inputs())));
+                    .push_layer(Layer::new(self.early_cx(), iter::zip(params, fsort.inputs())));
                 let pred = self.env.conv_expr(body);
-                let abs = rty::Binders::new(pred, flatten_sorts(self.genv.map(), fsort.inputs()));
+                let abs = rty::Binders::new(pred, flatten_sorts(self.early_cx(), fsort.inputs()));
                 self.env.pop_layer();
                 vec![rty::RefineArg::Abs(abs)]
             }
@@ -370,26 +371,36 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     fn conv_generic_arg(&mut self, arg: &fhir::Ty) -> rty::GenericArg {
         rty::GenericArg::Ty(self.conv_ty(arg))
     }
+
+    fn early_cx(&self) -> &EarlyCtxt<'a, 'tcx> {
+        self.genv.early_cx()
+    }
 }
 
-impl<'a> Env<'a> {
-    fn new(map: &'a fhir::Map, layer: Layer) -> Env<'a> {
-        Self { map, layers: vec![layer] }
+impl<'a, 'tcx> Env<'a, 'tcx> {
+    fn new(early_cx: &'a EarlyCtxt<'a, 'tcx>, layer: Layer) -> Env<'a, 'tcx> {
+        Self { early_cx, layers: vec![layer] }
     }
 
-    fn from_args(map: &'a fhir::Map, slice: &[(fhir::Ident, fhir::Sort)]) -> Self {
-        Self::new(map, Layer::new(map, slice.iter().map(|(ident, sort)| (&ident.name, sort))))
-    }
-
-    fn from_params(map: &'a fhir::Map, params: &[fhir::RefineParam]) -> Self {
-        Self::new(map, Layer::new(map, params.iter().map(|param| (&param.name.name, &param.sort))))
-    }
-
-    fn from_refined_by(map: &'a fhir::Map, refined_by: &fhir::RefinedBy) -> Self {
+    fn from_args(early_cx: &'a EarlyCtxt<'a, 'tcx>, slice: &[(fhir::Ident, fhir::Sort)]) -> Self {
         Self::new(
-            map,
+            early_cx,
+            Layer::new(early_cx, slice.iter().map(|(ident, sort)| (&ident.name, sort))),
+        )
+    }
+
+    fn from_params(early_cx: &'a EarlyCtxt<'a, 'tcx>, params: &[fhir::RefineParam]) -> Self {
+        Self::new(
+            early_cx,
+            Layer::new(early_cx, params.iter().map(|param| (&param.name.name, &param.sort))),
+        )
+    }
+
+    fn from_refined_by(early_cx: &'a EarlyCtxt<'a, 'tcx>, refined_by: &fhir::RefinedBy) -> Self {
+        Self::new(
+            early_cx,
             Layer::new(
-                map,
+                early_cx,
                 refined_by
                     .params
                     .iter()
@@ -429,7 +440,7 @@ impl<'a> Env<'a> {
     }
 }
 
-impl Env<'_> {
+impl Env<'_, '_> {
     fn conv_expr(&self, expr: &fhir::Expr) -> rty::Expr {
         match &expr.kind {
             fhir::ExprKind::Const(did, _) => rty::Expr::const_def_id(*did),
@@ -449,10 +460,9 @@ impl Env<'_> {
                 let (sort, vars) = self.get(var.name);
                 if let fhir::Sort::Adt(def_id) = sort {
                     let idx = self
-                        .map
-                        .adt(def_id.expect_local())
-                        .field_index(fld.name)
-                        .unwrap_or_else(|| panic!("field not found `{fld:?}`"));
+                        .early_cx
+                        .field_index(*def_id, fld.name)
+                        .unwrap_or_else(|| bug!("field not found `{fld:?}`"));
                     vars[idx].to_expr()
                 } else {
                     todo!()
@@ -479,14 +489,14 @@ impl Env<'_> {
 
 impl Layer {
     fn new<'a>(
-        fhir_map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         iter: impl IntoIterator<Item = (&'a fhir::Name, &'a fhir::Sort)>,
     ) -> Self {
         let mut map = FxHashMap::default();
         let mut i = 0;
         for (name, sort) in iter.into_iter() {
             let nsorts = if let fhir::Sort::Adt(def_id) = sort {
-                fhir_map.sorts_of(*def_id).unwrap_or(&[]).len()
+                early_cx.sorts_of(*def_id).len()
             } else {
                 1
             };
@@ -505,27 +515,27 @@ impl Layer {
     }
 }
 
-pub fn conv_uif(map: &fhir::Map, uif: &fhir::UifDef) -> rty::UifDef {
-    rty::UifDef { name: uif.name, sort: flatten_func_sort(map, &uif.sort) }
+pub fn conv_uif(early_cx: &EarlyCtxt, uif: &fhir::UifDef) -> rty::UifDef {
+    rty::UifDef { name: uif.name, sort: flatten_func_sort(early_cx, &uif.sort) }
 }
 
 fn flatten_sorts<'a>(
-    map: &fhir::Map,
+    early_cx: &EarlyCtxt,
     sorts: impl IntoIterator<Item = &'a fhir::Sort>,
 ) -> Vec<rty::Sort> {
     sorts
         .into_iter()
-        .flat_map(|sort| flatten_sort(map, sort))
+        .flat_map(|sort| flatten_sort(early_cx, sort))
         .collect()
 }
 
-fn flatten_sort(map: &fhir::Map, sort: &fhir::Sort) -> Vec<rty::Sort> {
+fn flatten_sort(early_cx: &EarlyCtxt, sort: &fhir::Sort) -> Vec<rty::Sort> {
     match sort {
         fhir::Sort::Tuple(sorts) => {
-            vec![rty::Sort::Tuple(List::from_vec(flatten_sorts(map, sorts)))]
+            vec![rty::Sort::Tuple(List::from_vec(flatten_sorts(early_cx, sorts)))]
         }
-        fhir::Sort::Func(fsort) => vec![rty::Sort::Func(flatten_func_sort(map, fsort))],
-        fhir::Sort::Adt(def_id) => flatten_sorts(map, map.sorts_of(*def_id).unwrap_or(&[])),
+        fhir::Sort::Func(fsort) => vec![rty::Sort::Func(flatten_func_sort(early_cx, fsort))],
+        fhir::Sort::Adt(def_id) => flatten_sorts(early_cx, early_cx.sorts_of(*def_id)),
         fhir::Sort::Int
         | fhir::Sort::Real
         | fhir::Sort::Bool
@@ -535,9 +545,9 @@ fn flatten_sort(map: &fhir::Map, sort: &fhir::Sort) -> Vec<rty::Sort> {
     }
 }
 
-fn flatten_func_sort(map: &fhir::Map, fsort: &fhir::FuncSort) -> rty::FuncSort {
+fn flatten_func_sort(early_cx: &EarlyCtxt, fsort: &fhir::FuncSort) -> rty::FuncSort {
     rty::FuncSort {
-        inputs_and_output: List::from_vec(flatten_sorts(map, fsort.inputs_and_output.iter())),
+        inputs_and_output: List::from_vec(flatten_sorts(early_cx, fsort.inputs_and_output.iter())),
     }
 }
 

--- a/flux-middle/src/rty/evars.rs
+++ b/flux-middle/src/rty/evars.rs
@@ -4,6 +4,7 @@ use flux_common::index::IndexVec;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustc_index::newtype_index;
+use rustc_macros::{Decodable, Encodable};
 
 use super::{ExprKind, RefineArg};
 
@@ -20,7 +21,7 @@ pub struct EVarSol {
 
 /// An *e*xistential *var*riable is identified by a context and an id. Two evars
 /// are considered equal if both the context and id are equal.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub struct EVar {
     cx: EVarCxId,
     id: EVid,
@@ -42,7 +43,7 @@ newtype_index! {
     struct EVid {}
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Encodable, Decodable)]
 pub struct EVarCxId(u64);
 
 impl EVar {

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -4,10 +4,11 @@ use flux_fixpoint::Sign;
 pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use rustc_hir::def_id::DefId;
 use rustc_index::newtype_index;
+use rustc_macros::{Decodable, Encodable};
 use rustc_middle::mir::{Field, Local};
 use rustc_span::Symbol;
 
-use super::{evars::EVar, BaseTy, KVar};
+use super::{evars::EVar, BaseTy};
 use crate::{
     intern::{impl_internable, Interned, List},
     rty::fold::{TypeFoldable, TypeFolder},
@@ -16,12 +17,12 @@ use crate::{
 
 pub type Expr = Interned<ExprS>;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct ExprS {
     kind: ExprKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum ExprKind {
     FreeVar(Name),
     EVar(EVar),
@@ -40,26 +41,42 @@ pub enum ExprKind {
     Hole,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+/// In theory a kvar is just an unknown predicate that can use some variables in scope. In practice,
+/// fixpoint makes a diference between the first and the rest of the variables, the first one being
+/// the kvar's *self argument*. Fixpoint will only instantiate qualifiers that use the self argument.
+/// Flux generalizes the self argument to be a list.
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
+pub struct KVar {
+    pub kvid: KVid,
+    pub args: List<Expr>,
+    pub scope: List<Expr>,
+}
+
+newtype_index! {
+    #[debug_format = "$k{}"]
+    pub struct KVid {}
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Func {
     Var(Var),
     Uif(Symbol),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub enum Var {
     Free(Name),
     Bound(BoundVar),
     EVar(EVar),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub struct Path {
     pub loc: Loc,
     projection: List<Field>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub enum Loc {
     Local(Local),
     Var(Var),
@@ -69,7 +86,7 @@ pub enum Loc {
 /// into a list of [`Binders`] and index into that list.
 ///
 /// [`Binders`]: super::Binders
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub struct BoundVar {
     pub debruijn: DebruijnIndex,
     pub index: usize,
@@ -392,6 +409,16 @@ impl Expr {
     }
 }
 
+impl KVar {
+    pub fn new(kvid: KVid, args: Vec<Expr>, scope: Vec<Expr>) -> Self {
+        KVar { kvid, args: List::from_vec(args), scope: List::from_vec(scope) }
+    }
+
+    pub fn all_args(&self) -> impl Iterator<Item = &Expr> {
+        self.args.iter().chain(&self.scope)
+    }
+}
+
 impl Var {
     pub fn to_expr(&self) -> Expr {
         match self {
@@ -614,7 +641,7 @@ impl From<Local> for Loc {
     }
 }
 
-impl_internable!(ExprS, [Expr]);
+impl_internable!(ExprS, [Expr], [KVar]);
 
 mod pretty {
     use super::*;
@@ -729,6 +756,25 @@ mod pretty {
         }
     }
 
+    impl Pretty for KVar {
+        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            define_scoped!(cx, f);
+            w!("{:?}", ^self.kvid)?;
+            match cx.kvar_args {
+                KVarArgs::All => {
+                    if self.scope.is_empty() {
+                        w!("({:?})", join!(", ", &self.args))?;
+                    } else {
+                        w!("({:?})[{:?}]", join!(", ", &self.args), join!(", ", &self.scope))?;
+                    }
+                }
+                KVarArgs::SelfOnly => w!("({:?})", join!(", ", &self.args))?,
+                KVarArgs::Hide => {}
+            }
+            Ok(())
+        }
+    }
+
     impl Pretty for Func {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
@@ -800,5 +846,5 @@ mod pretty {
         }
     }
 
-    impl_debug_with_default_cx!(Expr, Loc, Path, BoundVar, Var);
+    impl_debug_with_default_cx!(Expr, Loc, Path, BoundVar, Var, KVar);
 }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -62,13 +62,13 @@ pub struct Invariant {
 
 pub type PolyVariant = Binders<VariantDef>;
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct VariantDef {
     pub fields: List<Ty>,
     pub ret: VariantRet,
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, TyEncodable, TyDecodable)]
 pub struct VariantRet {
     pub bty: BaseTy,
     pub args: List<RefineArg>,

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -80,20 +80,20 @@ pub struct Binders<T> {
     value: T,
 }
 
-#[derive(Clone)]
+#[derive(Clone, TyEncodable, TyDecodable)]
 pub struct PolySig {
     pub fn_sig: Binders<FnSig>,
     pub modes: List<InferMode>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, TyEncodable, TyDecodable)]
 pub struct FnSig {
     requires: List<Constraint>,
     args: List<Ty>,
     output: Binders<FnOutput>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, TyEncodable, TyDecodable)]
 pub struct FnOutput {
     pub ret: Ty,
     pub ensures: List<Constraint>,
@@ -101,7 +101,7 @@ pub struct FnOutput {
 
 pub type Constraints = List<Constraint>;
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub enum Constraint {
     Type(Path, Ty),
     Pred(Expr),

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -13,13 +13,16 @@ pub mod subst;
 use std::{collections::HashSet, fmt, hash::Hash, iter, sync::LazyLock};
 
 pub use evars::{EVar, EVarGen};
-pub use expr::{BoundVar, DebruijnIndex, Expr, ExprKind, Func, Loc, Name, Path, Var, INNERMOST};
+pub use expr::{
+    BoundVar, DebruijnIndex, Expr, ExprKind, Func, KVar, KVid, Loc, Name, Path, Var, INNERMOST,
+};
 use flux_common::index::IndexGen;
 pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
-use rustc_index::{bit_set::BitSet, newtype_index};
+use rustc_index::bit_set::BitSet;
+use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::mir::{Field, Mutability};
 pub use rustc_middle::ty::{AdtFlags, FloatTy, IntTy, ParamTy, ScalarInt, UintTy};
 use rustc_span::Symbol;
@@ -39,10 +42,10 @@ use crate::{
     rustc::mir::Place,
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct AdtDef(Interned<AdtDefData>);
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct AdtDefData {
     def_id: DefId,
     invariants: Vec<Invariant>,
@@ -52,7 +55,7 @@ pub struct AdtDefData {
     opaque: bool,
 }
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct Invariant {
     pub pred: Binders<Expr>,
 }
@@ -71,7 +74,7 @@ pub struct VariantRet {
     pub args: List<RefineArg>,
 }
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct Binders<T> {
     params: List<Sort>,
     value: T,
@@ -127,12 +130,12 @@ pub struct Defns {
 
 pub type Ty = Interned<TyS>;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct TyS {
     kind: TyKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum TyKind {
     Indexed(BaseTy, RefineArgs),
     Exists(Binders<Ty>),
@@ -153,17 +156,17 @@ pub enum TyKind {
     Discr(AdtDef, Place),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum PtrKind {
     Shr,
     Mut,
     Box,
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
 pub struct RefineArgs(Interned<RefineArgsData>);
 
-#[derive(Eq, Hash, PartialEq)]
+#[derive(Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
 struct RefineArgsData {
     args: Vec<RefineArg>,
     /// Set containing all the indices of arguments that were used as binders in the surface syntax.
@@ -171,13 +174,13 @@ struct RefineArgsData {
     is_binder: BitSet<usize>,
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
 pub enum RefineArg {
     Expr(Expr),
     Abs(Binders<Expr>),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum BaseTy {
     Int(IntTy),
     Uint(UintTy),
@@ -192,27 +195,11 @@ pub enum BaseTy {
 
 pub type Substs = List<GenericArg>;
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum GenericArg {
     Ty(Ty),
     /// We treat lifetime opaquely
     Lifetime,
-}
-
-/// In theory a kvar is just an unknown predicate that can use some variables in scope. In practice,
-/// fixpoint makes a diference between the first and the rest of the variables, the first one being
-/// the kvar's *self argument*. Fixpoint will only instantiate qualifiers that use the self argument.
-/// Flux generalizes the self argument to be a list.
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct KVar {
-    pub kvid: KVid,
-    pub args: List<Expr>,
-    pub scope: List<Expr>,
-}
-
-newtype_index! {
-    #[debug_format = "$k{}"]
-    pub struct KVid {}
 }
 
 impl Qualifier {
@@ -723,16 +710,6 @@ impl Binders<Expr> {
     }
 }
 
-impl KVar {
-    pub fn new(kvid: KVid, args: Vec<Expr>, scope: Vec<Expr>) -> Self {
-        KVar { kvid, args: List::from_vec(args), scope: List::from_vec(scope) }
-    }
-
-    pub fn all_args(&self) -> impl Iterator<Item = &Expr> {
-        self.args.iter().chain(&self.scope)
-    }
-}
-
 #[track_caller]
 pub fn box_args(substs: &Substs) -> (&Ty, &Ty) {
     if let [GenericArg::Ty(boxed), GenericArg::Ty(alloc)] = &substs[..] {
@@ -749,7 +726,6 @@ impl_internable!(
     [Ty],
     [GenericArg],
     [Field],
-    [KVar],
     [Constraint],
     [RefineArg],
     [InferMode],
@@ -1029,25 +1005,6 @@ mod pretty {
         }
     }
 
-    impl Pretty for KVar {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("{:?}", ^self.kvid)?;
-            match cx.kvar_args {
-                KVarArgs::All => {
-                    if self.scope.is_empty() {
-                        w!("({:?})", join!(", ", &self.args))?;
-                    } else {
-                        w!("({:?})[{:?}]", join!(", ", &self.args), join!(", ", &self.scope))?;
-                    }
-                }
-                KVarArgs::SelfOnly => w!("({:?})", join!(", ", &self.args))?,
-                KVarArgs::Hide => {}
-            }
-            Ok(())
-        }
-    }
-
     impl Pretty for VariantDef {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
@@ -1067,7 +1024,6 @@ mod pretty {
         TyS => "ty",
         PolySig,
         BaseTy,
-        KVar,
         FnSig,
         GenericArg,
         RefineArg,

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -6,6 +6,7 @@ use flux_common::index::{Idx, IndexVec};
 use itertools::Itertools;
 use rustc_data_structures::graph::dominators::Dominators;
 use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_macros::{Decodable, Encodable};
 use rustc_middle::{
     mir,
     ty::{subst::SubstsRef, FloatTy, IntTy, UintTy},
@@ -181,7 +182,7 @@ pub enum Operand {
     Constant(Constant),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct Place {
     /// the "root" of the place, e.g. `_1` in `*_1.f.g.h`
     pub local: Local,
@@ -189,7 +190,7 @@ pub struct Place {
     pub projection: Vec<PlaceElem>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum PlaceElem {
     Deref,
     Field(Field),

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -4,6 +4,7 @@ use std::iter;
 
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
+use rustc_macros::{Decodable, Encodable};
 pub use rustc_middle::{
     mir::Mutability,
     ty::{
@@ -98,7 +99,7 @@ pub enum TyKind {
     RawPtr(Ty, Mutability),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct Const {
     pub val: usize,
 }

--- a/flux-refineck/src/wf.rs
+++ b/flux-refineck/src/wf.rs
@@ -3,20 +3,20 @@
 //! Well-formedness checking assumes names are correctly bound which is guaranteed after desugaring.
 use std::{borrow::Borrow, iter};
 
-use flux_common::iter::IterExt;
+use flux_common::{bug, iter::IterExt};
 use flux_errors::FluxSession;
-use flux_middle::fhir::{self, SurfaceIdent};
+use flux_middle::{
+    early_ctxt::EarlyCtxt,
+    fhir::{self, SurfaceIdent},
+};
 use itertools::izip;
 use rustc_errors::{ErrorGuaranteed, IntoDiagnostic};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
 pub struct Wf<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
-    sess: &'a FluxSession,
-    map: &'a fhir::Map,
+    early_cx: &'a EarlyCtxt<'a, 'tcx>,
     modes: FxHashMap<fhir::Name, fhir::InferMode>,
 }
 
@@ -69,35 +69,26 @@ impl<T: Borrow<fhir::Name>> std::ops::Index<T> for Env {
 
 impl Wf<'_, '_> {
     pub fn check_qualifier(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         qualifier: &fhir::Qualifier,
     ) -> Result<(), ErrorGuaranteed> {
-        let wf = Wf::new(tcx, sess, map);
+        let wf = Wf::new(early_cx);
         let env = Env::from(&qualifier.args[..]);
 
         wf.check_expr(&env, &qualifier.expr, &fhir::Sort::Bool)
     }
 
-    pub fn check_defn(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
-        defn: &fhir::Defn,
-    ) -> Result<(), ErrorGuaranteed> {
-        let wf = Wf::new(tcx, sess, map);
+    pub fn check_defn(early_cx: &EarlyCtxt, defn: &fhir::Defn) -> Result<(), ErrorGuaranteed> {
+        let wf = Wf::new(early_cx);
         let env = Env::from(&defn.args[..]);
         wf.check_expr(&env, &defn.expr, &defn.sort)
     }
 
     pub fn check_adt_def(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         adt_def: &fhir::AdtDef,
     ) -> Result<(), ErrorGuaranteed> {
-        let wf = Wf::new(tcx, sess, map);
+        let wf = Wf::new(early_cx);
         let env = Env::from(&adt_def.refined_by.params[..]);
         adt_def
             .invariants
@@ -121,13 +112,8 @@ impl Wf<'_, '_> {
         Ok(())
     }
 
-    pub fn check_fn_sig(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
-        fn_sig: &fhir::FnSig,
-    ) -> Result<(), ErrorGuaranteed> {
-        let mut wf = Wf::new(tcx, sess, map);
+    pub fn check_fn_sig(early_cx: &EarlyCtxt, fn_sig: &fhir::FnSig) -> Result<(), ErrorGuaranteed> {
+        let mut wf = Wf::new(early_cx);
         for param in &fn_sig.params {
             wf.modes.insert(param.name.name, param.mode);
         }
@@ -169,13 +155,11 @@ impl Wf<'_, '_> {
     }
 
     pub fn check_struct_def(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         refined_by: &fhir::RefinedBy,
         def: &fhir::StructDef,
     ) -> Result<(), ErrorGuaranteed> {
-        let wf = Wf::new(tcx, sess, map);
+        let wf = Wf::new(early_cx);
         let mut env = Env::from(&refined_by.params[..]);
         if let fhir::StructKind::Transparent { fields } = &def.kind {
             fields.iter().try_for_each_exhaust(|ty| {
@@ -190,12 +174,10 @@ impl Wf<'_, '_> {
     }
 
     pub fn check_enum_def(
-        tcx: TyCtxt,
-        sess: &FluxSession,
-        map: &fhir::Map,
+        early_cx: &EarlyCtxt,
         def: &fhir::EnumDef,
     ) -> Result<(), ErrorGuaranteed> {
-        let wf = Wf::new(tcx, sess, map);
+        let wf = Wf::new(early_cx);
         def.variants
             .iter()
             .try_for_each_exhaust(|variant| wf.check_variant(variant))
@@ -203,8 +185,8 @@ impl Wf<'_, '_> {
 }
 
 impl<'a, 'tcx> Wf<'a, 'tcx> {
-    fn new(tcx: TyCtxt<'tcx>, sess: &'a FluxSession, map: &'a fhir::Map) -> Self {
-        Wf { tcx, sess, map, modes: FxHashMap::default() }
+    fn new(early_cx: &'a EarlyCtxt<'a, 'tcx>) -> Self {
+        Wf { early_cx, modes: FxHashMap::default() }
     }
 
     fn check_variant(&self, variant: &fhir::VariantDef) -> Result<(), ErrorGuaranteed> {
@@ -331,7 +313,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         args: &[fhir::RefineArg],
         span: Span,
     ) -> Result<(), ErrorGuaranteed> {
-        let sorts = self.map.sorts_of(def_id).unwrap_or(&[]);
+        let sorts = self.early_cx.sorts_of(def_id);
         if args.len() != sorts.len() {
             return self.emit_err(errors::ArgCountMismatch::new(
                 Some(span),
@@ -426,13 +408,15 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
             fhir::ExprKind::Dot(var, fld) => {
                 let sort = &env[var.name];
                 if let fhir::Sort::Adt(def_id) = sort {
-                    self.map
-                        .adt(def_id.expect_local())
-                        .field_sort(fld.name)
+                    self.early_cx
+                        .field_sort(*def_id, fld.name)
                         .cloned()
                         .ok_or_else(|| {
-                            self.sess.emit_err(errors::FieldNotFound::new(
-                                self.tcx, self.map, *def_id, *fld,
+                            self.early_cx.emit_err(errors::FieldNotFound::new(
+                                self.early_cx.tcx,
+                                &self.early_cx.map,
+                                *def_id,
+                                *fld,
                             ))
                         })
                 } else {
@@ -506,7 +490,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
 
     #[track_caller]
     fn emit_err<'b, R>(&'b self, err: impl IntoDiagnostic<'b>) -> Result<R, ErrorGuaranteed> {
-        Err(self.sess.emit_err(err))
+        Err(self.early_cx.emit_err(err))
     }
 
     fn synth_app(
@@ -540,15 +524,15 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                     Ok(fsort)
                 } else {
                     Err(self
-                        .sess
+                        .early_cx
                         .emit_err(errors::ExpectedFun::new(var.span(), sort)))
                 }
             }
             fhir::Func::Uif(func, span) => {
                 Ok(self
-                    .map
+                    .early_cx
                     .uif(func)
-                    .unwrap_or_else(|| panic!("no definition found for uif `{func:?}` - {span:?}"))
+                    .unwrap_or_else(|| bug!("no definition found for uif `{func:?}` - {span:?}"))
                     .sort
                     .clone())
             }
@@ -594,7 +578,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
     }
 
     fn is_single_field_adt(&self, sort: &fhir::Sort) -> Option<&'a fhir::Sort> {
-        if let fhir::Sort::Adt(def_id) = sort && let Some([sort]) = self.map.sorts_of(*def_id) {
+        if let fhir::Sort::Adt(def_id) = sort && let [sort] = self.early_cx.sorts_of(*def_id) {
             Some(sort)
         } else {
             None
@@ -868,12 +852,18 @@ mod errors {
     impl DefSpanNote {
         fn new(tcx: TyCtxt, map: &fhir::Map, def_id: DefId) -> Option<Self> {
             let mut sp = MultiSpan::from_span(tcx.def_ident_span(def_id)?);
-            let refined_by = map.refined_by(def_id)?;
-            if !refined_by.params.is_empty() {
+
+            let mut has_params = false;
+            if let Some(local_id) = def_id.as_local()
+                && let refined_by = &map.adt(local_id).refined_by
+                && !refined_by.params.is_empty()
+            {
                 sp.push_span_label(refined_by.span, "");
+                has_params = true;
             }
+
             let def_kind = tcx.def_kind(def_id).descr(def_id);
-            Some(Self { sp, def_kind, has_params: !refined_by.params.is_empty() })
+            Some(Self { sp, def_kind, has_params })
         }
     }
 }


### PR DESCRIPTION
This PR adds support for loading refinement types for dependencies that were annotated with flux. Note that this doesn't allow us to annotate external dependencies for which we don't have control (e.g., `std`), you can only annotate crates you created and then use them as dependencies for other crates.

## Strategy

The strategy is very simple. There are two sides to it

### Generate metadata
If we detect `flux` is called with the flag `--emit=metadata`, which is the standard flag `cargo` uses to instruct `rustc` to generate a metadata file, then we will honor it and dump our own file with the necessary metadata for cross-crate refinement checking. We put the file in the same path rustc would put its metadata but using the extension `fluxmeta` instead of `rmeta`.

### Read metadata for dependencies
When `flux` is called with the flag `--extern crate_name=/path/to/lib.rmeta`, which is the standard flag `cargo` uses to instruct `rustc` to read the metadata for a dependency, then we will honor it and read the flux metadata from the same path but replacing the extension `rmeta` with `fluxmeta`.

## Limitations

Opaque sort declarations, flux defns (uninterpreted and interpreted), constants, and qualifiers cannot be used cross-crate. Those are currently identified with a string so further work needs to be done to disambiguate them between crates.