### PR TITLE
Update toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ name = "flux"
 version = "0.1.0"
 dependencies = [
  "flux-common",
+ "flux-config",
  "flux-driver",
  "tracing",
  "tracing-subscriber",
@@ -482,7 +483,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dirs",
- "flux-common",
+ "flux-config",
  "rust-toolchain-file",
 ]
 
@@ -491,7 +492,17 @@ name = "flux-common"
 version = "0.1.0"
 dependencies = [
  "config",
+ "flux-config",
  "once_cell",
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "flux-config"
+version = "0.1.0"
+dependencies = [
+ "config",
  "serde",
  "toml",
 ]
@@ -514,6 +525,7 @@ name = "flux-driver"
 version = "0.1.0"
 dependencies = [
  "flux-common",
+ "flux-config",
  "flux-desugar",
  "flux-errors",
  "flux-fixpoint",
@@ -538,6 +550,7 @@ name = "flux-fixpoint"
 version = "0.1.0"
 dependencies = [
  "flux-common",
+ "flux-config",
  "itertools",
  "serde",
  "serde_json",
@@ -574,6 +587,7 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "flux-common",
+ "flux-config",
  "flux-errors",
  "flux-fixpoint",
  "flux-macros",
@@ -587,6 +601,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "flux-common",
+ "flux-config",
  "flux-errors",
  "flux-fixpoint",
  "flux-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,11 +491,7 @@ dependencies = [
 name = "flux-common"
 version = "0.1.0"
 dependencies = [
- "config",
  "flux-config",
- "once_cell",
- "serde",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "flux",
     "flux-bin",
     "flux-common",
+    "flux-config",
     "flux-desugar",
     "flux-driver",
     "flux-errors",

--- a/flux-bin/Cargo.toml
+++ b/flux-bin/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
+edition = "2021"
 name = "flux-bin"
 version = "0.1.0"
-edition = "2021"
 
 [[bin]]
+doctest = false
 name = "cargo-flux"
 test = false
-doctest = false
 
 [[bin]]
+doctest = false
 name = "rustc-flux"
 test = false
-doctest = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flux-common = { path = "../flux-common" }
 anyhow = "1.0.68"
 dirs = "4.0.0"
+flux-config = { path = "../flux-config" }
 rust-toolchain-file = "0.1.0"

--- a/flux-bin/src/utils.rs
+++ b/flux-bin/src/utils.rs
@@ -1,7 +1,7 @@
 use std::{env, ffi::OsString, fs, path::PathBuf};
 
 use anyhow::{anyhow, Result};
-use flux_common::config;
+use flux_config as config;
 
 #[cfg(target_os = "windows")]
 pub const LIB_PATH: &str = "PATH";

--- a/flux-common/Cargo.toml
+++ b/flux-common/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 config = "0.12"
+flux-config = { path = "../flux-config" }
 once_cell = "1.9"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"

--- a/flux-common/Cargo.toml
+++ b/flux-common/Cargo.toml
@@ -6,11 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-config = "0.12"
 flux-config = { path = "../flux-config" }
-once_cell = "1.9"
-serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/flux-common/src/cache.rs
+++ b/flux-common/src/cache.rs
@@ -1,8 +1,7 @@
 use std::{fs::File, path::PathBuf};
 
+use flux_config as config;
 use rustc_hash::FxHashMap;
-
-use crate::config;
 
 pub struct QueryCache {
     entries: FxHashMap<String, u64>,

--- a/flux-common/src/dbg.rs
+++ b/flux-common/src/dbg.rs
@@ -4,10 +4,9 @@ use std::{
     io::{self, Write},
 };
 
+use flux_config as config;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
-
-use crate::config;
 
 pub fn writer_for_item(
     tcx: TyCtxt,

--- a/flux-common/src/lib.rs
+++ b/flux-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private, try_trait_v2, try_blocks, never_type, once_cell)]
 
+extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;
@@ -9,7 +10,6 @@ extern crate rustc_span;
 extern crate serde_json;
 
 pub mod cache;
-pub mod config;
 pub mod dbg;
 pub mod format;
 pub mod index;

--- a/flux-config/Cargo.toml
+++ b/flux-config/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
 edition = "2021"
-name = "flux-fixpoint"
+name = "flux-config"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flux-common = { path = "../flux-common" }
-flux-config = { path = "../flux-config" }
-itertools = "0.10"
+config = "0.12"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-
-[package.metadata.rust-analyzer]
-rustc_private = true
+toml = "0.5"

--- a/flux-config/src/lib.rs
+++ b/flux-config/src/lib.rs
@@ -1,0 +1,161 @@
+#![feature(once_cell)]
+
+use std::{io::Read, path::PathBuf, sync::LazyLock};
+
+use config::{Environment, File};
+use serde::Deserialize;
+pub use toml::Value;
+
+const FLUX_ENV_VAR_PREFIX: &str = "FLUX";
+const FLUX_CONFIG_ENV_VAR: &str = "FLUX_CONFIG";
+
+#[derive(Debug, Deserialize, Copy, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum AssertBehavior {
+    Ignore,
+    Assume,
+    Check,
+}
+
+pub fn check_def() -> &'static str {
+    &CONFIG.check_def
+}
+
+pub fn dump_timings() -> bool {
+    CONFIG.dump_timings
+}
+
+pub fn dump_checker_trace() -> bool {
+    CONFIG.dump_checker_trace
+}
+
+pub fn dump_mir() -> bool {
+    CONFIG.dump_mir
+}
+
+pub fn dump_constraint() -> bool {
+    CONFIG.dump_constraint
+}
+
+pub fn dump_fhir() -> bool {
+    CONFIG.dump_fhir
+}
+
+pub fn pointer_width() -> u64 {
+    CONFIG.pointer_width
+}
+
+pub fn assert_behavior() -> AssertBehavior {
+    CONFIG.check_asserts
+}
+
+pub fn log_dir() -> &'static PathBuf {
+    &CONFIG.log_dir
+}
+
+pub fn is_cache_enabled() -> bool {
+    CONFIG.cache
+}
+
+pub fn cache_path() -> PathBuf {
+    log_dir().join(&CONFIG.cache_file)
+}
+
+pub fn driver_path() -> Option<&'static PathBuf> {
+    CONFIG.driver_path.as_ref()
+}
+
+impl std::str::FromStr for AssertBehavior {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ignore" => Ok(AssertBehavior::Ignore),
+            "assume" => Ok(AssertBehavior::Assume),
+            "check" => Ok(AssertBehavior::Check),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CrateConfig {
+    pub log_dir: PathBuf,
+    pub dump_constraint: bool,
+    pub dump_checker_trace: bool,
+    pub check_asserts: AssertBehavior,
+}
+
+#[derive(Deserialize)]
+struct Config {
+    driver_path: Option<PathBuf>,
+    log_dir: PathBuf,
+    dump_constraint: bool,
+    dump_checker_trace: bool,
+    dump_timings: bool,
+    dump_fhir: bool,
+    check_asserts: AssertBehavior,
+    dump_mir: bool,
+    pointer_width: u64,
+    check_def: String,
+    cache: bool,
+    cache_file: String,
+}
+
+static CONFIG: LazyLock<Config> = LazyLock::new(|| {
+    fn build() -> Result<Config, config::ConfigError> {
+        let mut config_builder = config::Config::builder()
+            .set_default("driver_path", None::<String>)?
+            .set_default("log_dir", "./log/")?
+            .set_default("dump_constraint", false)?
+            .set_default("dump_checker_trace", false)?
+            .set_default("dump_timings", false)?
+            .set_default("dump_mir", false)?
+            .set_default("dump_fhir", false)?
+            .set_default("check_asserts", "assume")?
+            .set_default("pointer_width", 64)?
+            .set_default("check_def", "")?
+            .set_default("cache", false)?
+            .set_default("cache_file", "cache.json")?;
+        // Config comes first, enviroment settings override it.
+        if let Some(config_path) = CONFIG_PATH.as_ref() {
+            config_builder = config_builder.add_source(File::from(config_path.to_path_buf()));
+        };
+        config_builder
+            .add_source(Environment::with_prefix(FLUX_ENV_VAR_PREFIX).ignore_empty(true))
+            .build()?
+            .try_deserialize()
+    }
+    build().unwrap()
+});
+
+pub static CONFIG_PATH: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+    if let Ok(file) = std::env::var(FLUX_CONFIG_ENV_VAR) {
+        return Some(PathBuf::from(file));
+    }
+
+    // find config file in current or parent directories
+    let mut path = std::env::current_dir().unwrap();
+    loop {
+        for name in ["flux.toml", ".flux.toml"] {
+            let file = path.join(name);
+            if file.exists() {
+                return Some(file);
+            }
+        }
+        if !path.pop() {
+            return None;
+        }
+    }
+});
+
+pub static CONFIG_FILE: LazyLock<Value> = LazyLock::new(|| {
+    if let Some(path) = &*CONFIG_PATH {
+        let mut file = std::fs::File::open(path).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        toml::from_str(&contents).unwrap()
+    } else {
+        toml::from_str("").unwrap()
+    }
+});

--- a/flux-driver/Cargo.toml
+++ b/flux-driver/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 flux-common = { path = "../flux-common" }
+flux-config = { path = "../flux-config" }
 flux-desugar = { path = "../flux-desugar" }
 flux-errors = { path = "../flux-errors" }
 flux-fixpoint = { path = "../flux-fixpoint" }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -1,4 +1,5 @@
-use flux_common::{cache::QueryCache, config, dbg, iter::IterExt};
+use flux_common::{cache::QueryCache, dbg, iter::IterExt};
+use flux_config as config;
 use flux_desugar as desugar;
 use flux_errors::FluxSession;
 use flux_metadata::CStore;
@@ -53,7 +54,7 @@ impl Callbacks for FluxCallbacks {
             return Compilation::Stop;
         }
 
-        queries.global_ctxt().unwrap().peek_mut().enter(|tcx| {
+        queries.global_ctxt().unwrap().enter(|tcx| {
             if !is_tool_registered(tcx) {
                 return;
             }

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -1,9 +1,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use flux_common::{
-    config::{self, AssertBehavior, CrateConfig},
-    iter::IterExt,
-};
+use flux_common::iter::IterExt;
+use flux_config::{self as config, AssertBehavior, CrateConfig};
 use flux_errors::{FluxSession, ResultExt};
 use flux_middle::{const_eval::scalar_int_to_rty_constant, rty::Constant};
 use flux_syntax::{

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private, never_type)]
 
 extern crate rustc_data_structures;
+extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_session;
 extern crate rustc_span;

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -19,7 +19,8 @@ pub use constraint::{
     BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, Pred, Proj, Qualifier,
     Sign, Sort, UifDef, UnOp,
 };
-use flux_common::{cache::QueryCache, config, format::PadAdapter};
+use flux_common::{cache::QueryCache, format::PadAdapter};
+use flux_config as config;
 use itertools::Itertools;
 use serde::{de, Deserialize};
 

--- a/flux-middle/Cargo.toml
+++ b/flux-middle/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [dependencies]
 dashmap = { version = "4.0.2", features = ["raw-api"] }
 flux-common = { path = "../flux-common" }
+flux-config = { path = "../flux-config" }
 flux-errors = { path = "../flux-errors" }
 flux-fixpoint = { path = "../flux-fixpoint" }
 flux-macros = { path = "../flux-macros" }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -920,21 +920,3 @@ impl fmt::Debug for FuncSort {
         fmt::Display::fmt(self, f)
     }
 }
-
-impl rustc_errors::IntoDiagnosticArg for &Sort {
-    fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
-        let cow = match self {
-            Sort::Bool => Cow::Borrowed("bool"),
-            Sort::Int => Cow::Borrowed("int"),
-            Sort::Loc => Cow::Borrowed("loc"),
-            _ => Cow::Owned(format!("{self}")),
-        };
-        rustc_errors::DiagnosticArgValue::Str(cow)
-    }
-}
-
-impl rustc_errors::IntoDiagnosticArg for &FuncSort {
-    fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
-        rustc_errors::DiagnosticArgValue::Str(Cow::Owned(format!("{self}")))
-    }
-}

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -1,9 +1,7 @@
 use std::{cell::RefCell, collections::hash_map, string::ToString};
 
-use flux_common::{
-    bug,
-    config::{self, AssertBehavior},
-};
+use flux_common::bug;
+use flux_config::{self as config, AssertBehavior};
 use flux_errors::{ErrorGuaranteed, FluxSession};
 use itertools::Itertools;
 use rustc_errors::FatalError;

--- a/flux-middle/src/pretty.rs
+++ b/flux-middle/src/pretty.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, fmt};
 
-use flux_common::config;
+use flux_config as config;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{mir::Field, ty::TyCtxt};
 use rustc_span::{Pos, Span};
@@ -101,7 +101,7 @@ macro_rules! _impl_debug_with_default_cx {
                     #[allow(unused_mut)]
                     let mut cx = <$ty>::default_cx(tcx);
                     $(
-                    if let Some(opts) = flux_common::config::CONFIG_FILE
+                    if let Some(opts) = flux_config::CONFIG_FILE
                         .get("dev")
                         .and_then(|dev| dev.get("pprint"))
                         .and_then(|pprint| pprint.get($key))

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -150,7 +150,8 @@ impl<'a, 'tcx> LoweringCtxt<'a, 'tcx> {
             | rustc_mir::StatementKind::Deinit(_)
             | rustc_mir::StatementKind::AscribeUserType(..)
             | rustc_mir::StatementKind::Coverage(_)
-            | rustc_mir::StatementKind::Intrinsic(_) => {
+            | rustc_mir::StatementKind::Intrinsic(_)
+            | rustc_mir::StatementKind::ConstEvalCounter => {
                 return Err(errors::UnsupportedMir::from(stmt)).emit(self.sess);
             }
         };
@@ -569,7 +570,7 @@ pub fn lower_fn_sig_of(tcx: TyCtxt, def_id: DefId) -> Result<PolyFnSig, errors::
         .infer_ctxt()
         .build()
         .at(&rustc_middle::traits::ObligationCause::dummy(), param_env)
-        .normalize(fn_sig);
+        .normalize(fn_sig.subst_identity());
     lower_fn_sig(tcx, result.value)
         .map_err(|err| errors::UnsupportedFnSig { span, reason: err.reason })
 }

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -8,8 +8,8 @@ use rustc_macros::{Decodable, Encodable};
 pub use rustc_middle::{
     mir::Mutability,
     ty::{
-        BoundVar, DebruijnIndex, EarlyBoundRegion, FloatTy, IntTy, ParamTy, RegionVid, ScalarInt,
-        UintTy,
+        BoundVar, DebruijnIndex, EarlyBinder, EarlyBoundRegion, FloatTy, IntTy, ParamTy, RegionVid,
+        ScalarInt, UintTy,
     },
 };
 use rustc_span::Symbol;

--- a/flux-refineck/Cargo.toml
+++ b/flux-refineck/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [dependencies]
 bitflags = "1.3"
 flux-common = { path = "../flux-common" }
+flux-config = { path = "../flux-config" }
 flux-errors = { path = "../flux-errors" }
 flux-fixpoint = { path = "../flux-fixpoint" }
 flux-macros = { path = "../flux-macros" }

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -276,7 +276,6 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                     self.check_terminator(&mut rcx, &mut env, terminator, last_stmt_span)?;
                 dbg::terminator!("end", terminator, rcx, env);
 
-                println!("set {bb:?}");
                 self.snapshots[bb] = Some(rcx.snapshot());
                 let term_span = last_stmt_span.unwrap_or(terminator.source_info.span);
                 self.check_successors(rcx, env, term_span, successors)
@@ -1055,7 +1054,7 @@ impl PartialEq for Item<'_> {
 
 impl PartialOrd for Item<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.dominators.rank_partial_cmp(self.bb, other.bb)
+        self.dominators.rank_partial_cmp(other.bb, self.bb)
     }
 }
 impl Eq for Item<'_> {}

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -9,13 +9,8 @@ extern crate rustc_span;
 
 use std::collections::{hash_map::Entry, BinaryHeap};
 
-use flux_common::{
-    bug,
-    config::{self, AssertBehavior},
-    dbg,
-    index::IndexVec,
-    span_bug, tracked_span_bug,
-};
+use flux_common::{bug, dbg, index::IndexVec, span_bug, tracked_span_bug};
+use flux_config::{self as config, AssertBehavior};
 use flux_middle::{
     global_env::GlobalEnv,
     rty::{
@@ -195,8 +190,8 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
 
         ck.check_goto(rcx, env, body.span(), START_BLOCK)?;
         while let Some(bb) = ck.queue.pop() {
-            let snapshot = ck.snapshot_at_dominator(bb);
             if ck.visited.contains(bb) {
+                let snapshot = ck.snapshot_at_dominator(bb);
                 refine_tree.clear(snapshot);
                 ck.clear(bb);
             }
@@ -245,7 +240,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         // TODO(nilehmann) there should be a better way to iterate over all dominated blocks.
         self.visited.remove(root);
         for bb in self.body.basic_blocks.indices() {
-            if bb != root && self.dominators.is_dominated_by(bb, root) {
+            if bb != root && self.dominators.dominates(root, bb) {
                 self.phase.clear(bb);
                 self.visited.remove(bb);
             }
@@ -281,6 +276,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                     self.check_terminator(&mut rcx, &mut env, terminator, last_stmt_span)?;
                 dbg::terminator!("end", terminator, rcx, env);
 
+                println!("set {bb:?}");
                 self.snapshots[bb] = Some(rcx.snapshot());
                 let term_span = last_stmt_span.unwrap_or(terminator.source_info.span);
                 self.check_successors(rcx, env, term_span, successors)

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -3,9 +3,10 @@ use std::iter;
 use fixpoint::FixpointResult;
 use flux_common::{
     cache::QueryCache,
-    config, dbg,
+    dbg,
     index::{IndexGen, IndexVec},
 };
+use flux_config as config;
 use flux_fixpoint as fixpoint;
 use flux_middle::{
     global_env::GlobalEnv,

--- a/flux-refineck/src/lib.rs
+++ b/flux-refineck/src/lib.rs
@@ -33,7 +33,8 @@ mod sigs;
 
 use checker::Checker;
 use constraint_gen::{ConstrReason, Tag};
-use flux_common::{cache::QueryCache, config, dbg};
+use flux_common::{cache::QueryCache, dbg};
+use flux_config as config;
 use flux_errors::ResultExt;
 use flux_middle::{global_env::GlobalEnv, rty, rustc::mir::Body};
 use itertools::Itertools;

--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, iter::Peekable};
 pub use rustc_ast::token::{BinOpToken, Delimiter, Lit, LitKind};
 use rustc_ast::{
     token::{self, TokenKind},
-    tokenstream::{self, TokenStream, TokenTree},
+    tokenstream::{TokenStream, TokenTree, TokenTreeCursor},
 };
 use rustc_span::{symbol::kw, BytePos, Symbol};
 
@@ -81,7 +81,7 @@ struct Symbols {
 }
 
 struct Frame {
-    cursor: Peekable<tokenstream::Cursor>,
+    cursor: Peekable<TokenTreeCursor>,
     close: Option<(Location, Token, Location)>,
 }
 

--- a/flux-tests/tests/neg/error_messages/dfn_cycle.rs
+++ b/flux-tests/tests/neg/error_messages/dfn_cycle.rs
@@ -2,8 +2,8 @@
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
 #![flux::defs {
-    fn even(x: int) -> bool { x == 0 || odd(x-1) }  //~ ERROR cycle
-    fn odd(x: int) -> bool { x == 1 || even(x-1) }
+    fn even(x: int) -> bool { x == 0 || odd(x-1) }
+    fn odd(x: int) -> bool { x == 1 || even(x-1) } //~ ERROR cycle
 }]
 
 #[flux::sig(fn(x:i32) -> i32[x+1])]

--- a/flux/Cargo.toml
+++ b/flux/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 
 [dependencies]
 flux-common = { path = "../flux-common" }
+flux-config = { path = "../flux-config" }
 flux-driver = { path = "../flux-driver" }
 tracing-subscriber = { version = "0.3", features = ["json"] }
 tracing-timing = "0.6.0"

--- a/flux/src/logger.rs
+++ b/flux/src/logger.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use flux_common::config;
+use flux_config as config;
 use tracing::{Dispatch, Level};
 use tracing_subscriber::{filter::Targets, fmt::writer::BoxMakeWriter, prelude::*, Registry};
 use tracing_timing::TimingLayer;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-12-30"
+channel = "nightly-2023-02-09"
 components = ["rust-src", "rustc-dev", "llvm-tools", "rustfmt"]


### PR DESCRIPTION
* The way `rustc_driver` dynamic library is distributed changed [here](https://github.com/rust-lang/rust/pull/105609). Had to move `config` into a new crate that doesn't depend on rustc such that binaries in `flux-bin` also don't dependent on them.
* After the update lalrpop is giving a future incompatibility warning. There's a [PR fixing it](https://github.com/lalrpop/lalrpop/pull/703), but the crate is not getting much maintenance these days. Maybe we should start thinking about moving to a different parser library. 