### PR TITLE
Do not generate kvars for types refined by unit in function calls

### DIFF
--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -14,7 +14,13 @@ pub use crate::rustc::lowering::UnsupportedFnSig;
 use crate::{
     early_ctxt::EarlyCtxt,
     fhir::{self, VariantIdx},
-    rty::{self, fold::TypeFoldable, normalize::Defns, refining, Binder},
+    rty::{
+        self,
+        fold::TypeFoldable,
+        normalize::Defns,
+        refining::{self, Refiner},
+        Binder,
+    },
     rustc,
 };
 
@@ -178,7 +184,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                     fn_sig
                 } else {
                     let fn_sig = rustc::lowering::lower_fn_sig_of(self.tcx, def_id)?.skip_binder();
-                    refining::refine_fn_sig(self, &self.generics_of(def_id), &fn_sig, rty::Expr::tt)
+                    Refiner::default(self, &self.generics_of(def_id)).refine_fn_sig(&fn_sig)
                 };
                 Ok(entry.insert(fn_sig).clone())
             }
@@ -245,7 +251,8 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                                     variant_def,
                                 )
                                 .unwrap_or_else(|_| FatalError.raise());
-                                refining::refine_variant_def(self, def_id, &variant_def)
+                                Refiner::default(self, &self.generics_of(def_id))
+                                    .refine_variant_def(&variant_def)
                             })
                             .collect(),
                     )
@@ -281,12 +288,12 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.early_cx.early_bound_sorts_of(def_id)
     }
 
-    pub fn refine_with_true(&self, generics: &rty::Generics, rustc_ty: &rustc::ty::Ty) -> rty::Ty {
-        refining::refine_ty(self, generics, rustc_ty, rty::Expr::tt)
+    pub fn refine_default(&self, generics: &rty::Generics, rustc_ty: &rustc::ty::Ty) -> rty::Ty {
+        Refiner::default(self, generics).refine_ty(rustc_ty)
     }
 
     pub fn refine_with_holes(&self, generics: &rty::Generics, rustc_ty: &rustc::ty::Ty) -> rty::Ty {
-        refining::refine_ty(self, generics, rustc_ty, rty::Expr::hole)
+        Refiner::with_holes(self, generics).refine_ty(rustc_ty)
     }
 
     pub fn instantiate_generic_arg(
@@ -295,7 +302,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         param: &rty::GenericParamDef,
         arg: &rustc::ty::GenericArg,
     ) -> rty::GenericArg {
-        refining::refine_generic_arg(self, generics, param, arg, rty::Expr::hole)
+        Refiner::with_holes(self, generics).refine_generic_arg(param, arg)
     }
 
     pub fn type_of(&self, def_id: DefId) -> Binder<rty::Ty> {
@@ -324,7 +331,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                 .cloned()
                 .unwrap_or_else(|| {
                     let rustc_ty = self.lower_type_of(def_id);
-                    let ty = self.refine_with_true(&self.generics_of(def_id), &rustc_ty);
+                    let ty = self.refine_default(&self.generics_of(def_id), &rustc_ty);
                     Binder::new(ty, rty::Sort::unit())
                 })
         }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -296,7 +296,24 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         Refiner::with_holes(self, generics).refine_ty(rustc_ty)
     }
 
-    pub fn instantiate_generic_arg(
+    pub fn instantiate_arg_for_fun(
+        &self,
+        generics: &rty::Generics,
+        param: &rty::GenericParamDef,
+        arg: &rustc::ty::GenericArg,
+    ) -> rty::GenericArg {
+        Refiner::new(self, generics, |bty| {
+            let sort = bty.sort();
+            let mut ty = rty::Ty::indexed(bty, rty::Expr::nu());
+            if !sort.is_unit() {
+                ty = rty::Ty::constr(rty::Expr::hole(), ty);
+            }
+            rty::Binder::new(ty, sort)
+        })
+        .refine_generic_arg(param, arg)
+    }
+
+    pub fn instantiate_arg_for_constructor(
         &self,
         generics: &rty::Generics,
         param: &rty::GenericParamDef,

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -6,6 +6,7 @@ use std::iter;
 use flux_common::bug;
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
+use rustc_middle::ty::ParamTy;
 
 use crate::{global_env::GlobalEnv, rty, rustc};
 
@@ -31,140 +32,156 @@ pub(crate) fn refine_generics(generics: &rustc::ty::Generics) -> rty::Generics {
     rty::Generics { params, parent_count: generics.orig.parent_count, parent: generics.orig.parent }
 }
 
-pub(crate) fn refine_variant_def(
-    genv: &GlobalEnv,
-    def_id: DefId,
-    variant_def: &rustc::ty::VariantDef,
-) -> rty::PolyVariant {
-    let generics = genv.generics_of(def_id);
-    let fields = variant_def
-        .field_tys
-        .iter()
-        .map(|ty| refine_ty(genv, &generics, ty, rty::Expr::tt))
-        .collect_vec();
-    let rustc::ty::TyKind::Adt(def_id, substs) = variant_def.ret.kind() else {
-        bug!();
-    };
-    let substs = iter::zip(&generics.params, substs)
-        .map(|(param, arg)| refine_generic_arg(genv, &generics, param, arg, rty::Expr::tt))
-        .collect_vec();
-    let bty = rty::BaseTy::adt(genv.adt_def(*def_id), substs);
-    let ret = rty::Ty::indexed(bty, rty::Index::unit());
-    let value = rty::VariantDef::new(fields, ret);
-    rty::Binder::new(value, rty::Sort::unit())
+pub(crate) struct Refiner<'a, 'tcx> {
+    genv: &'a GlobalEnv<'a, 'tcx>,
+    generics: &'a rty::Generics,
+    refine: fn(rty::BaseTy) -> rty::Binder<rty::Ty>,
 }
 
-pub(crate) fn refine_fn_sig(
-    genv: &GlobalEnv,
-    generics: &rty::Generics,
-    fn_sig: &rustc::ty::FnSig,
-    mk_pred: fn() -> rty::Expr,
-) -> rty::PolySig {
-    let args = fn_sig
-        .inputs()
-        .iter()
-        .map(|ty| refine_ty(genv, generics, ty, mk_pred))
-        .collect_vec();
-    let ret = refine_ty(genv, generics, &fn_sig.output(), mk_pred);
-    let output = rty::Binder::new(rty::FnOutput::new(ret, vec![]), rty::Sort::unit());
-    rty::PolySig::new([], rty::FnSig::new(vec![], args, output))
-}
-
-pub(crate) fn refine_ty(
-    genv: &GlobalEnv,
-    generics: &rty::Generics,
-    ty: &rustc::ty::Ty,
-    mk_pred: fn() -> rty::Expr,
-) -> rty::Ty {
-    let ty = refine_ty_inner(genv, generics, ty, mk_pred);
-    if ty.sort().is_unit() {
-        ty.skip_binders()
-    } else {
-        rty::Ty::exists(ty)
+impl<'a, 'tcx> Refiner<'a, 'tcx> {
+    pub(crate) fn default(genv: &'a GlobalEnv<'a, 'tcx>, generics: &'a rty::Generics) -> Self {
+        Self { genv, generics, refine: refine_default }
     }
-}
 
-pub(crate) fn refine_generic_arg(
-    genv: &GlobalEnv,
-    generics: &rty::Generics,
-    param: &rty::GenericParamDef,
-    arg: &rustc::ty::GenericArg,
-    mk_pred: fn() -> rty::Expr,
-) -> rty::GenericArg {
-    match (&param.kind, arg) {
-        (rty::GenericParamDefKind::Type { .. }, rustc::ty::GenericArg::Ty(ty)) => {
-            rty::GenericArg::Ty(refine_ty(genv, generics, ty, mk_pred))
+    pub(crate) fn with_holes(genv: &'a GlobalEnv<'a, 'tcx>, generics: &'a rty::Generics) -> Self {
+        Self {
+            genv,
+            generics,
+            refine: |bty| {
+                let sort = bty.sort();
+                let indexed = rty::Ty::indexed(bty, rty::Expr::nu());
+                let constr = rty::Ty::constr(rty::Expr::hole(), indexed);
+                rty::Binder::new(constr, sort)
+            },
         }
-        (rty::GenericParamDefKind::BaseTy, rustc::ty::GenericArg::Ty(ty)) => {
-            rty::GenericArg::BaseTy(refine_ty_inner(genv, generics, ty, mk_pred))
-        }
-        (rty::GenericParamDefKind::Lifetime, rustc::ty::GenericArg::Lifetime(_)) => {
-            rty::GenericArg::Lifetime
-        }
-        _ => bug!("mismatched generic arg `{arg:?}` `{param:?}`"),
     }
-}
 
-fn refine_ty_inner(
-    genv: &GlobalEnv,
-    generics: &rty::Generics,
-    ty: &rustc::ty::Ty,
-    mk_pred: fn() -> rty::Expr,
-) -> rty::Binder<rty::Ty> {
-    let bty = match ty.kind() {
-        rustc::ty::TyKind::Closure(did, _substs) => rty::BaseTy::Closure(*did),
-        rustc::ty::TyKind::Never => rty::BaseTy::Never,
-        rustc::ty::TyKind::Ref(ty, rustc::ty::Mutability::Mut) => {
-            rty::BaseTy::Ref(rty::RefKind::Mut, refine_ty(genv, generics, ty, mk_pred))
-        }
-        rustc::ty::TyKind::Ref(ty, rustc::ty::Mutability::Not) => {
-            rty::BaseTy::Ref(rty::RefKind::Shr, refine_ty(genv, generics, ty, mk_pred))
-        }
-        rustc::ty::TyKind::Float(float_ty) => rty::BaseTy::Float(*float_ty),
-        rustc::ty::TyKind::Tuple(tys) => {
-            let tys = tys
-                .iter()
-                .map(|ty| refine_ty(genv, generics, ty, mk_pred))
-                .collect();
-            rty::BaseTy::Tuple(tys)
-        }
-        rustc::ty::TyKind::Array(ty, len) => {
-            rty::BaseTy::Array(refine_ty(genv, generics, ty, mk_pred), len.clone())
-        }
-        rustc::ty::TyKind::Param(param_ty) => {
-            match generics.param_at(param_ty.index as usize, genv).kind {
-                rty::GenericParamDefKind::Type { .. } => {
-                    return rty::Binder::new(rty::Ty::param(*param_ty), rty::Sort::unit());
-                }
-                rty::GenericParamDefKind::BaseTy => rty::BaseTy::Param(*param_ty),
-                rty::GenericParamDefKind::Lifetime => bug!(),
+    pub(crate) fn refine_variant_def(
+        &self,
+        variant_def: &rustc::ty::VariantDef,
+    ) -> rty::PolyVariant {
+        let fields = variant_def
+            .field_tys
+            .iter()
+            .map(|ty| self.refine_ty(ty))
+            .collect_vec();
+        let rustc::ty::TyKind::Adt(def_id, substs) = variant_def.ret.kind() else {
+            bug!();
+        };
+        let substs = iter::zip(&self.generics.params, substs)
+            .map(|(param, arg)| self.refine_generic_arg(param, arg))
+            .collect_vec();
+        let bty = rty::BaseTy::adt(self.adt_def(*def_id), substs);
+        let ret = rty::Ty::indexed(bty, rty::Index::unit());
+        let value = rty::VariantDef::new(fields, ret);
+        rty::Binder::new(value, rty::Sort::unit())
+    }
+
+    pub(crate) fn refine_fn_sig(&self, fn_sig: &rustc::ty::FnSig) -> rty::PolySig {
+        let args = fn_sig
+            .inputs()
+            .iter()
+            .map(|ty| self.refine_ty(ty))
+            .collect_vec();
+        let ret = self.refine_ty(&fn_sig.output());
+        let output = rty::Binder::new(rty::FnOutput::new(ret, vec![]), rty::Sort::unit());
+        rty::PolySig::new([], rty::FnSig::new(vec![], args, output))
+    }
+
+    pub(crate) fn refine_generic_arg(
+        &self,
+        param: &rty::GenericParamDef,
+        arg: &rustc::ty::GenericArg,
+    ) -> rty::GenericArg {
+        match (&param.kind, arg) {
+            (rty::GenericParamDefKind::Type { .. }, rustc::ty::GenericArg::Ty(ty)) => {
+                rty::GenericArg::Ty(self.refine_ty(ty))
             }
+            (rty::GenericParamDefKind::BaseTy, rustc::ty::GenericArg::Ty(ty)) => {
+                rty::GenericArg::BaseTy(self.refine_bound_ty(ty))
+            }
+            (rty::GenericParamDefKind::Lifetime, rustc::ty::GenericArg::Lifetime(_)) => {
+                rty::GenericArg::Lifetime
+            }
+            _ => bug!("mismatched generic arg `{arg:?}` `{param:?}`"),
         }
-        rustc::ty::TyKind::Adt(def_id, substs) => {
-            let adt_def = genv.adt_def(*def_id);
-            let substs = iter::zip(&genv.generics_of(*def_id).params, substs)
-                .map(|(param, arg)| refine_generic_arg(genv, generics, param, arg, mk_pred))
-                .collect_vec();
-            rty::BaseTy::adt(adt_def, substs)
+    }
+
+    pub(crate) fn refine_ty(&self, ty: &rustc::ty::Ty) -> rty::Ty {
+        let ty = self.refine_bound_ty(ty);
+        if ty.sort().is_unit() {
+            ty.replace_bvar(&rty::Expr::unit())
+        } else {
+            rty::Ty::exists(ty)
         }
-        rustc::ty::TyKind::Bool => rty::BaseTy::Bool,
-        rustc::ty::TyKind::Int(int_ty) => rty::BaseTy::Int(*int_ty),
-        rustc::ty::TyKind::Uint(uint_ty) => rty::BaseTy::Uint(*uint_ty),
-        rustc::ty::TyKind::Str => rty::BaseTy::Str,
-        rustc::ty::TyKind::Slice(ty) => rty::BaseTy::Slice(refine_ty(genv, generics, ty, mk_pred)),
-        rustc::ty::TyKind::Char => rty::BaseTy::Char,
-        rustc::ty::TyKind::FnSig(_) => todo!("refine_ty: FnSig"),
-        rustc::ty::TyKind::RawPtr(ty, mu) => {
-            rty::BaseTy::RawPtr(refine_ty(genv, generics, ty, rty::Expr::tt), *mu)
-        }
-    };
-    let pred = mk_pred();
+    }
+
+    fn refine_bound_ty(&self, ty: &rustc::ty::Ty) -> rty::Binder<rty::Ty> {
+        let bty = match ty.kind() {
+            rustc::ty::TyKind::Closure(did, _substs) => rty::BaseTy::Closure(*did),
+            rustc::ty::TyKind::Never => rty::BaseTy::Never,
+            rustc::ty::TyKind::Ref(ty, rustc::ty::Mutability::Mut) => {
+                rty::BaseTy::Ref(rty::RefKind::Mut, self.refine_ty(ty))
+            }
+            rustc::ty::TyKind::Ref(ty, rustc::ty::Mutability::Not) => {
+                rty::BaseTy::Ref(rty::RefKind::Shr, self.refine_ty(ty))
+            }
+            rustc::ty::TyKind::Float(float_ty) => rty::BaseTy::Float(*float_ty),
+            rustc::ty::TyKind::Tuple(tys) => {
+                let tys = tys.iter().map(|ty| self.refine_ty(ty)).collect();
+                rty::BaseTy::Tuple(tys)
+            }
+            rustc::ty::TyKind::Array(ty, len) => {
+                rty::BaseTy::Array(self.refine_ty(ty), len.clone())
+            }
+            rustc::ty::TyKind::Param(param_ty) => {
+                match self.param(*param_ty).kind {
+                    rty::GenericParamDefKind::Type { .. } => {
+                        return rty::Binder::new(rty::Ty::param(*param_ty), rty::Sort::unit());
+                    }
+                    rty::GenericParamDefKind::BaseTy => rty::BaseTy::Param(*param_ty),
+                    rty::GenericParamDefKind::Lifetime => bug!(),
+                }
+            }
+            rustc::ty::TyKind::Adt(def_id, substs) => {
+                let adt_def = self.genv.adt_def(*def_id);
+                let substs = iter::zip(&self.generics_of(*def_id).params, substs)
+                    .map(|(param, arg)| self.refine_generic_arg(param, arg))
+                    .collect_vec();
+                rty::BaseTy::adt(adt_def, substs)
+            }
+            rustc::ty::TyKind::Bool => rty::BaseTy::Bool,
+            rustc::ty::TyKind::Int(int_ty) => rty::BaseTy::Int(*int_ty),
+            rustc::ty::TyKind::Uint(uint_ty) => rty::BaseTy::Uint(*uint_ty),
+            rustc::ty::TyKind::Str => rty::BaseTy::Str,
+            rustc::ty::TyKind::Slice(ty) => rty::BaseTy::Slice(self.refine_ty(ty)),
+            rustc::ty::TyKind::Char => rty::BaseTy::Char,
+            rustc::ty::TyKind::FnSig(_) => todo!("refine_ty: FnSig"),
+            rustc::ty::TyKind::RawPtr(ty, mu) => {
+                rty::BaseTy::RawPtr(self.as_default().refine_ty(ty), *mu)
+            }
+        };
+        (self.refine)(bty)
+    }
+
+    fn as_default(&self) -> Self {
+        Refiner { refine: refine_default, ..*self }
+    }
+
+    fn adt_def(&self, def_id: DefId) -> rty::AdtDef {
+        self.genv.adt_def(def_id)
+    }
+
+    fn generics_of(&self, def_id: DefId) -> rty::Generics {
+        self.genv.generics_of(def_id)
+    }
+
+    fn param(&self, param_ty: ParamTy) -> rty::GenericParamDef {
+        self.generics.param_at(param_ty.index as usize, self.genv)
+    }
+}
+
+fn refine_default(bty: rty::BaseTy) -> rty::Binder<rty::Ty> {
     let sort = bty.sort();
-    let idx = rty::Expr::nu().eta_expand_tuple(&sort);
-    let ty = if pred.is_trivially_true() {
-        rty::Ty::indexed(bty, idx)
-    } else {
-        rty::Ty::constr(pred, rty::Ty::indexed(bty, idx))
-    };
-    rty::Binder::new(ty, sort)
+    rty::Binder::new(rty::Ty::indexed(bty, rty::Expr::nu()), sort)
 }

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -39,6 +39,14 @@ pub(crate) struct Refiner<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> Refiner<'a, 'tcx> {
+    pub(crate) fn new(
+        genv: &'a GlobalEnv<'a, 'tcx>,
+        generics: &'a rty::Generics,
+        refine: fn(rty::BaseTy) -> rty::Binder<rty::Ty>,
+    ) -> Self {
+        Self { genv, generics, refine }
+    }
+
     pub(crate) fn default(genv: &'a GlobalEnv<'a, 'tcx>, generics: &'a rty::Generics) -> Self {
         Self { genv, generics, refine: refine_default }
     }

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -788,7 +788,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             CastKind::FloatToInt
             | CastKind::IntToFloat
             | CastKind::Pointer(mir::PointerCast::MutToConstPointer) => {
-                self.genv.refine_with_true(&self.generics, to)
+                self.genv.refine_default(&self.generics, to)
             }
         }
     }

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                     .map(|(idx, arg)| {
                         let param = fn_generics.param_at(idx, self.genv);
                         self.genv
-                            .instantiate_generic_arg(&self.generics, &param, arg)
+                            .instantiate_arg_for_fun(&self.generics, &param, arg)
                     })
                     .collect_vec();
                 let ret = self.check_call(rcx, env, terminator_span, fn_sig, &substs, args)?;
@@ -617,7 +617,9 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
                     .map_err(|err| CheckerError::from(err).with_span(stmt_span))?
                     .to_fn_sig();
                 let substs = iter::zip(&genv.generics_of(*def_id).params, substs)
-                    .map(|(param, arg)| genv.instantiate_generic_arg(&self.generics, param, arg))
+                    .map(|(param, arg)| {
+                        genv.instantiate_arg_for_constructor(&self.generics, param, arg)
+                    })
                     .collect_vec();
                 self.check_call(rcx, env, stmt_span, sig, &substs, args)
             }


### PR DESCRIPTION
Do not generate kvars for types with unit sort when instantiating generics in function calls. This reduces the time for the `fft` benchmark from 1.2s to 0.6s. The reason for the speedup is that `fft` uses `Vec<f32>`  so by not generating kvars we avoid a bunch of `Vec<{f32 | $k(...)}>` where `$k` ends up resolving to true. 

A kvar for a type refined by unit is only useful if the kvar resolves to false as discussed in #271. So we keep the old behavior when instantiating generics for adt constructors to keep [this test](https://github.com/liquid-rust/flux/blob/2d55ce6248a071ec0638fd98715f8b8d76779c13/flux-tests/tests/pos/surface/issue-271.rs).

This pr also makes some progress on making the infrastructure for instantiating generics more configurable such that in the future we can explore different strategies to balance performance and expressiveness.