### PR TITLE
Decouple substitution from beta reduction

### DIFF
--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -512,10 +512,10 @@ impl Env<'_, '_> {
         }
     }
 
-    fn conv_func(&self, func: &fhir::Func) -> rty::Func {
+    fn conv_func(&self, func: &fhir::Func) -> rty::Expr {
         match func {
-            fhir::Func::Var(ident) => rty::Func::Var(self.lookup(*ident).expect_one().to_var()),
-            fhir::Func::Uif(sym, _) => rty::Func::Uif(*sym),
+            fhir::Func::Var(ident) => self.lookup(*ident).expect_one().to_expr(),
+            fhir::Func::Uif(sym, _) => rty::Expr::func(*sym),
         }
     }
 

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -486,7 +486,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         .into_iter()
                         .map(Expr::from)
                         .collect();
-                    let pred1 = Expr::app(var, args.clone());
+                    let pred1 = Expr::app(var.to_expr(), args.clone());
                     let pred2 = abs.replace_bvars(&args);
                     rcx.check_impl(&pred1, &pred2, self.tag);
                     rcx.check_impl(pred2, pred1, self.tag);

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -536,6 +536,7 @@ impl<'a> ExprCtxt<'a> {
             | rty::ExprKind::Local(_)
             | rty::ExprKind::BoundVar(_)
             | rty::ExprKind::Abs(_)
+            | rty::ExprKind::Func(_)
             | rty::ExprKind::PathProj(..) => {
                 span_bug!(self.dbg_span, "unexpected expr: `{expr:?}`")
             }
@@ -564,17 +565,17 @@ impl<'a> ExprCtxt<'a> {
         }
     }
 
-    fn func_to_fixpoint(&self, func: &rty::Func) -> fixpoint::Func {
-        match func {
-            rty::Func::Var(rty::Var::Free(name)) => {
+    fn func_to_fixpoint(&self, func: &rty::Expr) -> fixpoint::Func {
+        match func.kind() {
+            rty::ExprKind::FreeVar(name) => {
                 let name = self.name_map.get(name).unwrap_or_else(|| {
                     span_bug!(self.dbg_span, "no entry found for key: `{name:?}`")
                 });
                 fixpoint::Func::Var(*name)
             }
-            rty::Func::Uif(func) => fixpoint::Func::Uif(func.to_string()),
-            rty::Func::Var(var) => {
-                span_bug!(self.dbg_span, "unexpected var `{var:?}` in function application")
+            rty::ExprKind::Func(name) => fixpoint::Func::Uif(name.to_string()),
+            _ => {
+                span_bug!(self.dbg_span, "unexpected expr `{func:?}` in function position")
             }
         }
     }


### PR DESCRIPTION
Apply beta reduction of lambda abstractions as an additional step after substitution.