### PR TITLE
Remove refine arg in rty

### DIFF
--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -44,8 +44,8 @@ pub enum ExprKind {
     ///
     /// 1. They can appear as an index at the top level.
     /// 2. We can only substitute an abstraction for a variable in function position (or as an index).
-    ///    More generaly, what we need is to be able to partially evaluate expressions such that all
-    ///    abstractions are eliminated before encoding into the logic. Right now, the implementation
+    ///    More generaly, we need to be able to partially evaluate expressions such that all abstractions
+    ///    in non-index position are eliminated before encoding into fixpoint. Right now, the implementation
     ///    immediately applies the abstraction when it is substituted, thus the restriction.
     Abs(Binders<Expr>),
     Hole,

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -39,10 +39,14 @@ pub enum ExprKind {
     PathProj(Expr, Field),
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
-    /// Lambda abstractions. They show up in refinements when an explicit abstract predicate is
-    /// provided as the index to a type. Abstractions can only be used directly as an index or
-    /// replaced in positions where they can be fully applied, i.e., abstractions are purely
-    /// syntactic and we don't encode them in the logic.
+    /// Lambda abstractions. They are purely syntactic and we don't encode them in the logic. As such,
+    /// they have some syntactic restrictions that we must carefully maintain:
+    ///
+    /// 1. They can appear as an index at the top level.
+    /// 2. We can only substitute an abstraction for a variable in function position (or as an index).
+    ///    More generaly, what we need is to be able to partially evaluate expressions such that all
+    ///    abstractions are eliminated before encoding into the logic. Right now, the implementation
+    ///    immediately applies the abstraction when it is substituted, thus the restriction.
     Abs(Binders<Expr>),
     Hole,
 }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -164,12 +164,6 @@ struct RefineArgsData {
     is_binder: BitSet<usize>,
 }
 
-// #[derive(Clone, Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
-// pub enum RefineArg {
-//     Expr(Expr),
-//     Abs(Binders<Expr>),
-// }
-
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum BaseTy {
     Int(IntTy),

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -16,7 +16,7 @@ pub use evars::{EVar, EVarGen};
 pub use expr::{
     BoundVar, DebruijnIndex, Expr, ExprKind, Func, KVar, KVid, Loc, Name, Path, Var, INNERMOST,
 };
-use flux_common::{bug, index::IndexGen};
+use flux_common::index::IndexGen;
 pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
@@ -158,17 +158,17 @@ pub struct RefineArgs(Interned<RefineArgsData>);
 
 #[derive(Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
 struct RefineArgsData {
-    args: Vec<RefineArg>,
+    args: Vec<Expr>,
     /// Set containing all the indices of arguments that were used as binders in the surface syntax.
     /// This is used as a hint for inferring parameters at call sites.
     is_binder: BitSet<usize>,
 }
 
-#[derive(Clone, Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
-pub enum RefineArg {
-    Expr(Expr),
-    Abs(Binders<Expr>),
-}
+// #[derive(Clone, Eq, Hash, PartialEq, TyEncodable, TyDecodable)]
+// pub enum RefineArg {
+//     Expr(Expr),
+//     Abs(Binders<Expr>),
+// }
 
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum BaseTy {
@@ -245,24 +245,24 @@ impl<T> Binders<T>
 where
     T: TypeFoldable,
 {
-    pub fn replace_bvars(&self, args: &[RefineArg]) -> T {
+    pub fn replace_bvars(&self, args: &[Expr]) -> T {
         self.value.fold_with(&mut BVarSubstFolder::new(args))
     }
 
-    pub fn replace_bvars_with(&self, f: impl FnMut(&Sort) -> RefineArg) -> T {
+    pub fn replace_bvars_with(&self, f: impl FnMut(&Sort) -> Expr) -> T {
         let args = self.params.iter().map(f).collect_vec();
         self.replace_bvars(&args)
     }
 
     pub fn replace_bvars_with_fresh_fvars(&self, mut fresh: impl FnMut(&Sort) -> Name) -> T {
-        self.replace_bvars_with(|sort| RefineArg::Expr(Expr::fvar(fresh(sort))))
+        self.replace_bvars_with(|sort| Expr::fvar(fresh(sort)))
     }
 }
 
 impl RefineArgs {
     pub fn new<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (RefineArg, bool)>,
+        T: IntoIterator<Item = (Expr, bool)>,
         T::IntoIter: ExactSizeIterator,
     {
         let iter = iter.into_iter();
@@ -279,34 +279,30 @@ impl RefineArgs {
         RefineArgsData { args, is_binder: bitset }.intern()
     }
 
-    pub fn multi(args: Vec<RefineArg>) -> Self {
+    pub fn multi(args: Vec<Expr>) -> Self {
         let is_binder = BitSet::new_empty(args.len());
         RefineArgsData { args, is_binder }.intern()
     }
 
-    pub fn one(arg: impl Into<RefineArg>) -> Self {
+    pub fn one(arg: impl Into<Expr>) -> Self {
         RefineArgsData { args: vec![arg.into()], is_binder: BitSet::new_empty(1) }.intern()
     }
 
     /// Return a list of bound variables. The returned value will have escaping vars which
     /// need to be put inside a [`Binders`]
     pub fn bound(n: usize) -> RefineArgs {
-        RefineArgs::multi(
-            (0..n)
-                .map(|i| RefineArg::Expr(Expr::bvar(BoundVar::innermost(i))))
-                .collect(),
-        )
+        RefineArgs::multi((0..n).map(|i| Expr::bvar(BoundVar::innermost(i))).collect())
     }
 
     pub fn is_binder(&self, i: usize) -> bool {
         self.0.is_binder.contains(i)
     }
 
-    pub fn nth(&self, idx: usize) -> &RefineArg {
+    pub fn nth(&self, idx: usize) -> &Expr {
         &self.args()[idx]
     }
 
-    pub fn args(&self) -> &[RefineArg] {
+    pub fn args(&self) -> &[Expr] {
         &self.0.args
     }
 
@@ -321,17 +317,6 @@ impl RefineArgsData {
     }
 }
 
-impl RefineArg {
-    #[track_caller]
-    pub fn expect_expr(&self) -> &Expr {
-        if let RefineArg::Expr(e) = self {
-            e
-        } else {
-            bug!("expected an `RefineArg::Expr`")
-        }
-    }
-}
-
 impl PolySig {
     pub fn new(fn_sig: Binders<FnSig>, modes: impl Into<List<InferMode>>) -> PolySig {
         let modes = modes.into();
@@ -339,7 +324,7 @@ impl PolySig {
         PolySig { fn_sig, modes }
     }
 
-    pub fn replace_bvars_with(&self, mut f: impl FnMut(&Sort, InferMode) -> RefineArg) -> FnSig {
+    pub fn replace_bvars_with(&self, mut f: impl FnMut(&Sort, InferMode) -> Expr) -> FnSig {
         let args = iter::zip(&self.fn_sig.params, &self.modes)
             .map(|(sort, kind)| f(sort, *kind))
             .collect_vec();
@@ -633,24 +618,6 @@ impl From<RefKind> for PtrKind {
     }
 }
 
-impl From<&RefineArg> for RefineArg {
-    fn from(arg: &RefineArg) -> Self {
-        arg.clone()
-    }
-}
-
-impl From<Expr> for RefineArg {
-    fn from(expr: Expr) -> Self {
-        RefineArg::Expr(expr)
-    }
-}
-
-impl From<&Expr> for RefineArg {
-    fn from(expr: &Expr) -> Self {
-        RefineArg::Expr(expr.clone())
-    }
-}
-
 impl BaseTy {
     pub fn adt(adt_def: AdtDef, substs: impl Into<List<GenericArg>>) -> BaseTy {
         BaseTy::Adt(adt_def, substs.into())
@@ -743,7 +710,6 @@ impl_internable!(
     [GenericArg],
     [Field],
     [Constraint],
-    [RefineArg],
     [InferMode],
 );
 
@@ -972,16 +938,6 @@ mod pretty {
         }
     }
 
-    impl Pretty for RefineArg {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            match self {
-                RefineArg::Expr(e) => w!("{:?}", e),
-                RefineArg::Abs(abs) => w!("{:?}", abs),
-            }
-        }
-    }
-
     impl Pretty for BaseTy {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
@@ -1047,7 +1003,6 @@ mod pretty {
         BaseTy,
         FnSig,
         GenericArg,
-        RefineArg,
         RefineArgs,
         VariantDef,
         PtrKind,
@@ -1139,16 +1094,12 @@ impl Defns {
         None
     }
 
-    fn expand_defn(defn: &Defn, args: List<Expr>) -> Expr {
-        let args = args
-            .iter()
-            .map(|e| RefineArg::Expr(e.clone()))
-            .collect_vec();
-        defn.expr.replace_bvars(&args)
+    fn expand_defn(defn: &Defn, args: &[Expr]) -> Expr {
+        defn.expr.replace_bvars(args)
     }
 
     // expand a particular app if there is a known defn for it
-    pub fn app(&self, func: &Symbol, args: List<Expr>) -> Expr {
+    pub fn app(&self, func: &Symbol, args: &[Expr]) -> Expr {
         if let Some(defn) = self.func_defn(func) {
             Self::expand_defn(defn, args)
         } else {

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -455,9 +455,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         let ty = self.check_operand(rcx, env, terminator_span, cond)?;
         let pred = if let TyKind::Indexed(BaseTy::Bool, idxs) = ty.kind() {
             if expected {
-                idxs.nth(0).expect_expr().clone()
+                idxs.nth(0).clone()
             } else {
-                idxs.nth(0).expect_expr().not()
+                idxs.nth(0).not()
             }
         } else {
             tracked_span_bug!("unexpected ty `{ty:?}`")
@@ -484,17 +484,13 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             match discr_ty.kind() {
                 TyKind::Indexed(BaseTy::Bool, idxs) => {
                     if bits == 0 {
-                        idxs.nth(0).expect_expr().not()
+                        idxs.nth(0).not()
                     } else {
-                        idxs.nth(0).expect_expr().clone()
+                        idxs.nth(0).clone()
                     }
                 }
                 TyKind::Indexed(bty @ (BaseTy::Int(_) | BaseTy::Uint(_)), idxs) => {
-                    Expr::binary_op(
-                        BinOp::Eq,
-                        idxs.nth(0).expect_expr().clone(),
-                        Expr::from_bits(bty, bits),
-                    )
+                    Expr::binary_op(BinOp::Eq, idxs.nth(0).clone(), Expr::from_bits(bty, bits))
                 }
                 _ => tracked_span_bug!("unexpected discr_ty {:?}", discr_ty),
             }
@@ -704,8 +700,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                 debug_assert_eq!(idxs2.args().len(), 1);
 
                 let sig = sigs::get_bin_op_sig(bin_op, bty1, bty2);
-                let (e1, e2) =
-                    (idxs1.nth(0).expect_expr().clone(), idxs2.nth(0).expect_expr().clone());
+                let (e1, e2) = (idxs1.nth(0).clone(), idxs2.nth(0).clone());
                 if let sigs::Pre::Some(reason, constr) = sig.pre {
                     self.constr_gen(rcx, source_span).check_pred(
                         rcx,
@@ -739,7 +734,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         let ty = match un_op {
             mir::UnOp::Not => {
                 if let Bool!(idxs) = ty.kind() {
-                    Ty::indexed(BaseTy::Bool, RefineArgs::one(idxs.nth(0).expect_expr().not()))
+                    Ty::indexed(BaseTy::Bool, RefineArgs::one(idxs.nth(0).not()))
                 } else {
                     tracked_span_bug!("incompatible type: `{:?}`", ty)
                 }
@@ -747,10 +742,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             mir::UnOp::Neg => {
                 match ty.kind() {
                     Int!(int_ty, idxs) => {
-                        Ty::indexed(
-                            BaseTy::Int(*int_ty),
-                            RefineArgs::one(idxs.nth(0).expect_expr().neg()),
-                        )
+                        Ty::indexed(BaseTy::Int(*int_ty), RefineArgs::one(idxs.nth(0).neg()))
                     }
                     Float!(float_ty) => Ty::float(*float_ty),
                     _ => tracked_span_bug!("incompatible type: `{:?}`", ty),
@@ -765,20 +757,16 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
         match kind {
             CastKind::IntToInt => {
                 match (from.kind(), to.kind()) {
-                    (Bool!(idxs), RustTy::Int(int_ty)) => {
-                        bool_int_cast(idxs.nth(0).expect_expr(), *int_ty)
-                    }
-                    (Bool!(idxs), RustTy::Uint(uint_ty)) => {
-                        bool_uint_cast(idxs.nth(0).expect_expr(), *uint_ty)
-                    }
+                    (Bool!(idxs), RustTy::Int(int_ty)) => bool_int_cast(idxs.nth(0), *int_ty),
+                    (Bool!(idxs), RustTy::Uint(uint_ty)) => bool_uint_cast(idxs.nth(0), *uint_ty),
                     (Int!(int_ty1, idxs), RustTy::Int(int_ty2)) => {
-                        int_int_cast(idxs.nth(0).expect_expr(), *int_ty1, *int_ty2)
+                        int_int_cast(idxs.nth(0), *int_ty1, *int_ty2)
                     }
                     (Uint!(uint_ty1, idxs), RustTy::Uint(uint_ty2)) => {
-                        uint_uint_cast(idxs.nth(0).expect_expr(), *uint_ty1, *uint_ty2)
+                        uint_uint_cast(idxs.nth(0), *uint_ty1, *uint_ty2)
                     }
                     (Uint!(uint_ty, idxs), RustTy::Int(int_ty)) => {
-                        uint_int_cast(idxs.nth(0).expect_expr(), *uint_ty, *int_ty)
+                        uint_int_cast(idxs.nth(0), *uint_ty, *int_ty)
                     }
                     (Int!(_, _), RustTy::Uint(uint_ty)) => Ty::uint(*uint_ty),
                     _ => {

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -315,7 +315,7 @@ where
                 })
             }
             rty::ExprKind::BoundVar(_) => {
-                span_bug!(self.def_span(), "unexpected free bound variable")
+                span_bug!(self.def_span(), "unexpected escaping variable")
             }
             _ => {
                 let fresh = self.fresh_name();
@@ -535,6 +535,7 @@ impl<'a> ExprCtxt<'a> {
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)
             | rty::ExprKind::BoundVar(_)
+            | rty::ExprKind::Abs(_)
             | rty::ExprKind::PathProj(..) => {
                 span_bug!(self.dbg_span, "unexpected expr: `{expr:?}`")
             }

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -9,7 +9,7 @@ use flux_middle::{
     intern::List,
     rty::{
         box_args, evars::EVarSol, fold::TypeFoldable, subst::FVarSubst, BaseTy, Binders, BoundVar,
-        Expr, ExprKind, GenericArg, Path, PtrKind, Ref, RefKind, RefineArg, RefineArgs, Ty, TyKind,
+        Expr, ExprKind, GenericArg, Path, PtrKind, Ref, RefKind, RefineArgs, Ty, TyKind,
     },
     rustc::mir::{BasicBlock, Local, Place, PlaceElem},
 };
@@ -243,7 +243,7 @@ impl TypeEnv {
             (TyKind::Indexed(bty1, idxs1), TyKind::Indexed(bty2, idxs2)) => {
                 self.infer_subst_for_bb_env_bty(bb_env, params, bty1, bty2, subst);
                 for (idx1, idx2) in iter::zip(idxs1.args(), idxs2.args()) {
-                    subst.infer_from_refine_args(params, idx1, idx2);
+                    subst.infer_from_exprs(params, idx1, idx2);
                 }
             }
             (TyKind::Ptr(pk1, path1), TyKind::Ptr(pk2, path2)) => {
@@ -609,7 +609,7 @@ impl TypeEnvInfer {
                             arg1.clone()
                         } else {
                             sorts.push(sort.clone());
-                            RefineArg::Expr(Expr::bvar(BoundVar::innermost(sorts.len() - 1)))
+                            Expr::bvar(BoundVar::innermost(sorts.len() - 1))
                         }
                     })
                     .collect();
@@ -688,10 +688,7 @@ impl TypeEnvInfer {
             .into_iter()
             .filter(|pred| !matches!(pred.kind(), ExprKind::Hole))
             .collect_vec();
-        let exprs = names
-            .iter()
-            .map(|name| RefineArg::Expr(Expr::fvar(*name)))
-            .collect_vec();
+        let exprs = names.iter().map(|name| Expr::fvar(*name)).collect_vec();
         let kvar = kvar_store
             .fresh(&sorts, self.scope.iter(), KVarEncoding::Conj)
             .replace_bvars(&exprs);


### PR DESCRIPTION
Remove syntactic restriction between `RefineArg` and `Expr` in rty. This makes the code a bit cleaner by unifying the treatment of abstractions and expressions. In preparation for refined type variables.