### PR TITLE
Uniformly abstract over a single sort in rty

### DIFF
--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -28,7 +28,7 @@ pub enum Sort {
 
 #[derive(Clone, Hash)]
 pub struct FuncSort {
-    pub inputs_and_output: Vec<Sort>,
+    inputs_and_output: Vec<Sort>,
 }
 
 #[derive(Hash)]
@@ -196,7 +196,8 @@ impl Pred {
 }
 
 impl FuncSort {
-    pub fn new(mut inputs: Vec<Sort>, output: Sort) -> FuncSort {
+    pub fn new(inputs: impl IntoIterator<Item = Sort>, output: Sort) -> FuncSort {
+        let mut inputs = inputs.into_iter().collect_vec();
         inputs.push(output);
         FuncSort { inputs_and_output: inputs }
     }

--- a/flux-middle/src/rty/conv.rs
+++ b/flux-middle/src/rty/conv.rs
@@ -466,7 +466,7 @@ impl Env<'_, '_> {
             }
             fhir::ExprKind::UnaryOp(op, e) => rty::Expr::unary_op(*op, self.conv_expr(e)),
             fhir::ExprKind::App(func, args) => {
-                rty::Expr::app(self.conv_func(func), self.conv_exprs(args))
+                rty::Expr::app(self.conv_func(func), rty::Expr::tuple(self.conv_exprs(args)))
             }
             fhir::ExprKind::IfThenElse(box [p, e1, e2]) => {
                 rty::Expr::ite(self.conv_expr(p), self.conv_expr(e1), self.conv_expr(e2))
@@ -700,9 +700,10 @@ fn conv_sort(early_cx: &EarlyCtxt, sort: &fhir::Sort) -> rty::Sort {
 }
 
 fn conv_func_sort(early_cx: &EarlyCtxt, fsort: &fhir::FuncSort) -> rty::FuncSort {
-    rty::FuncSort {
-        inputs_and_output: List::from_vec(conv_sorts(early_cx, fsort.inputs_and_output.iter())),
-    }
+    rty::FuncSort::new(
+        rty::Sort::tuple(conv_sorts(early_cx, fsort.inputs())),
+        conv_sort(early_cx, fsort.output()),
+    )
 }
 
 fn conv_lit(lit: fhir::Lit) -> rty::Constant {

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -496,7 +496,7 @@ impl TypeFoldable for Expr {
                 Expr::tuple(exprs.iter().map(|e| e.fold_with(folder)).collect_vec())
             }
             ExprKind::PathProj(e, field) => Expr::path_proj(e.fold_with(folder), *field),
-            ExprKind::App(func, args) => Expr::app(func.fold_with(folder), args.fold_with(folder)),
+            ExprKind::App(func, arg) => Expr::app(func.fold_with(folder), arg.fold_with(folder)),
             ExprKind::IfThenElse(p, e1, e2) => {
                 Expr::ite(p.fold_with(folder), e1.fold_with(folder), e2.fold_with(folder))
             }
@@ -522,11 +522,9 @@ impl TypeFoldable for Expr {
             ExprKind::PathProj(e, _) | ExprKind::UnaryOp(_, e) | ExprKind::TupleProj(e, _) => {
                 e.visit_with(visitor);
             }
-            ExprKind::App(func, args) => {
+            ExprKind::App(func, arg) => {
                 func.visit_with(visitor);
-                for e in args {
-                    e.visit_with(visitor);
-                }
+                arg.visit_with(visitor);
             }
             ExprKind::IfThenElse(p, e1, e2) => {
                 p.visit_with(visitor);

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -907,7 +907,7 @@ mod pretty {
     impl Pretty for FuncSort {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("({:?}) -> {:?}", self.input(), self.output())
+            w!("{:?} -> {:?}", self.input(), self.output())
         }
     }
 

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -48,7 +48,7 @@ pub enum Sort {
 
 #[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct FuncSort {
-    pub inputs_and_output: List<Sort>,
+    input_and_output: List<Sort>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
@@ -242,6 +242,14 @@ impl Sort {
         }
     }
 
+    pub fn as_tuple(&self) -> &[Sort] {
+        if let Sort::Tuple(sorts) = self {
+            sorts
+        } else {
+            slice::from_ref(self)
+        }
+    }
+
     pub(crate) fn is_unit(&self) -> bool {
         matches!(self, Sort::Tuple(sorts) if sorts.is_empty())
     }
@@ -282,12 +290,16 @@ impl Sort {
 }
 
 impl FuncSort {
-    pub fn inputs(&self) -> &[Sort] {
-        &self.inputs_and_output[..self.inputs_and_output.len() - 1]
+    pub(crate) fn new(input: Sort, output: Sort) -> Self {
+        FuncSort { input_and_output: List::from_vec(vec![input, output]) }
     }
 
-    fn output(&self) -> &Sort {
-        &self.inputs_and_output[self.inputs_and_output.len() - 1]
+    pub fn input(&self) -> &Sort {
+        &self.input_and_output[0]
+    }
+
+    pub fn output(&self) -> &Sort {
+        &self.input_and_output[1]
     }
 }
 
@@ -895,7 +907,7 @@ mod pretty {
     impl Pretty for FuncSort {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("({:?}) -> {:?}", join!(", ", self.inputs()), self.output())
+            w!("({:?}) -> {:?}", self.input(), self.output())
         }
     }
 

--- a/flux-middle/src/rty/normalize.rs
+++ b/flux-middle/src/rty/normalize.rs
@@ -107,13 +107,13 @@ impl<'a> Normalizer<'a> {
         Self { defs }
     }
 
-    fn app(&self, func: &Expr, args: &[Expr]) -> Expr {
+    fn app(&self, func: &Expr, arg: &Expr) -> Expr {
         match func.kind() {
             ExprKind::Func(sym) if let Some(defn) = self.defs.func_defn(sym) => {
-                defn.expr.replace_bvar(&Expr::tuple(args))
+                defn.expr.replace_bvar(arg)
             }
-            ExprKind::Abs(body) => body.replace_bvar(&Expr::tuple(args)),
-            _ => Expr::app(func.clone(), args),
+            ExprKind::Abs(body) => body.replace_bvar(arg),
+            _ => Expr::app(func.clone(), arg),
         }
     }
 
@@ -130,7 +130,7 @@ impl TypeFolder for Normalizer<'_> {
     fn fold_expr(&mut self, expr: &Expr) -> Expr {
         let expr = expr.super_fold_with(self);
         match expr.kind() {
-            ExprKind::App(func, args) => self.app(func, args),
+            ExprKind::App(func, arg) => self.app(func, arg),
             ExprKind::TupleProj(tup, proj) => self.tuple_proj(tup, *proj),
             _ => expr,
         }

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -495,14 +495,11 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
     }
 }
 
-fn func_sort_to_fixpoint(sort: &rty::FuncSort) -> fixpoint::FuncSort {
-    fixpoint::FuncSort {
-        inputs_and_output: sort
-            .inputs_and_output
-            .iter()
-            .map(sort_to_fixpoint)
-            .collect(),
-    }
+fn func_sort_to_fixpoint(fsort: &rty::FuncSort) -> fixpoint::FuncSort {
+    fixpoint::FuncSort::new(
+        fsort.input().as_tuple().iter().map(sort_to_fixpoint),
+        sort_to_fixpoint(fsort.output()),
+    )
 }
 
 fn uif_def_to_fixpoint(uif_def: &rty::UifDef) -> fixpoint::UifDef {
@@ -542,9 +539,9 @@ impl<'a> ExprCtxt<'a> {
             }
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
             rty::ExprKind::ConstDefId(did) => fixpoint::Expr::Var(self.const_map[did].name),
-            rty::ExprKind::App(func, args) => {
+            rty::ExprKind::App(func, arg) => {
                 let func = self.func_to_fixpoint(func);
-                let args = self.exprs_to_fixpoint(args);
+                let args = self.exprs_to_fixpoint(arg.as_tuple());
                 fixpoint::Expr::App(func, args)
             }
             rty::ExprKind::IfThenElse(p, e1, e2) => {


### PR DESCRIPTION
Make functions/abstractions have a single argument (which can be a tuple) in rty.