### PR TITLE
Separate namespaces for constants and uifs

### DIFF
--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -55,7 +55,7 @@ pub enum Expr {
 #[derive(Hash)]
 pub enum Func {
     Var(Name),
-    Uif(String),
+    Uif(ConstName),
 }
 
 #[derive(Clone, Copy, Hash)]
@@ -72,17 +72,6 @@ pub struct Qualifier {
     pub global: bool,
 }
 
-#[derive(Hash)]
-pub struct UifDef {
-    pub name: String,
-    pub sort: FuncSort,
-}
-
-impl UifDef {
-    pub fn new(name: String, sort: FuncSort) -> Self {
-        UifDef { name, sort }
-    }
-}
 #[derive(Clone, Copy, Debug)]
 pub struct Const {
     pub name: ConstName,
@@ -377,7 +366,7 @@ impl fmt::Display for Func {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Func::Var(name) => write!(f, "{name:?}"),
-            Func::Uif(uif) => write!(f, "uif_{uif}"),
+            Func::Uif(uif) => write!(f, "{uif:?}"),
         }
     }
 }

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -41,6 +41,7 @@ pub enum Pred {
 #[derive(Hash)]
 pub enum Expr {
     Var(Name),
+    ConstDefId(Name),
     Constant(Constant),
     BinaryOp(BinOp, Box<[Expr; 2]>),
     App(Func, Vec<Expr>),
@@ -340,6 +341,7 @@ impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Var(x) => write!(f, "{x:?}"),
+            Expr::ConstDefId(x) => write!(f, "$c{x:?}"),
             Expr::Constant(c) => write!(f, "{c}"),
             Expr::BinaryOp(op, box [e1, e2]) => {
                 write!(f, "{} {op} {}", FmtParens(e1), FmtParens(e2))?;

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -377,7 +377,7 @@ impl fmt::Display for Func {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Func::Var(name) => write!(f, "{name:?}"),
-            Func::Uif(uif) => write!(f, "{uif}"),
+            Func::Uif(uif) => write!(f, "uif_{uif}"),
         }
     }
 }

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -41,7 +41,7 @@ pub enum Pred {
 #[derive(Hash)]
 pub enum Expr {
     Var(Name),
-    ConstDefId(Name),
+    ConstVar(ConstName),
     Constant(Constant),
     BinaryOp(BinOp, Box<[Expr; 2]>),
     App(Func, Vec<Expr>),
@@ -85,7 +85,7 @@ impl UifDef {
 }
 #[derive(Clone, Copy, Debug)]
 pub struct Const {
-    pub name: Name,
+    pub name: ConstName,
     pub val: i128,
 }
 
@@ -139,6 +139,11 @@ newtype_index! {
         const NAME1 = 1;
         const NAME2 = 2;
     }
+}
+
+newtype_index! {
+    #[debug_format = "c{}"]
+    pub struct ConstName {}
 }
 
 impl<Tag> Constraint<Tag> {
@@ -341,7 +346,7 @@ impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Var(x) => write!(f, "{x:?}"),
-            Expr::ConstDefId(x) => write!(f, "$c{x:?}"),
+            Expr::ConstVar(x) => write!(f, "{x:?}"),
             Expr::Constant(c) => write!(f, "{c}"),
             Expr::BinaryOp(op, box [e1, e2]) => {
                 write!(f, "{} {op} {}", FmtParens(e1), FmtParens(e2))?;
@@ -674,5 +679,11 @@ impl From<i128> for Expr {
 impl From<Name> for Expr {
     fn from(n: Name) -> Self {
         Expr::Var(n)
+    }
+}
+
+impl From<ConstName> for Expr {
+    fn from(c_n: ConstName) -> Self {
+        Expr::ConstVar(c_n)
     }
 }

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, ConstName, Pred, Proj,
+    BinOp, Const, ConstName, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, Pred, Proj,
     Qualifier, Sign, Sort, UifDef, UnOp,
 };
 use flux_common::{cache::QueryCache, format::PadAdapter};

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -167,7 +167,7 @@ impl<Tag: fmt::Display> fmt::Display for Task<Tag> {
         writeln!(f, "(data Unit 0 = [| Unit {{ }}])")?;
 
         for (name, sort) in &self.constants {
-            write!(f, "(constant {name:?} {sort:?})")?;
+            write!(f, "(constant $c{name:?} {sort:?})")?;
         }
         for uif_def in &self.uifs {
             writeln!(f, "{uif_def}")?;

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -172,7 +172,7 @@ impl<Tag: fmt::Display> fmt::Display for Task<Tag> {
         writeln!(f, "(data Unit 0 = [| Unit {{ }}])")?;
 
         for cinfo in &self.constants {
-            write!(f, "{cinfo}")?;
+            writeln!(f, "{cinfo}")?;
         }
 
         for kvar in &self.kvars {

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, Pred, Proj, Qualifier,
-    Sign, Sort, UifDef, UnOp,
+    BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, KVid, Name, ConstName, Pred, Proj,
+    Qualifier, Sign, Sort, UifDef, UnOp,
 };
 use flux_common::{cache::QueryCache, format::PadAdapter};
 use flux_config as config;
@@ -28,7 +28,7 @@ use crate::constraint::DEFAULT_QUALIFIERS;
 
 pub struct Task<Tag> {
     pub comments: Vec<String>,
-    pub constants: Vec<(Name, Sort)>,
+    pub constants: Vec<(ConstName, Sort)>,
     pub kvars: Vec<KVar>,
     pub constraint: Constraint<Tag>,
     pub qualifiers: Vec<Qualifier>,
@@ -83,7 +83,7 @@ pub struct KVar {
 impl<Tag: fmt::Display + FromStr> Task<Tag> {
     pub fn new(
         comments: Vec<String>,
-        constants: Vec<(Name, Sort)>,
+        constants: Vec<(ConstName, Sort)>,
         kvars: Vec<KVar>,
         constraint: Constraint<Tag>,
         qualifiers: Vec<Qualifier>,
@@ -167,7 +167,7 @@ impl<Tag: fmt::Display> fmt::Display for Task<Tag> {
         writeln!(f, "(data Unit 0 = [| Unit {{ }}])")?;
 
         for (name, sort) in &self.constants {
-            write!(f, "(constant $c{name:?} {sort:?})")?;
+            write!(f, "(constant {name:?} {sort:?})")?;
         }
         for uif_def in &self.uifs {
             writeln!(f, "{uif_def}")?;

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -202,7 +202,7 @@ impl fmt::Display for KVar {
 
 impl fmt::Display for ConstInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(constant {0:?} {1:?})", self.name, self.sort)
+        write!(f, "(constant {:?} {:?}) // orig: {}", self.name, self.sort, self.orig)
     }
 }
 

--- a/flux-fixpoint/src/lib.rs
+++ b/flux-fixpoint/src/lib.rs
@@ -200,7 +200,7 @@ impl fmt::Display for KVar {
 
 impl fmt::Display for UifDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(constant {} {})", self.name, self.sort)
+        write!(f, "(constant uif_{} {})", self.name, self.sort)
     }
 }
 

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -14,7 +14,7 @@ use flux_middle::{
     global_env::GlobalEnv,
     rty::{self, Binder, Constant, INNERMOST},
 };
-use itertools::Itertools;
+use itertools::{Itertools, chain};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
@@ -56,7 +56,13 @@ pub trait KVarGen {
 
 type NameMap = FxHashMap<rty::Name, fixpoint::Name>;
 type KVidMap = FxHashMap<rty::KVid, Vec<fixpoint::KVid>>;
-type ConstMap = FxIndexMap<DefId, ConstInfo>;
+type ConstMap = FxIndexMap<Key, ConstInfo>;
+
+#[derive(Eq, Hash, PartialEq)]
+enum Key {
+    Uif(rustc_span::Symbol),
+    Const(DefId),
+}
 
 pub struct FixpointCtxt<'genv, 'tcx, T> {
     comments: Vec<String>,
@@ -86,10 +92,12 @@ struct ExprCtxt<'a> {
     dbg_span: Span,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct ConstInfo {
     name: fixpoint::ConstName,
-    val: Constant,
+    sym: rustc_span::Symbol,
+    sort: fixpoint::Sort,
+    val: Option<Constant>,
 }
 
 impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
@@ -133,11 +141,11 @@ where
 
     fn assume_const_val(
         cstr: fixpoint::Constraint<TagIdx>,
-        const_info: &ConstInfo,
+        const_name: fixpoint::ConstName,
+        const_val: Constant,
     ) -> fixpoint::Constraint<TagIdx> {
-        let name = const_info.name;
-        let e1 = fixpoint::Expr::from(name);
-        let e2 = fixpoint::Expr::Constant(const_info.val);
+        let e1 = fixpoint::Expr::from(const_name);
+        let e2 = fixpoint::Expr::Constant(const_val);
         let pred = fixpoint::Pred::Expr(e1.eq(e2));
         fixpoint::Constraint::Guard(pred, Box::new(cstr))
     }
@@ -163,7 +171,9 @@ where
 
         let mut closed_constraint = constraint;
         for const_info in self.const_map.values() {
-            closed_constraint = Self::assume_const_val(closed_constraint, const_info);
+            if let Some(val) = const_info.val {
+                closed_constraint = Self::assume_const_val(closed_constraint, const_info.name, val);
+            }
         }
 
         let qualifiers = self
@@ -175,10 +185,13 @@ where
         let constants = self
             .const_map
             .values()
-            .map(|const_info| (const_info.name, fixpoint::Sort::Int))
+            .map(|const_info|
+                 fixpoint::ConstInfo{
+                     name: const_info.name,
+                     orig: const_info.sym,
+                     sort: const_info.sort.clone()
+                 })
             .collect();
-
-        let uifs = self.genv.uifs().map(uif_def_to_fixpoint).collect_vec();
 
         let sorts = self
             .genv
@@ -193,7 +206,6 @@ where
             kvars,
             closed_constraint,
             qualifiers,
-            uifs,
             sorts,
         );
         if config::dump_constraint() {
@@ -390,16 +402,23 @@ impl<'a> KVarGen for Box<dyn KVarGen + 'a> {
 fn fixpoint_const_map(
     genv: &GlobalEnv,
     const_name_gen: &IndexGen<fixpoint::ConstName>,
-) -> FxIndexMap<DefId, ConstInfo> {
-    genv.map()
+) -> FxIndexMap<Key, ConstInfo> {
+    let consts = genv.map()
         .consts()
         .sorted_by(|a, b| Ord::cmp(&a.sym, &b.sym))
         .map(|const_info| {
             let name = const_name_gen.fresh();
-            let cinfo = ConstInfo { name, val: const_info.val };
-            (const_info.def_id, cinfo)
-        })
-        .collect()
+            let cinfo = ConstInfo { name, sym: const_info.sym, sort: fixpoint::Sort::Int, val: Some(const_info.val) };
+            (Key::Const(const_info.def_id), cinfo)
+        });
+    let uifs = genv.uifs()
+        .map(|uif_def| {
+            let name = const_name_gen.fresh();
+            let sort = func_sort_to_fixpoint(&uif_def.sort);
+            let cinfo = ConstInfo {name, sym: uif_def.name, sort: fixpoint::Sort::Func(sort), val: None };
+            (Key::Uif(cinfo.sym), cinfo)
+        });
+    chain(consts, uifs).collect()
 }
 
 impl KVarDecl {
@@ -503,11 +522,6 @@ fn func_sort_to_fixpoint(fsort: &rty::FuncSort) -> fixpoint::FuncSort {
     )
 }
 
-fn uif_def_to_fixpoint(uif_def: &rty::UifDef) -> fixpoint::UifDef {
-    let sort = func_sort_to_fixpoint(&uif_def.sort);
-    fixpoint::UifDef::new(uif_def.name.to_string(), sort)
-}
-
 impl<'a> ExprCtxt<'a> {
     fn new(name_map: &'a NameMap, const_map: &'a ConstMap, dbg_span: Span) -> Self {
         Self { name_map, const_map, dbg_span }
@@ -517,7 +531,7 @@ impl<'a> ExprCtxt<'a> {
         match expr.kind() {
             rty::ExprKind::FreeVar(name) => {
                 let name = self.name_map.get(name).unwrap_or_else(|| {
-                    span_bug!(self.dbg_span, "no entry found for key: `{name:?}`")
+                    span_bug!(self.dbg_span, "no entry found in name_map for name: `{name:?}`")
                 });
                 fixpoint::Expr::Var(*name)
             }
@@ -539,7 +553,12 @@ impl<'a> ExprCtxt<'a> {
                     })
             }
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
-            rty::ExprKind::ConstDefId(did) => fixpoint::Expr::ConstVar(self.const_map[did].name),
+            rty::ExprKind::ConstDefId(did) => {
+                let const_info = self.const_map.get(&Key::Const(did.clone())).unwrap_or_else(||{
+                    span_bug!(self.dbg_span, "no entry found in const_map for def_id: `{did:?}`")
+                });
+                fixpoint::Expr::ConstVar(const_info.name)
+            }
             rty::ExprKind::App(func, args) => {
                 let func = self.func_to_fixpoint(func);
                 let args = self.exprs_to_fixpoint(args.as_tuple());
@@ -591,11 +610,16 @@ impl<'a> ExprCtxt<'a> {
         match func.kind() {
             rty::ExprKind::FreeVar(name) => {
                 let name = self.name_map.get(name).unwrap_or_else(|| {
-                    span_bug!(self.dbg_span, "no entry found for key: `{name:?}`")
+                    span_bug!(self.dbg_span, "no name found for key: `{name:?}`")
                 });
                 fixpoint::Func::Var(*name)
             }
-            rty::ExprKind::Func(name) => fixpoint::Func::Uif(name.to_string()),
+            rty::ExprKind::Func(name) => {
+                let cinfo = self.const_map.get(&Key::Uif(name.clone())).unwrap_or_else(|| {
+                    span_bug!(self.dbg_span, "no const found for key: `{name:?}`")
+                });
+                fixpoint::Func::Uif(cinfo.name)
+            }
             _ => {
                 span_bug!(self.dbg_span, "unexpected expr `{func:?}` in function position")
             }

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -538,8 +538,8 @@ impl<'a> ExprCtxt<'a> {
                     })
             }
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
-            rty::ExprKind::ConstDefId(did) => fixpoint::Expr::Var(self.const_map[did].name),
-            rty::ExprKind::App(func, arg) => {
+            rty::ExprKind::ConstDefId(did) => fixpoint::Expr::ConstDefId(self.const_map[did].name),
+            rty::ExprKind::App(func, args) => {
                 let func = self.func_to_fixpoint(func);
                 let args = self.exprs_to_fixpoint(arg.as_tuple());
                 fixpoint::Expr::App(func, args)

--- a/flux-refineck/src/fixpoint.rs
+++ b/flux-refineck/src/fixpoint.rs
@@ -542,7 +542,7 @@ impl<'a> ExprCtxt<'a> {
             rty::ExprKind::ConstDefId(did) => fixpoint::Expr::ConstVar(self.const_map[did].name),
             rty::ExprKind::App(func, args) => {
                 let func = self.func_to_fixpoint(func);
-                let args = self.exprs_to_fixpoint(arg.as_tuple());
+                let args = self.exprs_to_fixpoint(args.as_tuple());
                 fixpoint::Expr::App(func, args)
             }
             rty::ExprKind::IfThenElse(p, e1, e2) => {


### PR DESCRIPTION
# Before

* Uif: `c{n}`
* Constant: `a{n}`
* Variable: `a{n}`

# After

* Uifs: `c{n}`
* Constant: `c{n}`
* Variable `a{n}`