### PR TITLE
Refactor RefineTree

### DIFF
--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -351,9 +351,6 @@ impl From<Ty> for BtyOrTy {
 }
 
 impl BaseTy {
-    /// Returns `true` if the base ty is [`Bool`].
-    ///
-    /// [`Bool`]: BaseTy::Bool
     pub fn is_bool(&self) -> bool {
         matches!(self, Self::Path(Path { res: Res::Bool, .. }))
     }

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -8,7 +8,8 @@ use super::{
 use crate::rty::*;
 
 /// A substitution for [free variables]
-/// [free variables]: `crate::rty::expr::ExprKind::FreeVar`
+///
+/// [free variables]: `crate::rty::ExprKind::FreeVar`
 #[derive(Debug)]
 pub struct FVarSubst {
     fvar_map: FxHashMap<Name, Expr>,
@@ -86,7 +87,7 @@ impl TypeFolder for FVarSubstFolder<'_> {
 
 /// Substitution for [bound variables]
 ///
-/// [bound variables]: `crate::rty::expr::ExprKind::BoundVar`
+/// [bound variables]: `crate::rty::ExprKind::BoundVar`
 pub(super) struct BVarSubstFolder<'a> {
     current_index: DebruijnIndex,
     expr: &'a Expr,
@@ -120,7 +121,7 @@ impl TypeFolder for BVarSubstFolder<'_> {
 
 /// Substitution for [existential variables]
 ///
-/// [existential variables]: `crate::rty::expr::ExprKind::EVar`
+/// [existential variables]: `crate::rty::ExprKind::EVar`
 pub(super) struct EVarSubstFolder<'a> {
     evars: &'a EVarSol,
 }

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -74,17 +74,28 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         ConstrGen { genv, kvar_gen: Box::new(kvar_gen), span }
     }
 
-    pub fn check_pred(&self, rcx: &mut RefineCtxt, pred: impl Into<Expr>, reason: ConstrReason) {
+    pub(crate) fn check_pred(
+        &self,
+        rcx: &mut RefineCtxt,
+        pred: impl Into<Expr>,
+        reason: ConstrReason,
+    ) {
         rcx.check_pred(pred, Tag::new(reason, self.span));
     }
 
-    pub fn subtyping(&mut self, rcx: &mut RefineCtxt, ty1: &Ty, ty2: &Ty, reason: ConstrReason) {
+    pub(crate) fn subtyping(
+        &mut self,
+        rcx: &mut RefineCtxt,
+        ty1: &Ty,
+        ty2: &Ty,
+        reason: ConstrReason,
+    ) {
         let mut infcx = self.infcx(rcx, reason);
         infcx.subtyping(rcx, ty1, ty2);
         rcx.replace_evars(&infcx.solve().unwrap());
     }
 
-    pub fn check_fn_call(
+    pub(crate) fn check_fn_call(
         &mut self,
         rcx: &mut RefineCtxt,
         env: &mut TypeEnv,
@@ -166,7 +177,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         Ok(output)
     }
 
-    pub fn check_ret(
+    pub(crate) fn check_ret(
         &mut self,
         rcx: &mut RefineCtxt,
         env: &mut TypeEnv,
@@ -192,7 +203,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         Ok(())
     }
 
-    pub fn check_constructor(
+    pub(crate) fn check_constructor(
         &mut self,
         rcx: &mut RefineCtxt,
         variant: &PolyVariant,
@@ -226,7 +237,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         Ok(variant.ret.replace_evars(&evars_sol))
     }
 
-    pub fn check_mk_array(
+    pub(crate) fn check_mk_array(
         &mut self,
         rcx: &mut RefineCtxt,
         env: &mut TypeEnv,
@@ -331,7 +342,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         env: &mut TypeEnv,
         constraint: &Constraint,
     ) -> Result<(), OpaqueStructErr> {
-        let rcx = &mut rcx.breadcrumb();
+        let rcx = &mut rcx.branch();
         match constraint {
             Constraint::Type(path, ty) => self.check_type_constr(rcx, env, path, ty),
             Constraint::Pred(e) => {
@@ -342,7 +353,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     fn subtyping(&mut self, rcx: &mut RefineCtxt, ty1: &Ty, ty2: &Ty) {
-        let rcx = &mut rcx.breadcrumb();
+        let rcx = &mut rcx.branch();
 
         match (ty1.kind(), ty2.kind()) {
             (TyKind::Exists(ty1), _) => {

--- a/flux-refineck/src/lib.rs
+++ b/flux-refineck/src/lib.rs
@@ -41,6 +41,8 @@ use itertools::Itertools;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 
+use crate::refine_tree::RefineTree;
+
 pub fn check_fn<'tcx>(
     genv: &GlobalEnv<'_, 'tcx>,
     cache: &mut QueryCache,
@@ -53,8 +55,9 @@ pub fn check_fn<'tcx>(
         tracing::info!("Checker::infer");
 
         let mut kvars = fixpoint::KVarStore::new();
-        let mut refine_tree =
-            Checker::check(genv, body, def_id, &mut kvars, bb_envs).emit(genv.sess)?;
+        let mut refine_tree = RefineTree::new();
+        Checker::check(genv, body, def_id, refine_tree.as_subtree(), &mut kvars, bb_envs)
+            .emit(genv.sess)?;
 
         tracing::info!("Checker::check");
 

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -62,7 +62,7 @@ impl TypeEnv {
             .insert(local.into(), Ty::uninit(), LocKind::Local);
     }
 
-    pub fn into_infer(
+    pub(crate) fn into_infer(
         self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -71,7 +71,7 @@ impl TypeEnv {
         TypeEnvInfer::new(rcx, gen, scope, self)
     }
 
-    pub fn lookup_place(
+    pub(crate) fn lookup_place(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -84,7 +84,7 @@ impl TypeEnv {
             .ty())
     }
 
-    pub fn lookup_path(
+    pub(crate) fn lookup_path(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -101,7 +101,7 @@ impl TypeEnv {
         self.bindings.update(path, new_ty);
     }
 
-    pub fn borrow(
+    pub(crate) fn borrow(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -123,7 +123,7 @@ impl TypeEnv {
         Ok(ty)
     }
 
-    pub fn write_place(
+    pub(crate) fn write_place(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -149,7 +149,7 @@ impl TypeEnv {
         Ok(())
     }
 
-    pub fn move_place(
+    pub(crate) fn move_place(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -178,7 +178,7 @@ impl TypeEnv {
         }
     }
 
-    pub fn unpack(&mut self, rcx: &mut RefineCtxt) {
+    pub(crate) fn unpack(&mut self, rcx: &mut RefineCtxt) {
         self.bindings.fmap_mut(|binding| {
             match binding {
                 Binding::Owned(ty) => Binding::Owned(rcx.unpack(ty)),
@@ -187,7 +187,7 @@ impl TypeEnv {
         });
     }
 
-    pub fn block_with(
+    pub(crate) fn block_with(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -200,7 +200,7 @@ impl TypeEnv {
             .block_with(rcx, gen, updated)
     }
 
-    pub fn block(&mut self, rcx: &mut RefineCtxt, gen: &mut ConstrGen, path: &Path) -> Ty {
+    pub(crate) fn block(&mut self, rcx: &mut RefineCtxt, gen: &mut ConstrGen, path: &Path) -> Ty {
         self.bindings
             .lookup(gen.genv, rcx, path)
             .unwrap_or_else(|err| tracked_span_bug!("{:?}", err))
@@ -285,7 +285,7 @@ impl TypeEnv {
         }
     }
 
-    pub fn check_goto(
+    pub(crate) fn check_goto(
         mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -353,7 +353,7 @@ impl TypeEnv {
         Ok(())
     }
 
-    pub fn downcast(
+    pub(crate) fn downcast(
         &mut self,
         genv: &GlobalEnv,
         rcx: &mut RefineCtxt,
@@ -464,7 +464,7 @@ impl TypeEnvInfer {
             .block(rcx, gen)
     }
 
-    pub fn block_with(
+    pub(crate) fn block_with(
         &mut self,
         rcx: &mut RefineCtxt,
         gen: &mut ConstrGen,
@@ -769,7 +769,7 @@ impl Generalizer {
 }
 
 impl BasicBlockEnv {
-    pub fn enter(&self, rcx: &mut RefineCtxt) -> TypeEnv {
+    pub(crate) fn enter(&self, rcx: &mut RefineCtxt) -> TypeEnv {
         let mut subst = FVarSubst::empty();
         for (name, sort) in &self.params {
             let fresh = rcx.define_var(sort);
@@ -782,7 +782,7 @@ impl BasicBlockEnv {
         TypeEnv { bindings }
     }
 
-    pub fn scope(&self) -> &Scope {
+    pub(crate) fn scope(&self) -> &Scope {
         &self.scope
     }
 }

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -754,7 +754,7 @@ impl Binding {
         }
     }
 
-    pub fn unblock(&mut self, rcx: &mut RefineCtxt) -> Ty {
+    pub(crate) fn unblock(&mut self, rcx: &mut RefineCtxt) -> Ty {
         match self {
             Binding::Owned(ty) => ty.clone(),
             Binding::Blocked(ty) => {


### PR DESCRIPTION
Define a `RefineSubtree` struct and expose it to the `Checker` instead of the entire `RefineTree`. This will be needed when we implement closures to be able to share the same `RefineTree` between functions. It will also be useful for debugging because sometimes is useful to print the subtree associated with a `RefineCtxt` to understand what's going on.