### PR TITLE
Move Ref, Tuple, Array, Never to rty::BaseTy

### DIFF
--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -202,7 +202,8 @@ impl Expr {
             | BaseTy::Float(_)
             | BaseTy::Slice(_)
             | BaseTy::Char
-            | BaseTy::RawPtr(_, _) => bug!(),
+            | BaseTy::RawPtr(_, _)
+            | BaseTy::Tuple(_) => bug!(),
         }
     }
 

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -1,5 +1,6 @@
 use std::{fmt, sync::OnceLock};
 
+use flux_common::bug;
 use flux_fixpoint::Sign;
 pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use rustc_hir::def_id::DefId;
@@ -195,12 +196,13 @@ impl Expr {
             }
             BaseTy::Uint(_) => ExprKind::Constant(Constant::from(bits)).intern(),
             BaseTy::Bool => ExprKind::Constant(Constant::Bool(bits != 0)).intern(),
-            BaseTy::Adt(_, _)
+            BaseTy::Adt(..)
+            | BaseTy::Ref(..)
             | BaseTy::Str
             | BaseTy::Float(_)
             | BaseTy::Slice(_)
             | BaseTy::Char
-            | BaseTy::RawPtr(_, _) => panic!(),
+            | BaseTy::RawPtr(_, _) => bug!(),
         }
     }
 

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -203,7 +203,8 @@ impl Expr {
             | BaseTy::Slice(_)
             | BaseTy::Char
             | BaseTy::RawPtr(_, _)
-            | BaseTy::Tuple(_) => bug!(),
+            | BaseTy::Tuple(_)
+            | BaseTy::Array(_, _) => bug!(),
         }
     }
 

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -204,7 +204,8 @@ impl Expr {
             | BaseTy::Char
             | BaseTy::RawPtr(_, _)
             | BaseTy::Tuple(_)
-            | BaseTy::Array(_, _) => bug!(),
+            | BaseTy::Array(_, _)
+            | BaseTy::Never => bug!(),
         }
     }
 

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -381,7 +381,6 @@ impl TypeFoldable for Ty {
                         .expect("folding produced an invalid path"),
                 )
             }
-            TyKind::Ref(rk, ty) => Ty::mk_ref(*rk, ty.fold_with(folder)),
             TyKind::Constr(pred, ty) => Ty::constr(pred.fold_with(folder), ty.fold_with(folder)),
             TyKind::Uninit | TyKind::Param(_) | TyKind::Never | TyKind::Discr(..) => self.clone(),
         }
@@ -398,7 +397,6 @@ impl TypeFoldable for Ty {
             }
             TyKind::Tuple(tys) => tys.iter().for_each(|ty| ty.visit_with(visitor)),
             TyKind::Array(ty, _) => ty.visit_with(visitor),
-            TyKind::Ref(_, ty) => ty.visit_with(visitor),
             TyKind::Ptr(_, path) => path.to_expr().visit_with(visitor),
             TyKind::Constr(pred, ty) => {
                 pred.visit_with(visitor);
@@ -462,6 +460,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::Adt(adt_def, substs) => BaseTy::adt(adt_def.clone(), substs.fold_with(folder)),
             BaseTy::Slice(ty) => BaseTy::Slice(ty.fold_with(folder)),
             BaseTy::RawPtr(ty, mu) => BaseTy::RawPtr(ty.fold_with(folder), *mu),
+            BaseTy::Ref(rk, ty) => BaseTy::Ref(*rk, ty.fold_with(folder)),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool
@@ -476,6 +475,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::Adt(_, substs) => substs.iter().for_each(|ty| ty.visit_with(visitor)),
             BaseTy::Slice(ty) => ty.visit_with(visitor),
             BaseTy::RawPtr(ty, _) => ty.visit_with(visitor),
+            BaseTy::Ref(_, ty) => ty.visit_with(visitor),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -370,7 +370,6 @@ impl TypeFoldable for Ty {
                 Ty::indexed(bty.fold_with(folder), idxs.fold_with(folder))
             }
             TyKind::Exists(exists) => TyKind::Exists(exists.fold_with(folder)).intern(),
-            TyKind::Tuple(tys) => Ty::tuple(tys.fold_with(folder)),
             TyKind::Array(ty, c) => Ty::array(ty.fold_with(folder), c.clone()),
             TyKind::Ptr(pk, path) => {
                 Ty::ptr(
@@ -395,7 +394,6 @@ impl TypeFoldable for Ty {
             TyKind::Exists(exists) => {
                 exists.visit_with(visitor);
             }
-            TyKind::Tuple(tys) => tys.iter().for_each(|ty| ty.visit_with(visitor)),
             TyKind::Array(ty, _) => ty.visit_with(visitor),
             TyKind::Ptr(_, path) => path.to_expr().visit_with(visitor),
             TyKind::Constr(pred, ty) => {
@@ -461,6 +459,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::Slice(ty) => BaseTy::Slice(ty.fold_with(folder)),
             BaseTy::RawPtr(ty, mu) => BaseTy::RawPtr(ty.fold_with(folder), *mu),
             BaseTy::Ref(rk, ty) => BaseTy::Ref(*rk, ty.fold_with(folder)),
+            BaseTy::Tuple(tys) => BaseTy::Tuple(tys.fold_with(folder)),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool
@@ -476,6 +475,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::Slice(ty) => ty.visit_with(visitor),
             BaseTy::RawPtr(ty, _) => ty.visit_with(visitor),
             BaseTy::Ref(_, ty) => ty.visit_with(visitor),
+            BaseTy::Tuple(tys) => tys.iter().for_each(|ty| ty.visit_with(visitor)),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -370,7 +370,6 @@ impl TypeFoldable for Ty {
                 Ty::indexed(bty.fold_with(folder), idxs.fold_with(folder))
             }
             TyKind::Exists(exists) => TyKind::Exists(exists.fold_with(folder)).intern(),
-            TyKind::Array(ty, c) => Ty::array(ty.fold_with(folder), c.clone()),
             TyKind::Ptr(pk, path) => {
                 Ty::ptr(
                     *pk,
@@ -394,7 +393,6 @@ impl TypeFoldable for Ty {
             TyKind::Exists(exists) => {
                 exists.visit_with(visitor);
             }
-            TyKind::Array(ty, _) => ty.visit_with(visitor),
             TyKind::Ptr(_, path) => path.to_expr().visit_with(visitor),
             TyKind::Constr(pred, ty) => {
                 pred.visit_with(visitor);
@@ -460,6 +458,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::RawPtr(ty, mu) => BaseTy::RawPtr(ty.fold_with(folder), *mu),
             BaseTy::Ref(rk, ty) => BaseTy::Ref(*rk, ty.fold_with(folder)),
             BaseTy::Tuple(tys) => BaseTy::Tuple(tys.fold_with(folder)),
+            BaseTy::Array(ty, c) => BaseTy::Array(ty.fold_with(folder), c.clone()),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool
@@ -476,6 +475,7 @@ impl TypeFoldable for BaseTy {
             BaseTy::RawPtr(ty, _) => ty.visit_with(visitor),
             BaseTy::Ref(_, ty) => ty.visit_with(visitor),
             BaseTy::Tuple(tys) => tys.iter().for_each(|ty| ty.visit_with(visitor)),
+            BaseTy::Array(ty, _) => ty.visit_with(visitor),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -380,7 +380,7 @@ impl TypeFoldable for Ty {
                 )
             }
             TyKind::Constr(pred, ty) => Ty::constr(pred.fold_with(folder), ty.fold_with(folder)),
-            TyKind::Uninit | TyKind::Param(_) | TyKind::Never | TyKind::Discr(..) => self.clone(),
+            TyKind::Uninit | TyKind::Param(_) | TyKind::Discr(..) => self.clone(),
         }
     }
 
@@ -398,7 +398,7 @@ impl TypeFoldable for Ty {
                 pred.visit_with(visitor);
                 ty.visit_with(visitor);
             }
-            TyKind::Param(_) | TyKind::Never | TyKind::Discr(..) | TyKind::Uninit => {}
+            TyKind::Param(_) | TyKind::Discr(..) | TyKind::Uninit => {}
         }
     }
 
@@ -464,7 +464,8 @@ impl TypeFoldable for BaseTy {
             | BaseTy::Bool
             | BaseTy::Float(_)
             | BaseTy::Str
-            | BaseTy::Char => self.clone(),
+            | BaseTy::Char
+            | BaseTy::Never => self.clone(),
         }
     }
 
@@ -481,7 +482,8 @@ impl TypeFoldable for BaseTy {
             | BaseTy::Bool
             | BaseTy::Float(_)
             | BaseTy::Str
-            | BaseTy::Char => {}
+            | BaseTy::Char
+            | BaseTy::Never => {}
         }
     }
 

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -688,7 +688,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         let ty2 = self.check_operand(rcx, env, source_span, op2)?;
 
         match (ty1.kind(), ty2.kind()) {
-            (Float!(float_ty1, _), Float!(float_ty2, _)) => {
+            (Float!(float_ty1), Float!(float_ty2)) => {
                 debug_assert_eq!(float_ty1, float_ty2);
                 match bin_op {
                     mir::BinOp::Eq
@@ -760,7 +760,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                             RefineArgs::one(idxs.nth(0).as_expr().neg()),
                         )
                     }
-                    Float!(float_ty, _) => Ty::float(*float_ty),
+                    Float!(float_ty) => Ty::float(*float_ty),
                     _ => tracked_span_bug!("incompatible type: `{:?}`", ty),
                 }
             }

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -667,7 +667,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             .map_err(|err| CheckerError::from(err).with_span(source_span))?;
 
         let idxs = match ty.kind() {
-            TyKind::Array(_, len) => RefineArgs::one(Expr::constant(rty::Constant::from(len.val))),
+            TyKind::Indexed(BaseTy::Array(_, len), _) => {
+                RefineArgs::one(Expr::constant(rty::Constant::from(len.val)))
+            }
             TyKind::Indexed(BaseTy::Slice(_), idxs) => idxs.clone(),
             _ => tracked_span_bug!("expected array or slice type"),
         };

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -375,12 +375,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             (TyKind::Param(param1), TyKind::Param(param2)) => {
                 debug_assert_eq!(param1, param2);
             }
-            (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
-                debug_assert_eq!(tys1.len(), tys2.len());
-                for (ty1, ty2) in iter::zip(tys1, tys2) {
-                    self.subtyping(rcx, ty1, ty2);
-                }
-            }
             (TyKind::Array(ty1, len1), TyKind::Array(ty2, len2)) => {
                 debug_assert_eq!(len1.val, len2.val);
                 self.subtyping(rcx, ty1, ty2);
@@ -422,6 +416,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             (BaseTy::Ref(RefKind::Shr, ty1), BaseTy::Ref(RefKind::Shr, ty2)) => {
                 self.subtyping(rcx, ty1, ty2);
+            }
+            (BaseTy::Tuple(tys1), BaseTy::Tuple(tys2)) => {
+                debug_assert_eq!(tys1.len(), tys2.len());
+                for (ty1, ty2) in iter::zip(tys1, tys2) {
+                    self.subtyping(rcx, ty1, ty2);
+                }
             }
             (BaseTy::Bool, BaseTy::Bool)
             | (BaseTy::Str, BaseTy::Str)

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -375,10 +375,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             (TyKind::Param(param1), TyKind::Param(param2)) => {
                 debug_assert_eq!(param1, param2);
             }
-            (TyKind::Array(ty1, len1), TyKind::Array(ty2, len2)) => {
-                debug_assert_eq!(len1.val, len2.val);
-                self.subtyping(rcx, ty1, ty2);
-            }
             (_, TyKind::Constr(p2, ty2)) => {
                 rcx.check_pred(p2, self.tag);
                 self.subtyping(rcx, ty1, ty2);
@@ -422,6 +418,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 for (ty1, ty2) in iter::zip(tys1, tys2) {
                     self.subtyping(rcx, ty1, ty2);
                 }
+            }
+            (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
+                debug_assert_eq!(len1.val, len2.val);
+                self.subtyping(rcx, ty1, ty2);
             }
             (BaseTy::Bool, BaseTy::Bool)
             | (BaseTy::Str, BaseTy::Str)

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -418,7 +418,6 @@ impl TypeEnvInfer {
                     Ty::indexed(bty, idxs.clone())
                 }
             }
-            TyKind::Array(ty, c) => Ty::array(Self::pack_ty(scope, ty), c.clone()),
             // TODO(nilehmann) [`TyKind::Exists`] could also in theory contains free variables.
             TyKind::Exists(_)
             | TyKind::Never
@@ -450,6 +449,7 @@ impl TypeEnvInfer {
             }
             BaseTy::Slice(ty) => BaseTy::Slice(Self::pack_ty(scope, ty)),
             BaseTy::Ref(rk, ty) => BaseTy::Ref(*rk, Self::pack_ty(scope, ty)),
+            BaseTy::Array(ty, c) => BaseTy::Array(Self::pack_ty(scope, ty), c.clone()),
             BaseTy::Int(_)
             | BaseTy::Uint(_)
             | BaseTy::Bool
@@ -630,10 +630,6 @@ impl TypeEnvInfer {
                 debug_assert_eq!(param_ty1, param_ty2);
                 Ty::param(*param_ty1)
             }
-            (TyKind::Array(ty1, len1), TyKind::Array(ty2, len2)) => {
-                debug_assert_eq!(len1, len2);
-                Ty::array(self.join_ty(ty1, ty2), len1.clone())
-            }
             _ => tracked_span_bug!("unexpected types: `{ty1:?}` - `{ty2:?}`"),
         }
     }
@@ -656,6 +652,10 @@ impl TypeEnvInfer {
             (BaseTy::Ref(rk1, ty1), BaseTy::Ref(rk2, ty2)) => {
                 debug_assert_eq!(rk1, rk2);
                 BaseTy::Ref(*rk1, self.join_ty(ty1, ty2))
+            }
+            (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
+                debug_assert_eq!(len1, len2);
+                BaseTy::Array(self.join_ty(ty1, ty2), len1.clone())
             }
             _ => {
                 debug_assert_eq!(bty1, bty2);

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -418,9 +418,8 @@ impl TypeEnvInfer {
                     Ty::indexed(bty, idxs.clone())
                 }
             }
-            // TODO(nilehmann) [`TyKind::Exists`] could also in theory contains free variables.
+            // FIXME(nilehmann) [`TyKind::Exists`] could also contain free variables.
             TyKind::Exists(_)
-            | TyKind::Never
             | TyKind::Discr(..)
             | TyKind::Ptr(..)
             | TyKind::Uninit
@@ -456,7 +455,8 @@ impl TypeEnvInfer {
             | BaseTy::Float(_)
             | BaseTy::Str
             | BaseTy::RawPtr(_, _)
-            | BaseTy::Char => bty.clone(),
+            | BaseTy::Char
+            | BaseTy::Never => bty.clone(),
         }
     }
 

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -327,7 +327,7 @@ impl PathsTree {
                     let (boxed, _) = box_args(substs);
                     ty = boxed.clone();
                 }
-                (Field(field), TyKind::Tuple(tys)) => {
+                (Field(field), TyKind::Indexed(BaseTy::Tuple(tys), _)) => {
                     ty = tys[field.as_usize()].clone();
                 }
                 (Field(field), TyKind::Indexed(BaseTy::Adt(adt, substs), idxs)) => {
@@ -601,7 +601,7 @@ impl Node {
     fn split(&mut self, genv: &GlobalEnv, rcx: &mut RefineCtxt) -> Result<(), OpaqueStructErr> {
         let ty = self.expect_leaf_mut().unblock(rcx);
         match ty.kind() {
-            TyKind::Tuple(tys) => {
+            TyKind::Indexed(BaseTy::Tuple(tys), _) => {
                 let children = tys
                     .iter()
                     .cloned()

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -284,7 +284,7 @@ impl PathsTree {
                     PlaceElem::Index(_) => {
                         let ty = ptr.borrow().expect_owned();
                         match ty.kind() {
-                            TyKind::Array(arr_ty, _) => {
+                            TyKind::Indexed(BaseTy::Array(arr_ty, _), _) => {
                                 let (rk, ty) =
                                     Self::lookup_ty(genv, rcx, WeakKind::Arr, arr_ty, place_proj)?;
                                 return Ok(LookupResult {
@@ -292,7 +292,7 @@ impl PathsTree {
                                     kind: LookupKind::Weak(rk, ty),
                                 });
                             }
-                            _ => tracked_span_bug!("Unsupported Index: {elem:?} {ty:?}"),
+                            _ => tracked_span_bug!("unsupported index: {elem:?} {ty:?}"),
                         }
                     }
                 }

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -7,8 +7,8 @@ use flux_middle::{
     rty::{
         box_args,
         fold::{TypeFoldable, TypeFolder, TypeVisitor},
-        AdtDef, BaseTy, Expr, GenericArg, Loc, Path, PtrKind, RefineArg, Sort, Substs, Ty, TyKind,
-        Var, VariantIdx,
+        AdtDef, BaseTy, Expr, GenericArg, Loc, Path, PtrKind, Ref, RefineArg, Sort, Substs, Ty,
+        TyKind, Var, VariantIdx,
     },
     rustc::mir::{Field, Place, PlaceElem},
 };
@@ -246,7 +246,7 @@ impl PathsTree {
                                 path = ptr_path.clone();
                                 continue 'outer;
                             }
-                            TyKind::Ref(rk, ty) => {
+                            Ref!(rk, ty) => {
                                 let (rk, ty) = Self::lookup_ty(
                                     genv,
                                     rcx,
@@ -319,7 +319,7 @@ impl PathsTree {
                 ty = rcx.unpack_with(&ty, UnpackFlags::SHALLOW);
             }
             match (elem, ty.kind()) {
-                (Deref, TyKind::Ref(rk2, ty2)) => {
+                (Deref, Ref!(rk2, ty2)) => {
                     rk = rk.min(WeakKind::from(*rk2));
                     ty = ty2.clone();
                 }


### PR DESCRIPTION
This is in preparation for refined type variables as proposed here https://hackmd.io/O7Ywiy2ORq6OfrpvMSjTOQ