### PR TITLE
Clarify some terminology

### DIFF
--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -19,7 +19,7 @@ mod rustc_middle_ty_annot_check;
 mod table_resolver;
 
 pub use desugar::{
-    desugar_adt_def, desugar_defn, desugar_qualifier, resolve_defn_uif, resolve_uif_def,
+    desugar_defn, desugar_qualifier, desugar_refined_by, resolve_defn_uif, resolve_uif_def,
 };
 use flux_middle::{early_ctxt::EarlyCtxt, fhir};
 use flux_syntax::surface;

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -277,8 +277,8 @@ fn build_fhir_map(early_cx: &mut EarlyCtxt, specs: &mut Specs) -> Result<(), Err
         .iter()
         .try_for_each_exhaust(|(def_id, def)| {
             let refined_by = def.refined_by.as_ref().unwrap_or(surface::RefinedBy::DUMMY);
-            let adt_def = desugar::desugar_adt_def(early_cx, *def_id, refined_by)?;
-            early_cx.map.insert_adt(*def_id, adt_def);
+            let adt_def = desugar::desugar_refined_by(early_cx, *def_id, refined_by)?;
+            early_cx.map.insert_refined_by(*def_id, adt_def);
             Ok(())
         })
         .err()
@@ -288,8 +288,8 @@ fn build_fhir_map(early_cx: &mut EarlyCtxt, specs: &mut Specs) -> Result<(), Err
         .iter()
         .try_for_each_exhaust(|(def_id, def)| {
             let refined_by = def.refined_by.as_ref().unwrap_or(surface::RefinedBy::DUMMY);
-            let adt_def = desugar::desugar_adt_def(early_cx, *def_id, refined_by)?;
-            early_cx.map.insert_adt(*def_id, adt_def);
+            let adt_def = desugar::desugar_refined_by(early_cx, *def_id, refined_by)?;
+            early_cx.map.insert_refined_by(*def_id, adt_def);
             Ok(())
         })
         .err()
@@ -299,11 +299,11 @@ fn build_fhir_map(early_cx: &mut EarlyCtxt, specs: &mut Specs) -> Result<(), Err
         .iter()
         .try_for_each_exhaust(|(def_id, alias)| {
             let adt_def = if let Some(alias) = alias {
-                desugar::desugar_adt_def(early_cx, *def_id, &alias.refined_by)?
+                desugar::desugar_refined_by(early_cx, *def_id, &alias.refined_by)?
             } else {
-                fhir::lift::lift_adt_def(early_cx, *def_id)
+                fhir::lift::lift_refined_by(early_cx, *def_id)
             };
-            early_cx.map.insert_adt(*def_id, adt_def);
+            early_cx.map.insert_refined_by(*def_id, adt_def);
             Ok(())
         })
         .err()
@@ -422,17 +422,11 @@ fn check_wf(early_cx: &EarlyCtxt) -> Result<(), ErrorGuaranteed> {
     }
 
     for struct_def in early_cx.map.structs() {
-        let refined_by = &early_cx.map.get_adt(struct_def.def_id).refined_by;
-        err = Wf::check_struct_def(early_cx, refined_by, struct_def)
-            .err()
-            .or(err);
+        err = Wf::check_struct_def(early_cx, struct_def).err().or(err);
     }
 
     for enum_def in early_cx.map.enums() {
-        let refined_by = &early_cx.map.get_adt(enum_def.def_id).refined_by;
-        err = Wf::check_enum_def(early_cx, refined_by, enum_def)
-            .err()
-            .or(err);
+        err = Wf::check_enum_def(early_cx, enum_def).err().or(err);
     }
 
     for (_, fn_sig) in early_cx.map.fn_sigs() {

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -134,7 +134,7 @@ impl CrateMetadata {
                     );
                 }
                 DefKind::Enum | DefKind::Struct => {
-                    let refined_by = &genv.map().get_adt(local_id).refined_by;
+                    let refined_by = genv.map().refined_by(local_id);
                     let adt_def = genv.adt_def(def_id);
                     let variants = if adt_def.is_opaque() {
                         None

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -38,17 +38,9 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
         self.map.const_by_name(name)
     }
 
-    pub fn sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {
-        if let Some(local_id) = def_id.as_local() {
-            self.map.get_adt(local_id).sorts()
-        } else {
-            todo!()
-        }
-    }
-
     pub fn index_sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {
         if let Some(local_id) = def_id.as_local() {
-            self.map.get_adt(local_id).index_sorts()
+            self.map.refined_by(local_id).index_sorts()
         } else {
             self.cstore.index_sorts(def_id).unwrap_or_default()
         }
@@ -56,7 +48,7 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
 
     pub fn early_bound_sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {
         if let Some(local_id) = def_id.as_local() {
-            self.map.get_adt(local_id).early_bound_sorts()
+            self.map.refined_by(local_id).early_bound_sorts()
         } else {
             // FIXME(nilehmann) support for extern type aliases
             &[]
@@ -65,7 +57,7 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
 
     pub fn field_index(&self, def_id: DefId, fld: Symbol) -> Option<usize> {
         if let Some(local_id) = def_id.as_local() {
-            self.map.get_adt(local_id).field_index(fld)
+            self.map.refined_by(local_id).field_index(fld)
         } else {
             self.cstore.field_index(def_id, fld)
         }
@@ -73,7 +65,7 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
 
     pub fn field_sort(&self, def_id: DefId, fld: Symbol) -> Option<&fhir::Sort> {
         if let Some(local_id) = def_id.as_local() {
-            self.map.get_adt(local_id).field_sort(fld)
+            self.map.refined_by(local_id).field_sort(fld)
         } else {
             self.cstore.field_sort(def_id, fld)
         }
@@ -95,7 +87,7 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
     }
 
     pub fn is_single_field_adt<'b>(&'b self, sort: &fhir::Sort) -> Option<&'b fhir::Sort> {
-        if let fhir::Sort::Adt(def_id) = sort && let [sort] = self.index_sorts_of(*def_id) {
+        if let fhir::Sort::Aggregate(def_id) = sort && let [sort] = self.index_sorts_of(*def_id) {
             Some(sort)
         } else {
             None

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -101,7 +101,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         let map = &self.early_cx.map;
         for struct_def in map.structs() {
             let local_id = struct_def.def_id;
-            let refined_by = &map.get_adt(local_id).refined_by;
+            let refined_by = map.refined_by(local_id);
             let variant =
                 rty::conv::ConvCtxt::conv_struct_def_variant(self, refined_by, struct_def)
                     .map(|v| v.normalize(&self.defns));
@@ -269,7 +269,8 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             match self.tcx.def_kind(def_id) {
                 DefKind::TyAlias => {
                     let alias = self.early_cx.map.get_alias(local_id);
-                    rty::conv::expand_alias(self, alias)
+                    let refined_by = self.early_cx.map.refined_by(local_id);
+                    rty::conv::expand_alias(self, refined_by, alias)
                 }
                 kind => {
                     bug!("`{:?}` not supported", kind.descr(def_id))

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -444,7 +444,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
         // test for equality.
         rty::Sort::User(_) => fixpoint::Sort::Int,
         rty::Sort::Func(sort) => fixpoint::Sort::Func(func_sort_to_fixpoint(sort)),
-        rty::Sort::Infer | rty::Sort::Adt(_) | rty::Sort::Loc => {
+        rty::Sort::Infer | rty::Sort::Aggregate(_) | rty::Sort::Loc => {
             unreachable!("unexpected sort {sort:?}")
         }
     }

--- a/flux-refineck/src/wf.rs
+++ b/flux-refineck/src/wf.rs
@@ -546,11 +546,11 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
     }
 
     /// Whether a value of `sort1` can be automatically coerced to a value of `sort2`. A value of an
-    /// [`Adt`] sort with a single field of sort `s` can be coerced to a value of sort `s` and vice
+    /// [`Aggregate`] sort with a single field of sort `s` can be coerced to a value of sort `s` and vice
     /// versa, i.e., we can automatically project the field out of the adt or inject a value into an
     /// adt.
     ///
-    /// [`Adt`]: fhir::Sort::Adt
+    /// [`Aggregate`]: fhir::Sort::Aggregate
     fn is_coercible(&self, sort1: &fhir::Sort, sort2: &fhir::Sort) -> bool {
         let mut sort1 = sort1.clone();
         let mut sort2 = sort2.clone();

--- a/flux-syntax/src/surface_grammar.lalrpop
+++ b/flux-syntax/src/surface_grammar.lalrpop
@@ -12,17 +12,17 @@ pub Alias: surface::Alias = {
   <lo:@L>
     "type"
     <name:Ident>
-    <rblo:@L>
+    <refined_by_lo:@L>
     <early_bound_params:("(" <Comma<RefineParam>> ")")?>
     <params:("[" <Comma<RefineParam>> "]")?>
-    <rbhi:@R>
+    <refined_by_hi:@R>
     "="
     <ty:Ty>
     <hi:@R> => {
         let refined_by = surface::RefinedBy {
             early_bound_params: early_bound_params.unwrap_or_default(),
             params: params.unwrap_or_default(),
-            span: mk_span(rblo, rbhi)
+            span: mk_span(refined_by_lo, refined_by_hi)
         };
         surface::Alias { name, refined_by, ty, span: mk_span(lo, hi) }
     }


### PR DESCRIPTION
* Use `RefinedBy` instead of `AdtDef` in `fhir` since the term `Adt` doesn't make sense anymore as the struct should also consider type aliases.
* Document the distinction between early bound and index parameters